### PR TITLE
fix: use local midnight for prayer day date calculation

### DIFF
--- a/serverless/reminder/internal/handler/handler.go
+++ b/serverless/reminder/internal/handler/handler.go
@@ -102,7 +102,8 @@ func (h *Handler) Handel(ctx context.Context, botID int64) error {
 
 	cfg := h.cfg[botID]
 	now := h.now(cfg.Location.V())
-	date := now.Truncate(24 * time.Hour)
+	y, m, d := now.Date()
+	date := time.Date(y, m, d, 0, 0, 0, 0, now.Location())
 	prayerDay, err := h.db.GetPrayerDay(ctx, botID, date)
 	if err != nil {
 		log.Error("get prayer day", log.Err(err), log.BotID(botID))


### PR DESCRIPTION
time.Truncate(24h) truncates by absolute UTC time, not local time. For UTC+3 bots, this caused the Fajr arrive notification to be sent at 3:00am local (UTC midnight rollover) instead of the actual Fajr time (e.g. 2:51am), resulting in a ~10 minute delay.