### PR TITLE
fix: send most recent prayer reminder after downtime

### DIFF
--- a/serverless/reminder/internal/handler/reminder.go
+++ b/serverless/reminder/internal/handler/reminder.go
@@ -75,16 +75,19 @@ func (r *SoonReminder) ShouldTrigger(ctx context.Context, chat *domain.Chat, pra
 	}
 
 	config := chat.Reminder.Soon
+	found := false
+	var foundID domain.PrayerID
 	for _, p := range prayers {
 		// logic: last_at < (prayer_time - offset) AND (prayer_time - offset) <= now
+		// keep updating to get the most recent match, so after downtime we skip
+		// stale prayers and send only the latest one
 		trigger := p.time.Add(-config.Offset.Duration())
 		if config.LastAt.Before(trigger) && (trigger.Before(now) || trigger.Equal(now)) {
-			// // Next LastAt should be incremented by 1 minute to avoid re-triggering
-			// nextLastAt := now.Add(1 * time.Minute)
-			return true, p.id
+			found = true
+			foundID = p.id
 		}
 	}
-	return false, 0
+	return found, foundID
 }
 
 func (r *SoonReminder) Send(ctx context.Context, b *bot.Bot, chat *domain.Chat, prayerID domain.PrayerID, _ *domain.PrayerDay) (int, error) {
@@ -152,13 +155,18 @@ func (r *ArriveReminder) ShouldTrigger(ctx context.Context, chat *domain.Chat, p
 		{domain.PrayerIDIsha, prayerDay.Isha},
 	}
 
+	found := false
+	var foundID domain.PrayerID
 	for _, p := range prayers {
 		// logic: last_at < prayer_time AND prayer_time <= now
+		// keep updating to get the most recent match, so after downtime we skip
+		// stale prayers and send only the latest one
 		if config.LastAt.Before(p.time) && (p.time.Before(now) || p.time.Equal(now)) {
-			return true, p.id
+			found = true
+			foundID = p.id
 		}
 	}
-	return false, 0
+	return found, foundID
 }
 
 func (r *ArriveReminder) Send(ctx context.Context, b *bot.Bot, chat *domain.Chat, prayerID domain.PrayerID, _ *domain.PrayerDay) (int, error) {

--- a/serverless/reminder/internal/handler/reminder.go
+++ b/serverless/reminder/internal/handler/reminder.go
@@ -75,8 +75,10 @@ func (r *SoonReminder) ShouldTrigger(ctx context.Context, chat *domain.Chat, pra
 	}
 
 	config := chat.Reminder.Soon
-	found := false
-	var foundID domain.PrayerID
+	var (
+		found   = false
+		foundID domain.PrayerID
+	)
 	for _, p := range prayers {
 		// logic: last_at < (prayer_time - offset) AND (prayer_time - offset) <= now
 		// keep updating to get the most recent match, so after downtime we skip
@@ -155,8 +157,10 @@ func (r *ArriveReminder) ShouldTrigger(ctx context.Context, chat *domain.Chat, p
 		{domain.PrayerIDIsha, prayerDay.Isha},
 	}
 
-	found := false
-	var foundID domain.PrayerID
+	var (
+		found   = false
+		foundID domain.PrayerID
+	)
 	for _, p := range prayers {
 		// logic: last_at < prayer_time AND prayer_time <= now
 		// keep updating to get the most recent match, so after downtime we skip


### PR DESCRIPTION
After downtime, multiple prayer trigger windows may have passed. The previous logic returned on the first (oldest) match, causing a stale prayer to be sent and the actual current prayer to be skipped entirely (since LastAt would be set past its trigger time).

Now both SoonReminder and ArriveReminder iterate all prayers and keep the last match, ensuring only the most recently triggered prayer is sent on recovery.