### PR TITLE
[codex] fix global Cloud Run CPU allocation

### DIFF
--- a/global/infra/gcp/main.tf
+++ b/global/infra/gcp/main.tf
@@ -248,7 +248,8 @@ resource "google_cloud_run_v2_service" "webhook" {
       command = ["/webhook"]
 
       resources {
-        limits = { cpu = "1", memory = "256Mi" }
+        limits   = { cpu = "1", memory = "256Mi" }
+        cpu_idle = true
       }
 
       env {
@@ -329,7 +330,8 @@ resource "google_cloud_run_v2_service" "dispatch" {
       command = ["/dispatch"]
 
       resources {
-        limits = { cpu = "1", memory = "256Mi" }
+        limits   = { cpu = "1", memory = "256Mi" }
+        cpu_idle = true
       }
 
       env {
@@ -392,7 +394,8 @@ resource "google_cloud_run_v2_service" "sender" {
       command = ["/send"]
 
       resources {
-        limits = { cpu = "1", memory = "256Mi" }
+        limits   = { cpu = "1", memory = "256Mi" }
+        cpu_idle = true
       }
 
       env {


### PR DESCRIPTION
## What changed

- explicitly set `cpu_idle = true` on the global webhook, dispatcher, and sender Cloud Run services
- retain the existing `256Mi` memory limit and scale-to-zero configuration

## Root cause

The first testing deployment reached the final Terraform apply, but Cloud Run rejected the webhook and sender services because defining a Terraform `resources` block without explicitly setting `cpu_idle` selected instance-based (always-allocated) CPU. That mode requires at least `512Mi` of memory.

## Impact

The services now use request-based CPU allocation, which supports the configured `256Mi` limit and matches their request-driven, scale-to-zero design. This change is isolated to `global/infra/gcp`; the legacy city bots are unchanged.

The failed deployment had already created some global testing resources and completed the isolated schema migration. Rerunning the manual testing deployment after this PR merges will reconcile the existing Terraform state and continue to webhook configuration.

## Validation

- `git diff --check`
- `terraform -chdir=global/infra/gcp fmt -check -recursive`
- `terraform -chdir=global/infra/gcp validate`
