### PR TITLE
fix: normalize local date to UTC before YDB Date query

### DIFF
--- a/serverless/reminder/internal/service/db.go
+++ b/serverless/reminder/internal/service/db.go
@@ -152,6 +152,10 @@ func (db *DB) GetSubscribers(ctx context.Context, botID int64) (chatIDs []int64,
 }
 
 func (db *DB) GetPrayerDay(ctx context.Context, botID int64, date time.Time) (prayerDay *domain.PrayerDay, _ error) {
+	// DateValueFromTime uses absolute UTC seconds, so normalize the local calendar date
+	// to UTC midnight to get the correct YDB Date value for that calendar day.
+	y, m, d := date.Date()
+	date = time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
 	nextDate := date.Add(24 * time.Hour)
 
 	query := `


### PR DESCRIPTION
DateValueFromTime computes days since Unix epoch using absolute UTC seconds. Passing a local-timezone midnight (e.g. 00:00 +0300) is treated as 21:00 UTC the previous day, causing GetPrayerDay to fetch yesterday's prayers instead of today's — breaking all post-Fajr notifications (Dhuhr, Asr, etc.).

Fix: extract the calendar year/month/day from the local-time date and reconstruct it as UTC midnight before passing to DateValueFromTime.