### PR TITLE
Use remaining time when reminder runner recovers late

### DIFF
--- a/serverless/reminder/internal/handler/handler.go
+++ b/serverless/reminder/internal/handler/handler.go
@@ -134,7 +134,7 @@ func (h *Handler) Handel(ctx context.Context, botID int64) error {
 					continue
 				}
 
-				messageID, err := reminder.Send(ctx, b, chat, prayerID, prayerDay)
+				messageID, err := reminder.Send(ctx, b, chat, prayerID, prayerDay, now)
 				if err != nil {
 					if isBlockedErr(err) {
 						h.deleteChat(ctx, chat)

--- a/serverless/reminder/internal/handler/reminder.go
+++ b/serverless/reminder/internal/handler/reminder.go
@@ -13,7 +13,7 @@ import (
 
 type ReminderType interface {
 	ShouldTrigger(ctx context.Context, chat *domain.Chat, prayerDay *domain.PrayerDay, now time.Time) (shouldSend bool, prayerID domain.PrayerID)
-	Send(ctx context.Context, b *bot.Bot, chat *domain.Chat, prayerID domain.PrayerID, prayerDay *domain.PrayerDay) (messageID int, err error)
+	Send(ctx context.Context, b *bot.Bot, chat *domain.Chat, prayerID domain.PrayerID, prayerDay *domain.PrayerDay, now time.Time) (messageID int, err error)
 	Name() domain.ReminderType
 }
 
@@ -40,7 +40,7 @@ func (r *TomorrowReminder) ShouldTrigger(ctx context.Context, chat *domain.Chat,
 	return shouldSend, domain.PrayerIDUnknown
 }
 
-func (r *TomorrowReminder) Send(ctx context.Context, b *bot.Bot, chat *domain.Chat, _ domain.PrayerID, prayerDay *domain.PrayerDay) (int, error) {
+func (r *TomorrowReminder) Send(ctx context.Context, b *bot.Bot, chat *domain.Chat, _ domain.PrayerID, prayerDay *domain.PrayerDay, _ time.Time) (int, error) {
 	deleteMessages(ctx, b, chat, chat.Reminder.Tomorrow.MessageID)
 	res, err := b.SendMessage(ctx, &bot.SendMessageParams{
 		ChatID: chat.ChatID,
@@ -128,7 +128,7 @@ func (r *SoonReminder) ShouldTrigger(ctx context.Context, chat *domain.Chat, pra
 	return found, foundID
 }
 
-func (r *SoonReminder) Send(ctx context.Context, b *bot.Bot, chat *domain.Chat, prayerID domain.PrayerID, prayerDay *domain.PrayerDay) (int, error) {
+func (r *SoonReminder) Send(ctx context.Context, b *bot.Bot, chat *domain.Chat, prayerID domain.PrayerID, prayerDay *domain.PrayerDay, now time.Time) (int, error) {
 	text := r.lp.GetText(chat.LanguageCode)
 	prayer := text.Prayer[int(prayerID)]
 
@@ -137,17 +137,27 @@ func (r *SoonReminder) Send(ctx context.Context, b *bot.Bot, chat *domain.Chat, 
 		loc = cfg.Location.V()
 	}
 
-	now := time.Now().In(loc)
-	prayerTime := prayerTimeByID(prayerDay, prayerID, now).In(loc).Format(prayerTimeFormat)
+	now = now.In(loc)
+	prayerAt := prayerTimeByID(prayerDay, prayerID, now).In(loc)
+	prayerRemaining := prayerAt.Sub(now)
+	if prayerRemaining < 0 {
+		prayerRemaining = 0
+	}
+	prayerTime := prayerAt.Format(prayerTimeFormat)
 
 	deleteMessages(ctx, b, chat, chat.Reminder.Soon.MessageID, chat.Reminder.Arrive.MessageID)
 
 	if chat.Reminder.Jamaat.Enabled && prayerID != domain.PrayerIDShuruq {
 		delay := chat.Reminder.Jamaat.Delay.GetDelayByPrayerID(prayerID)
-		jamaatTime := prayerTimeByID(prayerDay, prayerID, now).Add(delay).In(loc).Format(prayerTimeFormat)
+		jamaatAt := prayerAt.Add(delay).In(loc)
+		jamaatRemaining := jamaatAt.Sub(now)
+		if jamaatRemaining < 0 {
+			jamaatRemaining = 0
+		}
+		jamaatTime := jamaatAt.Format(prayerTimeFormat)
 		message := fmt.Sprintf("%s\n%s",
-			fmt.Sprintf(strings.ReplaceAll(text.PrayerSoon, "*", ""), prayer, domain.FormatDuration(chat.Reminder.Soon.Offset.Duration()), prayerTime),
-			fmt.Sprintf(strings.ReplaceAll(text.PrayerJamaat, "*", ""), domain.FormatDuration(delay+chat.Reminder.Soon.Offset.Duration()), jamaatTime),
+			fmt.Sprintf(strings.ReplaceAll(text.PrayerSoon, "*", ""), prayer, domain.FormatDuration(prayerRemaining), prayerTime),
+			fmt.Sprintf(strings.ReplaceAll(text.PrayerJamaat, "*", ""), domain.FormatDuration(jamaatRemaining), jamaatTime),
 		)
 		isAnonymous := false
 
@@ -167,7 +177,7 @@ func (r *SoonReminder) Send(ctx context.Context, b *bot.Bot, chat *domain.Chat, 
 		return res.ID, nil
 	}
 
-	message := fmt.Sprintf(text.PrayerSoon, prayer, domain.FormatDuration(chat.Reminder.Soon.Offset.Duration()), prayerTime)
+	message := fmt.Sprintf(text.PrayerSoon, prayer, domain.FormatDuration(prayerRemaining), prayerTime)
 	message = escapeTelegramMarkdownParentheses(message)
 
 	res, err := b.SendMessage(ctx, &bot.SendMessageParams{
@@ -219,7 +229,7 @@ func (r *ArriveReminder) ShouldTrigger(ctx context.Context, chat *domain.Chat, p
 	return found, foundID
 }
 
-func (r *ArriveReminder) Send(ctx context.Context, b *bot.Bot, chat *domain.Chat, prayerID domain.PrayerID, _ *domain.PrayerDay) (int, error) {
+func (r *ArriveReminder) Send(ctx context.Context, b *bot.Bot, chat *domain.Chat, prayerID domain.PrayerID, _ *domain.PrayerDay, _ time.Time) (int, error) {
 	deleteMessages(ctx, b, chat, chat.Reminder.Arrive.MessageID)
 
 	text := r.lp.GetText(chat.LanguageCode)


### PR DESCRIPTION
## Summary
- compute soon reminder and jamaat durations from current scheduler time instead of configured offset
- pass scheduler now into reminder send implementations
- prevents stale messages like after 1h when runner was down and only 50m remain

## Testing
- go test ./... (root)
- go test ./... (serverless/reminder)