### PR TITLE
fixed calcualtions and added Jammat time

### DIFF
--- a/_scripts/migrate/main.go
+++ b/_scripts/migrate/main.go
@@ -52,6 +52,12 @@ type JamaatDelayConfig struct {
 type JamaatConfig struct {
 	Enabled bool               `json:"enabled"`
 	Delay   *JamaatDelayConfig `json:"delay"`
+	State   *JamaatState       `json:"state"`
+}
+
+type JamaatState struct {
+	MessageID int    `json:"message_id"`
+	LastAt    string `json:"last_at"`
 }
 
 type ReminderConfig struct {
@@ -250,11 +256,14 @@ func transformChat(oldChat OldChat, moscowLocation *time.Location) (NewChat, err
 		Jamaat: &JamaatConfig{
 			Enabled: subscribed && jamaat,
 			Delay: &JamaatDelayConfig{
-				Fajr:    Duration(10 * time.Minute),
+				Fajr:    Duration(20 * time.Minute),
 				Dhuhr:   Duration(10 * time.Minute),
 				Asr:     Duration(10 * time.Minute),
 				Maghrib: Duration(10 * time.Minute),
-				Isha:    Duration(20 * time.Minute),
+				Isha:    Duration(10 * time.Minute),
+			},
+			State: &JamaatState{
+				LastAt: now.Format(time.RFC3339),
 			},
 		},
 	}

--- a/_scripts/migrate/main.go
+++ b/_scripts/migrate/main.go
@@ -52,12 +52,7 @@ type JamaatDelayConfig struct {
 type JamaatConfig struct {
 	Enabled bool               `json:"enabled"`
 	Delay   *JamaatDelayConfig `json:"delay"`
-	State   *JamaatState       `json:"state"`
-}
-
-type JamaatState struct {
-	MessageID int    `json:"message_id"`
-	LastAt    string `json:"last_at"`
+	State   *ReminderConfig    `json:"state"`
 }
 
 type ReminderConfig struct {
@@ -262,7 +257,7 @@ func transformChat(oldChat OldChat, moscowLocation *time.Location) (NewChat, err
 				Maghrib: Duration(10 * time.Minute),
 				Isha:    Duration(10 * time.Minute),
 			},
-			State: &JamaatState{
+			State: &ReminderConfig{
 				LastAt: now.Format(time.RFC3339),
 			},
 		},

--- a/domain/duration_test.go
+++ b/domain/duration_test.go
@@ -6,32 +6,53 @@ import (
 	"time"
 )
 
-func TestDuration_MarshalUnmarshalJSON(t *testing.T) {
-	d := Duration(90 * time.Minute)
-
-	b, err := json.Marshal(d)
-	if err != nil {
-		t.Fatalf("marshal duration: %v", err)
+func TestDuration_JSON(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     Duration
+		expect    string
+		expectErr bool
+		payload   string
+	}{
+		{
+			name:   "marshal roundtrip",
+			value:  Duration(90 * time.Minute),
+			expect: "\"1h30m0s\"",
+		},
+		{
+			name:      "invalid unmarshal",
+			expectErr: true,
+			payload:   `"not valid"`,
+		},
 	}
 
-	if got := string(b); got != "\"1h30m0s\"" {
-		t.Fatalf("unexpected marshal %s", got)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.expectErr {
+				var got Duration
+				if err := json.Unmarshal([]byte(tt.payload), &got); err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
 
-	var decoded Duration
-	if err := json.Unmarshal(b, &decoded); err != nil {
-		t.Fatalf("unmarshal duration: %v", err)
-	}
+			b, err := json.Marshal(tt.value)
+			if err != nil {
+				t.Fatalf("marshal duration: %v", err)
+			}
 
-	if time.Duration(decoded) != 90*time.Minute {
-		t.Fatalf("decoded duration mismatch: want %v got %v", 90*time.Minute, decoded.Duration())
-	}
-}
+			if got := string(b); got != tt.expect {
+				t.Fatalf("unexpected marshal %s", got)
+			}
 
-func TestDuration_UnmarshalJSON_Invalid(t *testing.T) {
-	var d Duration
-	err := json.Unmarshal([]byte(`"not valid"`), &d)
-	if err == nil {
-		t.Fatalf("expected error for invalid duration")
+			var decoded Duration
+			if err := json.Unmarshal(b, &decoded); err != nil {
+				t.Fatalf("unmarshal duration: %v", err)
+			}
+
+			if time.Duration(decoded) != time.Duration(tt.value) {
+				t.Fatalf("decoded duration mismatch: want %v got %v", tt.value, decoded.Duration())
+			}
+		})
 	}
 }

--- a/domain/duration_test.go
+++ b/domain/duration_test.go
@@ -1,0 +1,37 @@
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestDuration_MarshalUnmarshalJSON(t *testing.T) {
+	d := Duration(90 * time.Minute)
+
+	b, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("marshal duration: %v", err)
+	}
+
+	if got := string(b); got != "\"1h30m0s\"" {
+		t.Fatalf("unexpected marshal %s", got)
+	}
+
+	var decoded Duration
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatalf("unmarshal duration: %v", err)
+	}
+
+	if time.Duration(decoded) != 90*time.Minute {
+		t.Fatalf("decoded duration mismatch: want %v got %v", 90*time.Minute, decoded.Duration())
+	}
+}
+
+func TestDuration_UnmarshalJSON_Invalid(t *testing.T) {
+	var d Duration
+	err := json.Unmarshal([]byte(`"not valid"`), &d)
+	if err == nil {
+		t.Fatalf("expected error for invalid duration")
+	}
+}

--- a/domain/prayer_test.go
+++ b/domain/prayer_test.go
@@ -25,14 +25,28 @@ func TestFormatDuration(t *testing.T) {
 }
 
 func TestDateUTC(t *testing.T) {
-	got := DateUTC(31, time.December, 2024)
-	if got.Year() != 2024 || got.Month() != time.December || got.Day() != 31 {
-		t.Fatalf("unexpected date: %v", got)
+	tests := []struct {
+		name  string
+		day   int
+		month time.Month
+		year  int
+	}{
+		{"year end", 31, time.December, 2024},
+		{"beginning", 1, time.January, 2025},
 	}
-	if got.Location() != time.UTC {
-		t.Fatalf("expected UTC location")
-	}
-	if got.Hour() != 0 || got.Minute() != 0 || got.Second() != 0 {
-		t.Fatalf("expected midnight UTC, got %v", got)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DateUTC(tt.day, tt.month, tt.year)
+			if got.Year() != tt.year || got.Month() != tt.month || got.Day() != tt.day {
+				t.Fatalf("unexpected date: %v", got)
+			}
+			if got.Location() != time.UTC {
+				t.Fatalf("expected UTC location")
+			}
+			if got.Hour() != 0 || got.Minute() != 0 || got.Second() != 0 {
+				t.Fatalf("expected midnight UTC, got %v", got)
+			}
+		})
 	}
 }

--- a/domain/prayer_test.go
+++ b/domain/prayer_test.go
@@ -1,0 +1,38 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		name string
+		d    time.Duration
+		want string
+	}{
+		{"minutes only", 30 * time.Minute, "30m"},
+		{"hours and minutes", 90 * time.Minute, "1h30m"},
+		{"exact hours", 2 * time.Hour, "2h0m"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FormatDuration(tt.d); got != tt.want {
+				t.Fatalf("FormatDuration(%v) = %s, want %s", tt.d, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDateUTC(t *testing.T) {
+	got := DateUTC(31, time.December, 2024)
+	if got.Year() != 2024 || got.Month() != time.December || got.Day() != 31 {
+		t.Fatalf("unexpected date: %v", got)
+	}
+	if got.Location() != time.UTC {
+		t.Fatalf("expected UTC location")
+	}
+	if got.Hour() != 0 || got.Minute() != 0 || got.Second() != 0 {
+		t.Fatalf("expected midnight UTC, got %v", got)
+	}
+}

--- a/domain/reminder.go
+++ b/domain/reminder.go
@@ -8,6 +8,7 @@ const (
 	ReminderTypeTomorrow ReminderType = "tomorrow"
 	ReminderTypeSoon     ReminderType = "soon"
 	ReminderTypeArrive   ReminderType = "arrive"
+	ReminderTypeJamaat   ReminderType = "jamaat"
 )
 
 func (rt ReminderType) String() string {
@@ -26,6 +27,12 @@ type (
 	JamaatConfig struct {
 		Enabled bool               `json:"enabled"`
 		Delay   *JamaatDelayConfig `json:"delay"`
+		State   *JamaatState       `json:"state"`
+	}
+
+	JamaatState struct {
+		MessageID int       `json:"message_id"`
+		LastAt    time.Time `json:"last_at"`
 	}
 
 	ReminderConfig struct {

--- a/domain/reminder.go
+++ b/domain/reminder.go
@@ -27,12 +27,7 @@ type (
 	JamaatConfig struct {
 		Enabled bool               `json:"enabled"`
 		Delay   *JamaatDelayConfig `json:"delay"`
-		State   *JamaatState       `json:"state"`
-	}
-
-	JamaatState struct {
-		MessageID int       `json:"message_id"`
-		LastAt    time.Time `json:"last_at"`
+		State   *ReminderConfig    `json:"state"`
 	}
 
 	ReminderConfig struct {

--- a/serverless/dispatcher/internal/handler/handler.go
+++ b/serverless/dispatcher/internal/handler/handler.go
@@ -249,11 +249,14 @@ func (h *Handler) getChat(ctx context.Context, update *models.Update) (*domain.C
 		Arrive: &domain.ReminderConfig{LastAt: now},
 		Jamaat: &domain.JamaatConfig{
 			Delay: &domain.JamaatDelayConfig{
-				Fajr:    domain.Duration(10 * time.Minute),
+				Fajr:    domain.Duration(20 * time.Minute),
 				Dhuhr:   domain.Duration(10 * time.Minute),
 				Asr:     domain.Duration(10 * time.Minute),
 				Maghrib: domain.Duration(10 * time.Minute),
-				Isha:    domain.Duration(20 * time.Minute),
+				Isha:    domain.Duration(10 * time.Minute),
+			},
+			State: &domain.JamaatState{
+				LastAt: now,
 			},
 		},
 	}

--- a/serverless/dispatcher/internal/handler/handler.go
+++ b/serverless/dispatcher/internal/handler/handler.go
@@ -255,7 +255,7 @@ func (h *Handler) getChat(ctx context.Context, update *models.Update) (*domain.C
 				Maghrib: domain.Duration(10 * time.Minute),
 				Isha:    domain.Duration(10 * time.Minute),
 			},
-			State: &domain.JamaatState{
+			State: &domain.ReminderConfig{
 				LastAt: now,
 			},
 		},

--- a/serverless/reminder/internal/handler/handler.go
+++ b/serverless/reminder/internal/handler/handler.go
@@ -118,6 +118,7 @@ func (h *Handler) Handel(ctx context.Context, botID int64) error {
 		},
 		&SoonReminder{lp: h.lp},
 		&ArriveReminder{lp: h.lp},
+		&JamaatReminder{lp: h.lp},
 	}
 
 	errG := &errgroup.Group{}

--- a/serverless/reminder/internal/handler/reminder.go
+++ b/serverless/reminder/internal/handler/reminder.go
@@ -75,16 +75,19 @@ func (r *SoonReminder) ShouldTrigger(ctx context.Context, chat *domain.Chat, pra
 	}
 
 	config := chat.Reminder.Soon
+	found := false
+	var foundID domain.PrayerID
 	for _, p := range prayers {
 		// logic: last_at < (prayer_time - offset) AND (prayer_time - offset) <= now
+		// keep updating to get the most recent match, so after downtime we skip
+		// stale prayers and send only the latest one
 		trigger := p.time.Add(-config.Offset.Duration())
 		if config.LastAt.Before(trigger) && (trigger.Before(now) || trigger.Equal(now)) {
-			// // Next LastAt should be incremented by 1 minute to avoid re-triggering
-			// nextLastAt := now.Add(1 * time.Minute)
-			return true, p.id
+			found = true
+			foundID = p.id
 		}
 	}
-	return false, 0
+	return found, foundID
 }
 
 func (r *SoonReminder) Send(ctx context.Context, b *bot.Bot, chat *domain.Chat, prayerID domain.PrayerID, _ *domain.PrayerDay) (int, error) {
@@ -152,13 +155,18 @@ func (r *ArriveReminder) ShouldTrigger(ctx context.Context, chat *domain.Chat, p
 		{domain.PrayerIDIsha, prayerDay.Isha},
 	}
 
+	found := false
+	var foundID domain.PrayerID
 	for _, p := range prayers {
 		// logic: last_at < prayer_time AND prayer_time <= now
+		// keep updating to get the most recent match, so after downtime we skip
+		// stale prayers and send only the latest one
 		if config.LastAt.Before(p.time) && (p.time.Before(now) || p.time.Equal(now)) {
-			return true, p.id
+			found = true
+			foundID = p.id
 		}
 	}
-	return false, 0
+	return found, foundID
 }
 
 func (r *ArriveReminder) Send(ctx context.Context, b *bot.Bot, chat *domain.Chat, prayerID domain.PrayerID, _ *domain.PrayerDay) (int, error) {

--- a/serverless/reminder/internal/handler/reminder.go
+++ b/serverless/reminder/internal/handler/reminder.go
@@ -213,7 +213,7 @@ func (r *JamaatReminder) ShouldTrigger(ctx context.Context, chat *domain.Chat, p
 	}
 
 	if jamaat.State == nil {
-		jamaat.State = &domain.JamaatState{}
+		jamaat.State = &domain.ReminderConfig{}
 	}
 
 	prayers := []struct {
@@ -248,7 +248,7 @@ func (r *JamaatReminder) Send(ctx context.Context, b *bot.Bot, chat *domain.Chat
 	}
 
 	if chat.Reminder.Jamaat.State == nil {
-		chat.Reminder.Jamaat.State = &domain.JamaatState{}
+		chat.Reminder.Jamaat.State = &domain.ReminderConfig{}
 	}
 
 	deleteMessages(ctx, b, chat, chat.Reminder.Jamaat.State.MessageID)

--- a/serverless/reminder/internal/handler/reminder.go
+++ b/serverless/reminder/internal/handler/reminder.go
@@ -75,8 +75,10 @@ func (r *SoonReminder) ShouldTrigger(ctx context.Context, chat *domain.Chat, pra
 	}
 
 	config := chat.Reminder.Soon
-	found := false
-	var foundID domain.PrayerID
+	var (
+		found   = false
+		foundID domain.PrayerID
+	)
 	for _, p := range prayers {
 		// logic: last_at < (prayer_time - offset) AND (prayer_time - offset) <= now
 		// keep updating to get the most recent match, so after downtime we skip
@@ -155,8 +157,10 @@ func (r *ArriveReminder) ShouldTrigger(ctx context.Context, chat *domain.Chat, p
 		{domain.PrayerIDIsha, prayerDay.Isha},
 	}
 
-	found := false
-	var foundID domain.PrayerID
+	var (
+		found   = false
+		foundID domain.PrayerID
+	)
 	for _, p := range prayers {
 		// logic: last_at < prayer_time AND prayer_time <= now
 		// keep updating to get the most recent match, so after downtime we skip

--- a/serverless/reminder/internal/handler/reminder.go
+++ b/serverless/reminder/internal/handler/reminder.go
@@ -26,16 +26,17 @@ type TomorrowReminder struct {
 func (r *TomorrowReminder) ShouldTrigger(ctx context.Context, chat *domain.Chat, _ *domain.PrayerDay, now time.Time) (bool, domain.PrayerID) {
 	config := chat.Reminder.Tomorrow
 
-	triggerTime := time.Date(
+	midnight := time.Date(
 		now.Year(),
 		now.Month(),
-		now.Day()+1,                            // move to next day
-		int(-config.Offset.Duration().Hours()), // get triggerTime by moving back in time
+		now.Day()+1, // move to next day
+		0,
 		0,
 		0,
 		0,
 		now.Location(),
 	)
+	triggerTime := midnight.Add(-config.Offset.Duration())
 	shouldSend := config.LastAt.Before(triggerTime) && (triggerTime.Before(now) || triggerTime.Equal(now))
 	return shouldSend, domain.PrayerIDUnknown
 }
@@ -200,3 +201,72 @@ func (r *ArriveReminder) Send(ctx context.Context, b *bot.Bot, chat *domain.Chat
 }
 
 func (r *ArriveReminder) Name() domain.ReminderType { return domain.ReminderTypeArrive }
+
+type JamaatReminder struct {
+	lp *languagesProvider
+}
+
+func (r *JamaatReminder) ShouldTrigger(ctx context.Context, chat *domain.Chat, prayerDay *domain.PrayerDay, now time.Time) (bool, domain.PrayerID) {
+	jamaat := chat.Reminder.Jamaat
+	if jamaat == nil || !jamaat.Enabled || jamaat.Delay == nil {
+		return false, domain.PrayerIDUnknown
+	}
+
+	if jamaat.State == nil {
+		jamaat.State = &domain.JamaatState{}
+	}
+
+	prayers := []struct {
+		id   domain.PrayerID
+		time time.Time
+	}{
+		{domain.PrayerIDFajr, prayerDay.Fajr},
+		{domain.PrayerIDDhuhr, prayerDay.Dhuhr},
+		{domain.PrayerIDAsr, prayerDay.Asr},
+		{domain.PrayerIDMaghrib, prayerDay.Maghrib},
+		{domain.PrayerIDIsha, prayerDay.Isha},
+	}
+
+	for _, p := range prayers {
+		delay := jamaat.Delay.GetDelayByPrayerID(p.id)
+		if delay == 0 {
+			continue
+		}
+
+		trigger := p.time.Add(delay)
+		if jamaat.State.LastAt.Before(trigger) && (trigger.Before(now) || trigger.Equal(now)) {
+			return true, p.id
+		}
+	}
+
+	return false, domain.PrayerIDUnknown
+}
+
+func (r *JamaatReminder) Send(ctx context.Context, b *bot.Bot, chat *domain.Chat, prayerID domain.PrayerID, _ *domain.PrayerDay) (int, error) {
+	if chat.Reminder.Jamaat == nil {
+		return 0, fmt.Errorf("jamaat reminder missing config")
+	}
+
+	if chat.Reminder.Jamaat.State == nil {
+		chat.Reminder.Jamaat.State = &domain.JamaatState{}
+	}
+
+	deleteMessages(ctx, b, chat, chat.Reminder.Jamaat.State.MessageID)
+
+	text := r.lp.GetText(chat.LanguageCode)
+	delay := chat.Reminder.Jamaat.Delay.GetDelayByPrayerID(prayerID)
+	message := fmt.Sprintf(text.PrayerJamaat, domain.FormatDuration(delay))
+
+	res, err := b.SendMessage(ctx, &bot.SendMessageParams{
+		ChatID:    chat.ChatID,
+		Text:      message,
+		ParseMode: models.ParseModeMarkdown,
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return res.ID, nil
+}
+
+func (r *JamaatReminder) Name() domain.ReminderType { return domain.ReminderTypeJamaat }

--- a/serverless/reminder/internal/handler/reminder_test.go
+++ b/serverless/reminder/internal/handler/reminder_test.go
@@ -123,15 +123,15 @@ func TestJamaatReminder_ShouldTrigger(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			chat := &domain.Chat{
-				Reminder: &domain.Reminder{
-					Jamaat: &domain.JamaatConfig{
-						Enabled: tt.enabled,
-						Delay:   &domain.JamaatDelayConfig{},
-						State: &domain.JamaatState{
-							LastAt: tt.lastAt,
-						},
+			Reminder: &domain.Reminder{
+				Jamaat: &domain.JamaatConfig{
+					Enabled: tt.enabled,
+					Delay:   &domain.JamaatDelayConfig{},
+					State: &domain.ReminderConfig{
+						LastAt: tt.lastAt,
 					},
 				},
+			},
 			}
 			for prayerID, delay := range tt.delays {
 				chat.Reminder.Jamaat.Delay.SetDelayByPrayerID(prayerID, delay)

--- a/serverless/reminder/internal/handler/reminder_test.go
+++ b/serverless/reminder/internal/handler/reminder_test.go
@@ -1,0 +1,149 @@
+package handler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/escalopa/prayer-bot/domain"
+)
+
+func TestTomorrowReminder_ShouldTrigger(t *testing.T) {
+	midnight := time.Date(2026, 4, 7, 22, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name   string
+		now    time.Time
+		lastAt time.Time
+		offset time.Duration
+		want   bool
+	}{
+		{
+			name:   "trigger when now past offset and lastAt before",
+			now:    midnight,
+			lastAt: midnight.Add(-2 * time.Hour),
+			offset: 3 * time.Hour,
+			want:   true,
+		},
+		{
+			name:   "no trigger when now before deadline",
+			now:    midnight.Add(-2 * time.Hour),
+			lastAt: midnight.Add(-3 * time.Hour),
+			offset: 1 * time.Hour,
+			want:   false,
+		},
+		{
+			name:   "no trigger when already sent",
+			now:    midnight,
+			lastAt: midnight.Add(30 * time.Minute),
+			offset: 3 * time.Hour,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chat := &domain.Chat{
+				Reminder: &domain.Reminder{
+					Tomorrow: &domain.ReminderConfig{
+						Offset: domain.Duration(tt.offset),
+						LastAt: tt.lastAt,
+					},
+				},
+			}
+			should, _ := (&TomorrowReminder{}).ShouldTrigger(context.Background(), chat, nil, tt.now)
+			if should != tt.want {
+				t.Fatalf("should trigger = %v, want %v", should, tt.want)
+			}
+		})
+	}
+}
+
+func TestJamaatReminder_ShouldTrigger(t *testing.T) {
+	base := time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC)
+	prayerDay := &domain.PrayerDay{
+		Fajr:    base.Add(5 * time.Hour),
+		Dhuhr:   base.Add(12 * time.Hour),
+		Asr:     base.Add(15 * time.Hour),
+		Maghrib: base.Add(18 * time.Hour),
+		Isha:    base.Add(20 * time.Hour),
+	}
+
+	tests := []struct {
+		name     string
+		now      time.Time
+		lastAt   time.Time
+		delays   map[domain.PrayerID]time.Duration
+		enabled  bool
+		want     bool
+		prayerID domain.PrayerID
+	}{
+		{
+			name:    "trigger after delay",
+			now:     prayerDay.Asr.Add(15 * time.Minute),
+			lastAt:  base,
+			enabled: true,
+			delays: map[domain.PrayerID]time.Duration{
+				domain.PrayerIDAsr: 10 * time.Minute,
+			},
+			want:     true,
+			prayerID: domain.PrayerIDAsr,
+		},
+		{
+			name:    "does not trigger when already sent",
+			now:     prayerDay.Maghrib.Add(12 * time.Minute),
+			lastAt:  prayerDay.Maghrib.Add(13 * time.Minute),
+			enabled: true,
+			delays: map[domain.PrayerID]time.Duration{
+				domain.PrayerIDMaghrib: 10 * time.Minute,
+			},
+			want: false,
+		},
+		{
+			name:    "skips when disabled",
+			now:     prayerDay.Dhuhr.Add(11 * time.Minute),
+			lastAt:  base,
+			enabled: false,
+			delays: map[domain.PrayerID]time.Duration{
+				domain.PrayerIDDhuhr: 10 * time.Minute,
+			},
+			want: false,
+		},
+		{
+			name:    "skips when delay is zero",
+			now:     prayerDay.Fajr.Add(25 * time.Minute),
+			lastAt:  base,
+			enabled: true,
+			delays: map[domain.PrayerID]time.Duration{
+				domain.PrayerIDFajr: 0,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chat := &domain.Chat{
+				Reminder: &domain.Reminder{
+					Jamaat: &domain.JamaatConfig{
+						Enabled: tt.enabled,
+						Delay:   &domain.JamaatDelayConfig{},
+						State: &domain.JamaatState{
+							LastAt: tt.lastAt,
+						},
+					},
+				},
+			}
+			for prayerID, delay := range tt.delays {
+				chat.Reminder.Jamaat.Delay.SetDelayByPrayerID(prayerID, delay)
+			}
+
+			should, prayerID := (&JamaatReminder{}).ShouldTrigger(context.Background(), chat, prayerDay, tt.now)
+			if should != tt.want {
+				t.Fatalf("should trigger = %v, want %v", should, tt.want)
+			}
+			if tt.want && prayerID != tt.prayerID {
+				t.Fatalf("prayer id = %v, want %v", prayerID, tt.prayerID)
+			}
+		})
+	}
+}

--- a/serverless/reminder/internal/service/db.go
+++ b/serverless/reminder/internal/service/db.go
@@ -290,6 +290,15 @@ func (db *DB) UpdateReminder(
 		case domain.ReminderTypeArrive:
 			reminder.Arrive.MessageID = messageID
 			reminder.Arrive.LastAt = lastAt
+		case domain.ReminderTypeJamaat:
+			if reminder.Jamaat == nil {
+				reminder.Jamaat = &domain.JamaatConfig{}
+			}
+			if reminder.Jamaat.State == nil {
+				reminder.Jamaat.State = &domain.JamaatState{}
+			}
+			reminder.Jamaat.State.MessageID = messageID
+			reminder.Jamaat.State.LastAt = lastAt
 		}
 
 		updatedReminderJSON, err := json.Marshal(&reminder)

--- a/serverless/reminder/internal/service/db.go
+++ b/serverless/reminder/internal/service/db.go
@@ -295,7 +295,7 @@ func (db *DB) UpdateReminder(
 				reminder.Jamaat = &domain.JamaatConfig{}
 			}
 			if reminder.Jamaat.State == nil {
-				reminder.Jamaat.State = &domain.JamaatState{}
+				reminder.Jamaat.State = &domain.ReminderConfig{}
 			}
 			reminder.Jamaat.State.MessageID = messageID
 			reminder.Jamaat.State.LastAt = lastAt


### PR DESCRIPTION
Summary: fix tomorrow reminder math so minute offsets subtract the full duration from midnight and add a Jama’at reminder that fires after each prayer (20 m after Fajr, 10 m after the others) plus persistence for its last message/timestamp.

Details: extend the reminder domain with ReminderTypeJamaat/state, seed new chats & migration with the default delays, include Jama’at reminder in the scheduler, and keep the database in sync.

Testing: go test ./... (includes new domain helpers tests and reminder logic coverage).

