### PR TITLE
[codex] Add global Telegram Mini App and feedback

### DIFF
--- a/.github/workflows/global-deploy.yaml
+++ b/.github/workflows/global-deploy.yaml
@@ -130,6 +130,7 @@ jobs:
           export GLOBAL_BOT_TOKEN="$(gcloud secrets versions access latest --secret=global-prayer-bot-token-${{ inputs.environment }} --project="$GCP_PROJECT_ID")"
           export GLOBAL_WEBHOOK_SECRET="$(gcloud secrets versions access latest --secret=global-prayer-bot-webhook-secret-${{ inputs.environment }} --project="$GCP_PROJECT_ID")"
           export WEBHOOK_URL="$(terraform -chdir=infra/gcp output -raw webhook_url)"
+          export MINI_APP_URL="${WEBHOOK_URL}/app/"
           go run ./cmd/botprofile
 
       - name: Show deployment endpoints
@@ -137,4 +138,5 @@ jobs:
         run: |
           echo "### Global prayer bot" >> "$GITHUB_STEP_SUMMARY"
           echo "- Webhook: $(terraform output -raw webhook_url)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Mini App: $(terraform output -raw webhook_url)/app/" >> "$GITHUB_STEP_SUMMARY"
           echo "- Sender: $(terraform output -raw sender_url)" >> "$GITHUB_STEP_SUMMARY"

--- a/global/README.md
+++ b/global/README.md
@@ -9,11 +9,13 @@ This directory is a separate application derived from the existing city bots. It
 - Local calculation of prayer times with MWL, Egyptian, Umm al-Qura, Karachi, ISNA, Diyanet, Kemenag, MUIS, and JAKIM methods.
 - Shafii/Hanafi Asr selection, three high-latitude rules, and per-prayer minute adjustments.
 - A persistent two-column Telegram menu for today, tomorrow, the next prayer, location, settings, reminders, language, and help.
+- A Telegram Mini App, opened from the bot menu, for today/tomorrow schedules, location, calculation settings, Hijri correction, and all reminder toggles without typed commands.
 - Inline button pickers for calculation method, madhab, high-latitude rule, per-prayer adjustments, reminder state, and language. The equivalent typed commands remain available.
-- Localized interface, prayer names, dates, command menus, profile descriptions, and reminder deliveries in English, Arabic, Spanish, French, Russian, Turkish, Uzbek, and Tatar.
+- Localized messages, reply keyboards, prayer names, dates, Mini App, and reminder deliveries in English, Arabic, Spanish, French, Russian, Turkish, Uzbek, and Tatar. The public Telegram bot name and description remain stable for every user.
 - Gregorian and calculated Umm al-Qura Hijri dates on every daily schedule, with a per-chat moon-sighting correction from -2 to +2 days.
 - Opt-in weekly reminders for Monday/Thursday voluntary fasting (20:00 on the preceding evening) and reading Surah Al-Kahf on Friday (09:00), scheduled in the saved local timezone.
 - An embedded welcome illustration sent on `/start` and a generated bot avatar installed during profile synchronization.
+- A localized feedback and bug-report flow that accepts text or screenshots in a private chat and delivers them directly to the configured owner with the sender's disclosed Telegram identity.
 - Indexed reminder scheduling through Cloud Scheduler, an outbox, Cloud Tasks, a private sender service, leases, and delivery idempotency keys.
 - Dedicated `global_bot_testing` and `global_bot_production` PostgreSQL schemas, each with its own Goose migration table.
 
@@ -25,11 +27,11 @@ Hijri dates use the calculated Umm al-Qura calendar. Because official local moon
 
 | Service | Access | Responsibility |
 | --- | --- | --- |
-| `webhook` | Public URL, protected by Telegram's webhook secret header | Commands, location setup, calculation settings |
+| `webhook` | Public URL; webhook protected by Telegram's secret header, Mini App API protected by signed init data | Commands, Mini App, location setup, calculation settings |
 | `dispatch` | Cloud Scheduler service account only | Claim due indexed schedules and create Cloud Tasks |
 | `sender` | Cloud Tasks service account only | Idempotent Telegram delivery and next-occurrence planning |
 
-The three services use one immutable image and select `/webhook`, `/dispatch`, or `/send` as the command.
+The three services use one immutable image and select `/webhook`, `/dispatch`, or `/send` as the command. The webhook binary embeds the Mini App and serves it at `/app/`, so the feature does not add another Cloud Run service, container image, database, migration, or secret.
 
 ## Testing and production secrets
 
@@ -90,6 +92,6 @@ The bootstrap command only creates the selected empty global schema. `GLOBAL_DB_
 
 ## Deployment
 
-Run the separate **Deploy global prayer bot** GitHub workflow and choose `testing` or `production`. It uses a distinct state prefix (`prayer-bot/global-testing` or `prayer-bot/global-production`), migrates the matching `global_bot_testing` or `global_bot_production` schema, builds the global image, provisions the global resources, and then configures the selected Telegram webhook, localized command menus, names, descriptions, and avatar.
+Run the separate **Deploy global prayer bot** GitHub workflow and choose `testing` or `production`. It uses a distinct state prefix (`prayer-bot/global-testing` or `prayer-bot/global-production`), migrates the matching `global_bot_testing` or `global_bot_production` schema, builds the global image, provisions the global resources, and then configures the selected Telegram webhook, Mini App menu button, stable public profile, command menu, and avatar. The Mini App URL is derived from the environment's existing webhook URL; no new GitHub variable is required.
 
 The workflow is intentionally manual until the new token, secrets, API quotas, privacy text, and prayer-time samples are approved through the logical `testing` deployment.

--- a/global/cmd/botprofile/main.go
+++ b/global/cmd/botprofile/main.go
@@ -33,7 +33,7 @@ func main() {
 	}); err != nil {
 		fatal(fmt.Errorf("set webhook failed"))
 	}
-	if err := profile.Sync(ctx, client, cfg.TelegramToken); err != nil {
+	if err := profile.Sync(ctx, client, cfg.TelegramToken, cfg.MiniAppURL); err != nil {
 		fatal(fmt.Errorf("sync bot profile failed: %w", err))
 	}
 }

--- a/global/cmd/webhook/main.go
+++ b/global/cmd/webhook/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/escalopa/prayer-bot/global/internal/config"
 	"github.com/escalopa/prayer-bot/global/internal/httpx"
 	"github.com/escalopa/prayer-bot/global/internal/location"
+	"github.com/escalopa/prayer-bot/global/internal/miniapp"
 	"github.com/escalopa/prayer-bot/global/internal/prayertime"
 	"github.com/escalopa/prayer-bot/global/internal/reminders"
 	"github.com/escalopa/prayer-bot/global/internal/store"
@@ -40,12 +41,15 @@ func main() {
 	}
 	calculator := prayertime.New()
 	planner := reminders.NewPlanner(storage, calculator)
+	resolver := location.NewGoogleMaps(cfg.GoogleMapsAPIKey, cfg.HTTPTimeout)
 	handler := telegramhandler.NewHandler(
-		telegramBot, storage, location.NewGoogleMaps(cfg.GoogleMapsAPIKey, cfg.HTTPTimeout), calculator, planner, cfg.OwnerID,
+		telegramBot, storage, resolver, calculator, planner, cfg.OwnerID,
 	)
+	miniApp := miniapp.NewHandler(cfg.TelegramToken, storage, resolver, calculator, planner, logger)
 
 	mux := http.NewServeMux()
 	httpx.HealthMux(mux)
+	miniApp.Register(mux)
 	mux.HandleFunc("POST /telegram/webhook", func(w http.ResponseWriter, r *http.Request) {
 		provided := r.Header.Get("X-Telegram-Bot-Api-Secret-Token")
 		if len(provided) != len(cfg.WebhookSecret) || subtle.ConstantTimeCompare([]byte(provided), []byte(cfg.WebhookSecret)) != 1 {

--- a/global/docs/architecture.md
+++ b/global/docs/architecture.md
@@ -3,6 +3,7 @@
 ```mermaid
 flowchart LR
     T[Telegram] -->|secret-protected webhook| W[Cloud Run webhook]
+    A[Telegram Mini App] -->|signed init data| W
     W -->|profile and rules| P[(Existing PostgreSQL\nenvironment-specific global schema)]
     W -->|location changes only| G[Google Time Zone and Geocoding]
     C[Cloud Scheduler] -->|OIDC| D[Cloud Run dispatch]
@@ -13,11 +14,19 @@ flowchart LR
     S --> T
 ```
 
+## Mini App
+
+The webhook service embeds and serves a dependency-free HTML/CSS/JavaScript Mini App at `/app/`. Deployment sets that HTTPS URL as the bot's default chat menu button. The app calls same-origin `/api/miniapp/*` endpoints and uses the same storage, location resolver, prayer calculator, and reminder planner as the conversational interface, so settings remain consistent across both interfaces.
+
+The backend never trusts a Telegram user ID sent in JSON. Every Mini App API request carries the exact `Telegram.WebApp.initData` string in a header. The server verifies Telegram's HMAC signature with the environment's bot token, rejects duplicate fields and sessions older than 24 hours, and derives the private chat ID from the signed user object. The app is private-chat scoped; group configuration remains in the bot, where administrator authorization is enforced.
+
 ## Data ownership
 
 The legacy `public.chats` and `public.prayers` tables remain untouched. Global testing data is owned by `global_bot_testing`, production data is owned by `global_bot_production`, foreign keys cascade from each schema's `chats` table, and `/delete_me` deletes the chat root.
 
 Raw coordinates exist only in the webhook request while resolving the timezone and approximate place. Persistence rounds them to three decimals. The reverse-geocoded city is displayed in the immediate reply but is not stored; only Google's Place ID is retained. A future user-entered label can be stored because it is user-provided content.
+
+Feedback is not stored in PostgreSQL. When a user explicitly replies to the localized feedback prompt, Telegram copies that message or screenshot into the private owner chat together with the sender's name, username, Telegram ID, and selected bot language. The prompt discloses that identity sharing before submission.
 
 ## Calculation profile
 

--- a/global/docs/operations.md
+++ b/global/docs/operations.md
@@ -17,7 +17,13 @@ Cloud Run secret references use `latest`; a new revision is still recommended af
 
 ## Telegram profile synchronization
 
-The final deployment step runs `cmd/botprofile`. It registers both message and callback-query webhook updates, installs the default and localized command menus, names and descriptions, and uploads the embedded avatar when the bot has no profile photo. Re-running the deployment is safe; an existing avatar is left in place.
+The final deployment step runs `cmd/botprofile`. It registers both message and callback-query webhook updates, installs one stable default bot name, description, and command menu, removes localized profile variants left by earlier releases, configures the default chat menu button to open `${WEBHOOK_URL}/app/`, and uploads the embedded avatar when the bot has no profile photo. Re-running the deployment is safe; an existing avatar is left in place. The URL is derived by the workflow, so there is no additional GitHub secret or variable.
+
+The language selected inside the bot is per chat. It changes messages, reply keyboards, reminders, dates, and the Mini App, but never calls Telegram's global profile methods. Telegram profile localization is based on the viewer's Telegram client language rather than this saved preference, so the production profile intentionally uses one stable public identity.
+
+After deployment, verify the workflow summary's Mini App URL returns HTTP 200, open a private chat with the selected testing bot, and tap the menu button next to the message field. Check initial location setup, today/tomorrow switching, a settings save, and each reminder toggle. Opening `/app/` in a normal browser should show the “open inside Telegram” state; Mini App API requests without valid signed Telegram init data should return HTTP 401.
+
+The menu button is configured automatically through the Bot API. BotFather's optional “Main Mini App” profile launch button is separate and may be configured manually later if a second entry point on the bot profile is wanted; it is not required for this release.
 
 The welcome illustration is embedded in the webhook binary and sent with the localized `/start` caption. Updating either JPEG requires a normal application deployment; updating an already configured avatar also requires removing the old photo in Telegram before rerunning profile synchronization.
 
@@ -30,3 +36,11 @@ Migration `00002` adds the per-chat Hijri correction and the two weekly reminder
 ## Maps failure mode
 
 Existing profiles and prayer calculations continue working if Google Maps is unavailable. Only new location setup or a location change fails, and Telegram retries the webhook after a server error. No Maps API is called for `/today`, `/tomorrow`, `/next`, or reminder delivery.
+
+The same behavior applies to the Mini App: loading an existing schedule and saving calculation/reminder settings do not call Maps. Only an explicit location update calls the Time Zone and Geocoding APIs.
+
+## Feedback delivery
+
+`GLOBAL_OWNER_ID` is also the destination for feedback and bug reports. The owner must open the selected testing or production bot and send `/start` at least once, because Telegram does not allow a bot to initiate a conversation with a user who has never contacted it. Users open the localized feedback prompt from the persistent keyboard or `/feedback`, then reply with text, media, or a screenshot. Group submissions are redirected to a private chat so reports and user identity are not exposed to group members.
+
+The application does not persist feedback content. Telegram delivers an owner-only context message and a copy of the user's submission. Delivery errors are logged without the feedback content.

--- a/global/internal/botprofile/sync.go
+++ b/global/internal/botprofile/sync.go
@@ -29,21 +29,20 @@ var startDescriptions = map[string]string{
 	"tt": "Ботны ачу һәм төп менюны күрсәтү",
 }
 
-// Sync applies the default English profile, all supported localized profiles,
-// the localized command menus and the generated avatar. The avatar is uploaded
-// only when the bot does not yet have a profile photo.
-func Sync(ctx context.Context, client *botapi.Bot, token string) error {
-	english := i18n.Resolve("en")
-	if err := syncLocale(ctx, client, english, ""); err != nil {
+var profileSyncDelay = 50 * time.Millisecond
+
+// Sync applies one stable Telegram-facing identity and removes old localized
+// profile variants. User-selected languages belong to chat data and must never
+// mutate global bot metadata. The avatar is uploaded only when the bot does not
+// yet have a profile photo.
+func Sync(ctx context.Context, client *botapi.Bot, token, miniAppURL string) error {
+	if err := syncStableIdentity(ctx, client); err != nil {
 		return err
 	}
-	for _, locale := range i18n.Supported() {
-		if locale.Code == "en" {
-			continue
-		}
-		if err := syncLocale(ctx, client, locale, locale.Code); err != nil {
-			return err
-		}
+	if _, err := client.SetChatMenuButton(ctx, &botapi.SetChatMenuButtonParams{
+		MenuButton: miniAppMenuButton(miniAppURL),
+	}); err != nil {
+		return fmt.Errorf("set Mini App menu button: %w", err)
 	}
 
 	me, err := client.GetMe(ctx)
@@ -62,34 +61,79 @@ func Sync(ctx context.Context, client *botapi.Bot, token string) error {
 	return nil
 }
 
-func syncLocale(ctx context.Context, client *botapi.Bot, locale i18n.Locale, languageCode string) error {
-	if _, err := client.SetMyName(ctx, &botapi.SetMyNameParams{Name: locale.BotName, LanguageCode: languageCode}); err != nil {
-		return fmt.Errorf("set bot name for %q: %w", languageCode, err)
+func miniAppMenuButton(url string) models.MenuButtonWebApp {
+	return models.MenuButtonWebApp{Text: "🕌 Prayer App", WebApp: models.WebAppInfo{URL: url}}
+}
+
+type identityClient interface {
+	SetMyName(context.Context, *botapi.SetMyNameParams) (bool, error)
+	SetMyShortDescription(context.Context, *botapi.SetMyShortDescriptionParams) (bool, error)
+	SetMyDescription(context.Context, *botapi.SetMyDescriptionParams) (bool, error)
+	SetMyCommands(context.Context, *botapi.SetMyCommandsParams) (bool, error)
+	DeleteMyCommands(context.Context, *botapi.DeleteMyCommandsParams) (bool, error)
+}
+
+func syncStableIdentity(ctx context.Context, client identityClient) error {
+	english := i18n.Resolve("en")
+	if _, err := client.SetMyName(ctx, &botapi.SetMyNameParams{Name: english.BotName}); err != nil {
+		return fmt.Errorf("set default bot name: %w", err)
 	}
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(profileSyncDelay)
 	if _, err := client.SetMyShortDescription(ctx, &botapi.SetMyShortDescriptionParams{
-		ShortDescription: locale.ShortDescription, LanguageCode: languageCode,
+		ShortDescription: english.ShortDescription,
 	}); err != nil {
-		return fmt.Errorf("set short description for %q: %w", languageCode, err)
+		return fmt.Errorf("set default short description: %w", err)
 	}
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(profileSyncDelay)
 	if _, err := client.SetMyDescription(ctx, &botapi.SetMyDescriptionParams{
-		Description: locale.Description, LanguageCode: languageCode,
+		Description: english.Description,
 	}); err != nil {
-		return fmt.Errorf("set description for %q: %w", languageCode, err)
+		return fmt.Errorf("set default description: %w", err)
 	}
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(profileSyncDelay)
 	if _, err := client.SetMyCommands(ctx, &botapi.SetMyCommandsParams{
-		Commands: commands(locale), LanguageCode: languageCode,
+		Commands: commands(english),
 	}); err != nil {
-		return fmt.Errorf("set commands for %q: %w", languageCode, err)
+		return fmt.Errorf("set default commands: %w", err)
 	}
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(profileSyncDelay)
+
+	// Earlier releases published localized profile metadata. Telegram selects
+	// those values from the viewer's Telegram language, not the per-chat bot
+	// preference, so remove them to keep the public identity consistent.
+	for _, locale := range i18n.Supported() {
+		if locale.Code == english.Code {
+			continue
+		}
+		if err := clearLocalizedIdentity(ctx, client, locale.Code); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func clearLocalizedIdentity(ctx context.Context, client identityClient, languageCode string) error {
+	if _, err := client.SetMyName(ctx, &botapi.SetMyNameParams{LanguageCode: languageCode}); err != nil {
+		return fmt.Errorf("remove localized bot name for %q: %w", languageCode, err)
+	}
+	time.Sleep(profileSyncDelay)
+	if _, err := client.SetMyShortDescription(ctx, &botapi.SetMyShortDescriptionParams{LanguageCode: languageCode}); err != nil {
+		return fmt.Errorf("remove localized short description for %q: %w", languageCode, err)
+	}
+	time.Sleep(profileSyncDelay)
+	if _, err := client.SetMyDescription(ctx, &botapi.SetMyDescriptionParams{LanguageCode: languageCode}); err != nil {
+		return fmt.Errorf("remove localized description for %q: %w", languageCode, err)
+	}
+	time.Sleep(profileSyncDelay)
+	if _, err := client.DeleteMyCommands(ctx, &botapi.DeleteMyCommandsParams{LanguageCode: languageCode}); err != nil {
+		return fmt.Errorf("remove localized commands for %q: %w", languageCode, err)
+	}
+	time.Sleep(profileSyncDelay)
 	return nil
 }
 
 func commands(locale i18n.Locale) []models.BotCommand {
-	order := []string{"start", "location", "today", "tomorrow", "next", "settings", "remind", "language", "privacy", "help"}
+	order := []string{"start", "location", "today", "tomorrow", "next", "settings", "remind", "language", "feedback", "privacy", "help"}
 	result := make([]models.BotCommand, 0, len(order))
 	for _, command := range order {
 		description := locale.Commands[command]

--- a/global/internal/botprofile/sync_test.go
+++ b/global/internal/botprofile/sync_test.go
@@ -1,8 +1,11 @@
 package botprofile
 
 import (
+	"context"
 	"testing"
 	"unicode/utf8"
+
+	botapi "github.com/go-telegram/bot"
 
 	"github.com/escalopa/prayer-bot/global/internal/i18n"
 )
@@ -10,8 +13,8 @@ import (
 func TestLocalizedCommandsAreCompleteAndWithinTelegramLimits(t *testing.T) {
 	for _, locale := range i18n.Supported() {
 		items := commands(locale)
-		if len(items) != 10 {
-			t.Fatalf("%s has %d commands, want 10", locale.Code, len(items))
+		if len(items) != 11 {
+			t.Fatalf("%s has %d commands, want 11", locale.Code, len(items))
 		}
 		seen := make(map[string]bool)
 		for _, item := range items {
@@ -26,3 +29,75 @@ func TestLocalizedCommandsAreCompleteAndWithinTelegramLimits(t *testing.T) {
 		}
 	}
 }
+
+func TestMiniAppMenuButtonUsesDeploymentURL(t *testing.T) {
+	button := miniAppMenuButton("https://example.run.app/app/")
+	if button.Text != "🕌 Prayer App" || button.WebApp.URL != "https://example.run.app/app/" {
+		t.Fatalf("unexpected Mini App menu button: %+v", button)
+	}
+}
+
+func TestStableIdentityRemovesLocalizedGlobalMetadata(t *testing.T) {
+	originalDelay := profileSyncDelay
+	profileSyncDelay = 0
+	t.Cleanup(func() { profileSyncDelay = originalDelay })
+
+	client := &fakeIdentityClient{}
+	if err := syncStableIdentity(context.Background(), client); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(client.names) != len(i18n.Supported()) || client.names[0].LanguageCode != "" || client.names[0].Name != i18n.Resolve("en").BotName {
+		t.Fatalf("unexpected name operations: %+v", client.names)
+	}
+	if len(client.shortDescriptions) != len(i18n.Supported()) || client.shortDescriptions[0].LanguageCode != "" || client.shortDescriptions[0].ShortDescription == "" {
+		t.Fatalf("unexpected short-description operations: %+v", client.shortDescriptions)
+	}
+	if len(client.descriptions) != len(i18n.Supported()) || client.descriptions[0].LanguageCode != "" || client.descriptions[0].Description == "" {
+		t.Fatalf("unexpected description operations: %+v", client.descriptions)
+	}
+	if len(client.commandSets) != 1 || client.commandSets[0].LanguageCode != "" || len(client.commandDeletes) != len(i18n.Supported())-1 {
+		t.Fatalf("unexpected command operations: set=%+v delete=%+v", client.commandSets, client.commandDeletes)
+	}
+	for index := 1; index < len(client.names); index++ {
+		if client.names[index].LanguageCode == "" || client.names[index].Name != "" ||
+			client.shortDescriptions[index].ShortDescription != "" || client.descriptions[index].Description != "" {
+			t.Fatalf("localized metadata was not cleared at index %d", index)
+		}
+	}
+}
+
+type fakeIdentityClient struct {
+	names             []botapi.SetMyNameParams
+	shortDescriptions []botapi.SetMyShortDescriptionParams
+	descriptions      []botapi.SetMyDescriptionParams
+	commandSets       []botapi.SetMyCommandsParams
+	commandDeletes    []botapi.DeleteMyCommandsParams
+}
+
+func (f *fakeIdentityClient) SetMyName(_ context.Context, params *botapi.SetMyNameParams) (bool, error) {
+	f.names = append(f.names, *params)
+	return true, nil
+}
+
+func (f *fakeIdentityClient) SetMyShortDescription(_ context.Context, params *botapi.SetMyShortDescriptionParams) (bool, error) {
+	f.shortDescriptions = append(f.shortDescriptions, *params)
+	return true, nil
+}
+
+func (f *fakeIdentityClient) SetMyDescription(_ context.Context, params *botapi.SetMyDescriptionParams) (bool, error) {
+	f.descriptions = append(f.descriptions, *params)
+	return true, nil
+}
+
+func (f *fakeIdentityClient) SetMyCommands(_ context.Context, params *botapi.SetMyCommandsParams) (bool, error) {
+	f.commandSets = append(f.commandSets, *params)
+	return true, nil
+}
+
+func (f *fakeIdentityClient) DeleteMyCommands(_ context.Context, params *botapi.DeleteMyCommandsParams) (bool, error) {
+	f.commandDeletes = append(f.commandDeletes, *params)
+	return true, nil
+}
+
+var _ identityClient = (*fakeIdentityClient)(nil)

--- a/global/internal/config/config.go
+++ b/global/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -18,6 +19,7 @@ type Config struct {
 	WebhookSecret            string
 	OwnerID                  int64
 	GoogleMapsAPIKey         string
+	MiniAppURL               string
 	GCPProjectID             string
 	GCPRegion                string
 	CloudTasksQueue          string
@@ -35,6 +37,7 @@ func Load(service string) (Config, error) {
 		TelegramToken:            strings.TrimSpace(os.Getenv("GLOBAL_BOT_TOKEN")),
 		WebhookSecret:            strings.TrimSpace(os.Getenv("GLOBAL_WEBHOOK_SECRET")),
 		GoogleMapsAPIKey:         strings.TrimSpace(os.Getenv("GOOGLE_MAPS_API_KEY")),
+		MiniAppURL:               strings.TrimSpace(os.Getenv("MINI_APP_URL")),
 		GCPProjectID:             strings.TrimSpace(os.Getenv("GCP_PROJECT_ID")),
 		GCPRegion:                envOr("GCP_REGION", "europe-west1"),
 		CloudTasksQueue:          envOr("CLOUD_TASKS_QUEUE", "global-prayer-notifications"),
@@ -69,11 +72,14 @@ func Load(service string) (Config, error) {
 			return Config{}, fmt.Errorf("send requires DATABASE_URL, GLOBAL_DB_SCHEMA, and GLOBAL_BOT_TOKEN")
 		}
 	case "botprofile":
-		if cfg.TelegramToken == "" || cfg.WebhookSecret == "" {
-			return Config{}, fmt.Errorf("botprofile requires GLOBAL_BOT_TOKEN and GLOBAL_WEBHOOK_SECRET")
+		if cfg.TelegramToken == "" || cfg.WebhookSecret == "" || cfg.MiniAppURL == "" {
+			return Config{}, fmt.Errorf("botprofile requires GLOBAL_BOT_TOKEN, GLOBAL_WEBHOOK_SECRET, and MINI_APP_URL")
 		}
 		if !validWebhookSecret(cfg.WebhookSecret) {
 			return Config{}, fmt.Errorf("GLOBAL_WEBHOOK_SECRET must be 1-256 characters using only letters, numbers, underscore, or hyphen")
+		}
+		if !validMiniAppURL(cfg.MiniAppURL) {
+			return Config{}, fmt.Errorf("MINI_APP_URL must be an HTTPS URL")
 		}
 	default:
 		return Config{}, fmt.Errorf("unknown service %q", service)
@@ -84,6 +90,11 @@ func Load(service string) (Config, error) {
 		}
 	}
 	return cfg, nil
+}
+
+func validMiniAppURL(value string) bool {
+	parsed, err := url.Parse(value)
+	return err == nil && parsed.Scheme == "https" && parsed.Host != "" && parsed.User == nil && parsed.Fragment == ""
 }
 
 func validWebhookSecret(value string) bool {

--- a/global/internal/config/config_test.go
+++ b/global/internal/config/config_test.go
@@ -44,3 +44,17 @@ func TestLoadAcceptsEnvironmentDatabaseSchema(t *testing.T) {
 		t.Fatalf("expected %q, got %q", database.TestingSchema, cfg.DatabaseSchema)
 	}
 }
+
+func TestBotProfileRequiresSecureMiniAppURL(t *testing.T) {
+	t.Setenv("GLOBAL_BOT_TOKEN", "token")
+	t.Setenv("GLOBAL_WEBHOOK_SECRET", "secret")
+	t.Setenv("MINI_APP_URL", "http://example.com/app/")
+
+	if _, err := Load("botprofile"); err == nil || !strings.Contains(err.Error(), "HTTPS") {
+		t.Fatalf("expected insecure Mini App URL error, got %v", err)
+	}
+	t.Setenv("MINI_APP_URL", "https://example.com/app/")
+	if _, err := Load("botprofile"); err != nil {
+		t.Fatalf("load secure Mini App config: %v", err)
+	}
+}

--- a/global/internal/i18n/catalog.go
+++ b/global/internal/i18n/catalog.go
@@ -15,11 +15,12 @@ const (
 	ActionReminders = "reminders"
 	ActionLanguage  = "language"
 	ActionHelp      = "help"
+	ActionFeedback  = "feedback"
 )
 
 var mainActions = []string{
 	ActionToday, ActionTomorrow, ActionNext, ActionLocation,
-	ActionSettings, ActionReminders, ActionLanguage, ActionHelp,
+	ActionSettings, ActionReminders, ActionLanguage, ActionHelp, ActionFeedback,
 }
 
 // Locale contains all user-visible copy for one Telegram language.

--- a/global/internal/i18n/catalog_test.go
+++ b/global/internal/i18n/catalog_test.go
@@ -58,8 +58,9 @@ func TestLocalesAreCompleteAndWithinTelegramLimits(t *testing.T) {
 		"language_saved", "admin_only", "unknown", "deleted", "help", "privacy", "reminder_at",
 		"reminder_before", "reminder_tomorrow", "enabled", "disabled", "fasting_schedule", "kahf_schedule",
 		"hijri_date", "hijri_era", "hijri_setting", "hijri_note", "choose_hijri", "reminder_fasting", "reminder_kahf",
+		"feedback_prompt", "feedback_placeholder", "feedback_sent", "feedback_private",
 	}
-	commandKeys := []string{"location", "today", "tomorrow", "next", "settings", "remind", "language", "privacy", "help"}
+	commandKeys := []string{"location", "today", "tomorrow", "next", "settings", "remind", "language", "feedback", "privacy", "help"}
 	prayers := []domain.Prayer{domain.PrayerFajr, domain.PrayerSunrise, domain.PrayerDhuhr, domain.PrayerAsr, domain.PrayerMaghrib, domain.PrayerIsha}
 
 	seen := make(map[string]bool)
@@ -92,6 +93,9 @@ func TestLocalesAreCompleteAndWithinTelegramLimits(t *testing.T) {
 			if locale.Text[key] == "" {
 				t.Errorf("%s missing text %q", locale.Code, key)
 			}
+		}
+		if utf8.RuneCountInString(locale.Message("feedback_placeholder")) > 64 {
+			t.Errorf("%s feedback placeholder exceeds Telegram's 64-character limit", locale.Code)
 		}
 		for _, key := range commandKeys {
 			if locale.Commands[key] == "" {

--- a/global/internal/i18n/feedback_copy.go
+++ b/global/internal/i18n/feedback_copy.go
@@ -1,0 +1,60 @@
+package i18n
+
+type feedbackCopy struct {
+	Button, Command, Prompt, Placeholder, Sent, Private string
+}
+
+var feedbackCopies = map[string]feedbackCopy{
+	"en": {
+		"💬 Feedback", "Send feedback or report a bug",
+		"Tell us what went wrong or what could be improved. Reply with a message or screenshot. Your name, username and Telegram ID will be shared privately with the bot owner.",
+		"Describe the problem", "Thank you — your feedback was sent to the bot owner ✅", "Please open a private chat with the bot to send feedback.",
+	},
+	"ar": {
+		"💬 ملاحظات أو بلاغ", "إرسال ملاحظة أو الإبلاغ عن مشكلة",
+		"أخبرنا بالمشكلة أو بما يمكن تحسينه. أرسل رسالة أو لقطة شاشة ردًا على هذه الرسالة. سيُشارك اسمك واسم المستخدم ومعرّف تيليجرام بشكل خاص مع مالك البوت.",
+		"صف المشكلة", "شكرًا لك — تم إرسال ملاحظاتك إلى مالك البوت ✅", "يرجى فتح محادثة خاصة مع البوت لإرسال الملاحظات.",
+	},
+	"es": {
+		"💬 Comentarios", "Enviar comentarios o informar un error",
+		"Cuéntanos qué salió mal o qué podemos mejorar. Responde con un mensaje o una captura. Tu nombre, usuario e ID de Telegram se compartirán en privado con el propietario del bot.",
+		"Describe el problema", "Gracias: tus comentarios se enviaron al propietario del bot ✅", "Abre un chat privado con el bot para enviar comentarios.",
+	},
+	"fr": {
+		"💬 Avis et problème", "Envoyer un avis ou signaler un problème",
+		"Dites-nous ce qui ne va pas ou ce qui peut être amélioré. Répondez avec un message ou une capture. Votre nom, identifiant et ID Telegram seront transmis en privé au propriétaire du bot.",
+		"Décrivez le problème", "Merci — votre message a été envoyé au propriétaire du bot ✅", "Ouvrez une discussion privée avec le bot pour envoyer votre avis.",
+	},
+	"ru": {
+		"💬 Отзыв или ошибка", "Отправить отзыв или сообщить об ошибке",
+		"Расскажите, что не работает или что можно улучшить. Ответьте сообщением или снимком экрана. Ваше имя, username и Telegram ID будут переданы владельцу бота в личном сообщении.",
+		"Опишите проблему", "Спасибо — сообщение отправлено владельцу бота ✅", "Чтобы отправить отзыв, откройте личный чат с ботом.",
+	},
+	"tr": {
+		"💬 Geri bildirim", "Geri bildirim gönder veya hata bildir",
+		"Neyin yanlış gittiğini veya neyin geliştirilebileceğini anlatın. Mesaj ya da ekran görüntüsüyle yanıtlayın. Adınız, kullanıcı adınız ve Telegram kimliğiniz bot sahibine özel olarak iletilir.",
+		"Sorunu açıklayın", "Teşekkürler — geri bildiriminiz bot sahibine gönderildi ✅", "Geri bildirim için botla özel sohbet açın.",
+	},
+	"uz": {
+		"💬 Fikr yoki xato", "Fikr yuborish yoki xato haqida xabar berish",
+		"Nima ishlamagani yoki nimani yaxshilash mumkinligini yozing. Xabar yoki skrinshot bilan javob bering. Ismingiz, username va Telegram ID bot egasiga shaxsiy tarzda yuboriladi.",
+		"Muammoni tasvirlang", "Rahmat — fikringiz bot egasiga yuborildi ✅", "Fikr yuborish uchun bot bilan shaxsiy chatni oching.",
+	},
+	"tt": {
+		"💬 Фикер яки хата", "Фикер җибәрү яки хата турында хәбәр итү",
+		"Нәрсә эшләмәгәнен яки нәрсәне яхшыртып булганын языгыз. Хәбәр яки экран рәсеме белән җавап бирегез. Исемегез, username һәм Telegram ID бот хуҗасына шәхси рәвештә җибәреләчәк.",
+		"Проблеманы тасвирлагыз", "Рәхмәт — фикерегез бот хуҗасына җибәрелде ✅", "Фикер җибәрү өчен бот белән шәхси чат ачыгыз.",
+	},
+}
+
+func init() {
+	for code, copy := range feedbackCopies {
+		locale := locales[code]
+		locale.Buttons[ActionFeedback] = copy.Button
+		locale.Commands[ActionFeedback] = copy.Command
+		locale.Text["feedback_prompt"] = copy.Prompt
+		locale.Text["feedback_placeholder"] = copy.Placeholder
+		locale.Text["feedback_sent"] = copy.Sent
+		locale.Text["feedback_private"] = copy.Private
+	}
+}

--- a/global/internal/miniapp/auth.go
+++ b/global/internal/miniapp/auth.go
@@ -1,0 +1,86 @@
+package miniapp
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var ErrInvalidInitData = errors.New("invalid Telegram Mini App init data")
+
+type Identity struct {
+	UserID       int64
+	FirstName    string
+	LanguageCode string
+}
+
+type initDataUser struct {
+	ID           int64  `json:"id"`
+	IsBot        bool   `json:"is_bot"`
+	FirstName    string `json:"first_name"`
+	LanguageCode string `json:"language_code"`
+}
+
+// ValidateInitData implements Telegram's HMAC validation for WebApp.initData
+// and rejects stale sessions. The raw query string must come from Telegram.WebApp.initData.
+func ValidateInitData(raw, botToken string, now time.Time, maxAge time.Duration) (Identity, error) {
+	if raw == "" || botToken == "" || len(raw) > 16<<10 {
+		return Identity{}, ErrInvalidInitData
+	}
+	values, err := url.ParseQuery(raw)
+	if err != nil {
+		return Identity{}, ErrInvalidInitData
+	}
+	for _, value := range values {
+		if len(value) != 1 {
+			return Identity{}, ErrInvalidInitData
+		}
+	}
+
+	providedHex := values.Get("hash")
+	provided, err := hex.DecodeString(providedHex)
+	if err != nil || len(provided) != sha256.Size {
+		return Identity{}, ErrInvalidInitData
+	}
+	delete(values, "hash")
+
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, key+"="+values.Get(key))
+	}
+	secretMAC := hmac.New(sha256.New, []byte("WebAppData"))
+	_, _ = secretMAC.Write([]byte(botToken))
+	signatureMAC := hmac.New(sha256.New, secretMAC.Sum(nil))
+	_, _ = signatureMAC.Write([]byte(strings.Join(parts, "\n")))
+	if !hmac.Equal(provided, signatureMAC.Sum(nil)) {
+		return Identity{}, ErrInvalidInitData
+	}
+
+	authUnix, err := strconv.ParseInt(values.Get("auth_date"), 10, 64)
+	if err != nil || authUnix <= 0 {
+		return Identity{}, ErrInvalidInitData
+	}
+	authTime := time.Unix(authUnix, 0)
+	if authTime.After(now.Add(5*time.Minute)) || now.Sub(authTime) > maxAge {
+		return Identity{}, fmt.Errorf("%w: expired", ErrInvalidInitData)
+	}
+
+	var user initDataUser
+	if err := json.Unmarshal([]byte(values.Get("user")), &user); err != nil || user.ID <= 0 || user.IsBot {
+		return Identity{}, ErrInvalidInitData
+	}
+	return Identity{UserID: user.ID, FirstName: user.FirstName, LanguageCode: user.LanguageCode}, nil
+}

--- a/global/internal/miniapp/auth_test.go
+++ b/global/internal/miniapp/auth_test.go
@@ -1,0 +1,66 @@
+package miniapp
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidateInitDataAcceptsTelegramSignature(t *testing.T) {
+	now := time.Date(2026, time.July, 17, 12, 0, 0, 0, time.UTC)
+	raw := signedInitData(t, "test-token", now, initDataUser{ID: 1385434843, FirstName: "Ahmed", LanguageCode: "ar"})
+
+	identity, err := ValidateInitData(raw, "test-token", now.Add(time.Minute), 24*time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identity.UserID != 1385434843 || identity.FirstName != "Ahmed" || identity.LanguageCode != "ar" {
+		t.Fatalf("unexpected identity: %+v", identity)
+	}
+}
+
+func TestValidateInitDataRejectsTamperingAndExpiry(t *testing.T) {
+	now := time.Date(2026, time.July, 17, 12, 0, 0, 0, time.UTC)
+	raw := signedInitData(t, "test-token", now, initDataUser{ID: 42, FirstName: "A"})
+	if _, err := ValidateInitData(strings.Replace(raw, "first_name%22%3A%22A", "first_name%22%3A%22B", 1), "test-token", now, time.Hour); err == nil {
+		t.Fatal("expected tampered init data to fail")
+	}
+	if _, err := ValidateInitData(raw, "test-token", now.Add(2*time.Hour), time.Hour); err == nil {
+		t.Fatal("expected expired init data to fail")
+	}
+}
+
+func signedInitData(t *testing.T, token string, authTime time.Time, user initDataUser) string {
+	t.Helper()
+	encodedUser, err := json.Marshal(user)
+	if err != nil {
+		t.Fatal(err)
+	}
+	values := url.Values{
+		"auth_date": {strconv.FormatInt(authTime.Unix(), 10)},
+		"query_id":  {"AAE-test"},
+		"user":      {string(encodedUser)},
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, key+"="+values.Get(key))
+	}
+	secretMAC := hmac.New(sha256.New, []byte("WebAppData"))
+	_, _ = secretMAC.Write([]byte(token))
+	signatureMAC := hmac.New(sha256.New, secretMAC.Sum(nil))
+	_, _ = signatureMAC.Write([]byte(strings.Join(parts, "\n")))
+	values.Set("hash", hex.EncodeToString(signatureMAC.Sum(nil)))
+	return values.Encode()
+}

--- a/global/internal/miniapp/handler.go
+++ b/global/internal/miniapp/handler.go
@@ -1,0 +1,573 @@
+package miniapp
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/escalopa/prayer-bot/global/internal/domain"
+	"github.com/escalopa/prayer-bot/global/internal/hijri"
+	"github.com/escalopa/prayer-bot/global/internal/i18n"
+	"github.com/escalopa/prayer-bot/global/internal/location"
+	"github.com/escalopa/prayer-bot/global/internal/prayertime"
+	"github.com/escalopa/prayer-bot/global/internal/store"
+)
+
+const initDataMaxAge = 24 * time.Hour
+
+//go:embed static/*
+var embeddedStatic embed.FS
+
+type Storage interface {
+	UpsertChat(context.Context, domain.Chat) error
+	Chat(context.Context, int64) (domain.Chat, error)
+	SetLanguage(context.Context, int64, string) error
+	Profile(context.Context, int64) (domain.PrayerProfile, error)
+	UpsertProfile(context.Context, domain.PrayerProfile) (domain.PrayerProfile, error)
+	EnabledRules(context.Context, int64) ([]domain.ReminderRule, error)
+	EnableDefaultRules(context.Context, int64) error
+	DisableRules(context.Context, int64) error
+	SetWeeklyRule(context.Context, int64, domain.ReminderKind, bool) error
+}
+
+type ReminderPlanner interface {
+	RebuildChat(context.Context, int64, time.Time) error
+}
+
+type Handler struct {
+	botToken   string
+	store      Storage
+	resolver   location.Resolver
+	calculator prayertime.Calculator
+	planner    ReminderPlanner
+	logger     *slog.Logger
+	now        func() time.Time
+}
+
+func NewHandler(botToken string, storage Storage, resolver location.Resolver, calculator prayertime.Calculator, planner ReminderPlanner, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	return &Handler{
+		botToken: botToken, store: storage, resolver: resolver,
+		calculator: calculator, planner: planner, logger: logger, now: time.Now,
+	}
+}
+
+func (h *Handler) Register(mux *http.ServeMux) {
+	static, err := fs.Sub(embeddedStatic, "static")
+	if err != nil {
+		panic(err)
+	}
+	files := http.StripPrefix("/app/", http.FileServer(http.FS(static)))
+	mux.Handle("GET /app/", h.staticHeaders(files))
+	mux.HandleFunc("GET /app", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/app/", http.StatusPermanentRedirect)
+	})
+	mux.HandleFunc("POST /api/miniapp/bootstrap", h.api(h.bootstrap))
+	mux.HandleFunc("PUT /api/miniapp/location", h.api(h.updateLocation))
+	mux.HandleFunc("PUT /api/miniapp/settings", h.api(h.updateSettings))
+	mux.HandleFunc("PUT /api/miniapp/reminders", h.api(h.updateReminders))
+}
+
+type endpoint func(http.ResponseWriter, *http.Request, Identity) error
+
+func (h *Handler) api(next endpoint) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		identity, err := ValidateInitData(r.Header.Get("X-Telegram-Init-Data"), h.botToken, h.now(), initDataMaxAge)
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		if err := next(w, r, identity); err != nil {
+			var apiErr *requestError
+			if errors.As(err, &apiErr) {
+				writeError(w, apiErr.status, apiErr.code)
+				return
+			}
+			h.logger.Error("Mini App request failed", "path", r.URL.Path, "user_id", identity.UserID, "error", err)
+			writeError(w, http.StatusInternalServerError, "temporary_failure")
+		}
+	}
+}
+
+func (h *Handler) staticHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self' https://telegram.org; style-src 'self'; img-src 'self' data: https:; connect-src 'self'; frame-ancestors https://web.telegram.org https://*.telegram.org")
+		w.Header().Set("Referrer-Policy", "no-referrer")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("Cache-Control", "no-cache")
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (h *Handler) bootstrap(w http.ResponseWriter, r *http.Request, identity Identity) error {
+	data, err := h.build(r.Context(), identity)
+	if err != nil {
+		return err
+	}
+	return writeJSON(w, data)
+}
+
+type locationRequest struct {
+	Latitude  *float64 `json:"latitude"`
+	Longitude *float64 `json:"longitude"`
+}
+
+func (h *Handler) updateLocation(w http.ResponseWriter, r *http.Request, identity Identity) error {
+	var request locationRequest
+	if err := decodeJSON(w, r, &request); err != nil {
+		return badRequest("invalid_request")
+	}
+	if request.Latitude == nil || request.Longitude == nil ||
+		*request.Latitude < -90 || *request.Latitude > 90 || *request.Longitude < -180 || *request.Longitude > 180 {
+		return badRequest("invalid_location")
+	}
+	if err := h.ensureChat(r.Context(), identity); err != nil {
+		return err
+	}
+	resolved, err := h.resolver.Resolve(r.Context(), *request.Latitude, *request.Longitude)
+	if err != nil {
+		return fmt.Errorf("resolve location: %w", err)
+	}
+	latitude, longitude := domain.RoundedCoordinates(*request.Latitude, *request.Longitude)
+	profile := domain.PrayerProfile{
+		ChatID: identity.UserID, Latitude: latitude, Longitude: longitude,
+		Timezone: resolved.Timezone, PlaceID: resolved.PlaceID,
+		Method: location.RecommendedMethod(resolved.CountryCode), Madhab: domain.MadhabShafii,
+		HighLatitudeRule: domain.HighLatitudeAngleBased,
+	}
+	current, err := h.store.Profile(r.Context(), identity.UserID)
+	if err == nil {
+		profile.Method = current.Method
+		profile.Madhab = current.Madhab
+		profile.HighLatitudeRule = current.HighLatitudeRule
+		profile.Adjustments = current.Adjustments
+		profile.HijriAdjustment = current.HijriAdjustment
+	} else if !store.IsNotFound(err) {
+		return fmt.Errorf("load profile: %w", err)
+	}
+	if _, err := h.store.UpsertProfile(r.Context(), profile); err != nil {
+		return fmt.Errorf("save profile: %w", err)
+	}
+	if err := h.planner.RebuildChat(r.Context(), identity.UserID, h.now()); err != nil {
+		return fmt.Errorf("rebuild reminders: %w", err)
+	}
+	data, err := h.build(r.Context(), identity)
+	if err != nil {
+		return err
+	}
+	data.LocationName = resolved.City
+	return writeJSON(w, data)
+}
+
+type settingsRequest struct {
+	Language         string         `json:"language"`
+	Method           domain.Method  `json:"method"`
+	Madhab           domain.Madhab  `json:"madhab"`
+	HighLatitudeRule string         `json:"high_latitude_rule"`
+	HijriAdjustment  int            `json:"hijri_adjustment"`
+	Adjustments      map[string]int `json:"adjustments"`
+}
+
+func (h *Handler) updateSettings(w http.ResponseWriter, r *http.Request, identity Identity) error {
+	var request settingsRequest
+	if err := decodeJSON(w, r, &request); err != nil {
+		return badRequest("invalid_request")
+	}
+	locale, ok := supportedLocale(request.Language)
+	if !ok || !request.Method.Valid() || !request.Madhab.Valid() {
+		return badRequest("invalid_settings")
+	}
+	highLatitude := domain.HighLatitudeRule(request.HighLatitudeRule)
+	if !highLatitude.Valid() || request.HijriAdjustment < -2 || request.HijriAdjustment > 2 {
+		return badRequest("invalid_settings")
+	}
+	adjustments, err := parseAdjustments(request.Adjustments)
+	if err != nil {
+		return badRequest("invalid_adjustments")
+	}
+	profile, err := h.store.Profile(r.Context(), identity.UserID)
+	if store.IsNotFound(err) {
+		return conflict("location_required")
+	}
+	if err != nil {
+		return fmt.Errorf("load profile: %w", err)
+	}
+	profile.Method = request.Method
+	profile.Madhab = request.Madhab
+	profile.HighLatitudeRule = highLatitude
+	profile.HijriAdjustment = request.HijriAdjustment
+	profile.Adjustments = adjustments
+	if err := h.store.SetLanguage(r.Context(), identity.UserID, locale.Code); err != nil {
+		return fmt.Errorf("save language: %w", err)
+	}
+	if _, err := h.store.UpsertProfile(r.Context(), profile); err != nil {
+		return fmt.Errorf("save profile: %w", err)
+	}
+	if err := h.planner.RebuildChat(r.Context(), identity.UserID, h.now()); err != nil {
+		return fmt.Errorf("rebuild reminders: %w", err)
+	}
+	data, err := h.build(r.Context(), Identity{UserID: identity.UserID, FirstName: identity.FirstName, LanguageCode: locale.Code})
+	if err != nil {
+		return err
+	}
+	return writeJSON(w, data)
+}
+
+type remindersRequest struct {
+	Prayer  *bool `json:"prayer"`
+	Fasting *bool `json:"fasting"`
+	Kahf    *bool `json:"kahf"`
+}
+
+func (h *Handler) updateReminders(w http.ResponseWriter, r *http.Request, identity Identity) error {
+	var request remindersRequest
+	if err := decodeJSON(w, r, &request); err != nil {
+		return badRequest("invalid_request")
+	}
+	if request.Prayer == nil || request.Fasting == nil || request.Kahf == nil {
+		return badRequest("invalid_request")
+	}
+	if _, err := h.store.Profile(r.Context(), identity.UserID); store.IsNotFound(err) {
+		return conflict("location_required")
+	} else if err != nil {
+		return fmt.Errorf("load profile: %w", err)
+	}
+	current, err := h.reminderState(r.Context(), identity.UserID)
+	if err != nil {
+		return err
+	}
+	if current.Prayer != *request.Prayer {
+		if *request.Prayer {
+			err = h.store.EnableDefaultRules(r.Context(), identity.UserID)
+		} else {
+			err = h.store.DisableRules(r.Context(), identity.UserID)
+		}
+		if err != nil {
+			return fmt.Errorf("update prayer reminders: %w", err)
+		}
+	}
+	if current.Fasting != *request.Fasting {
+		if err := h.store.SetWeeklyRule(r.Context(), identity.UserID, domain.ReminderWeeklyFasting, *request.Fasting); err != nil {
+			return fmt.Errorf("update fasting reminders: %w", err)
+		}
+	}
+	if current.Kahf != *request.Kahf {
+		if err := h.store.SetWeeklyRule(r.Context(), identity.UserID, domain.ReminderWeeklyKahf, *request.Kahf); err != nil {
+			return fmt.Errorf("update Al-Kahf reminders: %w", err)
+		}
+	}
+	changed := current != (reminderResponse{Prayer: *request.Prayer, Fasting: *request.Fasting, Kahf: *request.Kahf})
+	if changed && (*request.Prayer || *request.Fasting || *request.Kahf) {
+		if err := h.planner.RebuildChat(r.Context(), identity.UserID, h.now()); err != nil {
+			return fmt.Errorf("rebuild reminders: %w", err)
+		}
+	}
+	data, err := h.build(r.Context(), identity)
+	if err != nil {
+		return err
+	}
+	return writeJSON(w, data)
+}
+
+type bootstrapResponse struct {
+	User          userResponse      `json:"user"`
+	Locale        string            `json:"locale"`
+	NeedsLocation bool              `json:"needs_location"`
+	LocationName  string            `json:"location_name,omitempty"`
+	Profile       *profileResponse  `json:"profile,omitempty"`
+	Today         *scheduleResponse `json:"today,omitempty"`
+	Tomorrow      *scheduleResponse `json:"tomorrow,omitempty"`
+	Reminders     reminderResponse  `json:"reminders"`
+	Options       optionsResponse   `json:"options"`
+	Labels        map[string]string `json:"labels"`
+}
+
+type userResponse struct {
+	ID        int64  `json:"id"`
+	FirstName string `json:"first_name"`
+}
+
+type profileResponse struct {
+	Timezone         string         `json:"timezone"`
+	Method           domain.Method  `json:"method"`
+	Madhab           domain.Madhab  `json:"madhab"`
+	HighLatitudeRule string         `json:"high_latitude_rule"`
+	HijriAdjustment  int            `json:"hijri_adjustment"`
+	Adjustments      map[string]int `json:"adjustments"`
+}
+
+type scheduleResponse struct {
+	Gregorian string           `json:"gregorian"`
+	Hijri     string           `json:"hijri"`
+	Timezone  string           `json:"timezone"`
+	Prayers   []prayerResponse `json:"prayers"`
+}
+
+type prayerResponse struct {
+	ID    domain.Prayer `json:"id"`
+	Name  string        `json:"name"`
+	Emoji string        `json:"emoji"`
+	Time  string        `json:"time"`
+}
+
+type reminderResponse struct {
+	Prayer  bool `json:"prayer"`
+	Fasting bool `json:"fasting"`
+	Kahf    bool `json:"kahf"`
+}
+
+type option struct {
+	Value string `json:"value"`
+	Label string `json:"label"`
+}
+
+type optionsResponse struct {
+	Languages    []option `json:"languages"`
+	Methods      []option `json:"methods"`
+	Madhabs      []option `json:"madhabs"`
+	HighLatitude []option `json:"high_latitude"`
+}
+
+func (h *Handler) build(ctx context.Context, identity Identity) (bootstrapResponse, error) {
+	if err := h.ensureChat(ctx, identity); err != nil {
+		return bootstrapResponse{}, err
+	}
+	chat, err := h.store.Chat(ctx, identity.UserID)
+	if err != nil {
+		return bootstrapResponse{}, fmt.Errorf("load chat: %w", err)
+	}
+	locale := i18n.Resolve(chat.LanguageCode)
+	response := bootstrapResponse{
+		User:   userResponse{ID: identity.UserID, FirstName: identity.FirstName},
+		Locale: locale.Code, Labels: labels(locale), Options: options(locale),
+	}
+	response.Reminders, err = h.reminderState(ctx, identity.UserID)
+	if err != nil {
+		return bootstrapResponse{}, err
+	}
+	profile, err := h.store.Profile(ctx, identity.UserID)
+	if store.IsNotFound(err) {
+		response.NeedsLocation = true
+		return response, nil
+	}
+	if err != nil {
+		return bootstrapResponse{}, fmt.Errorf("load profile: %w", err)
+	}
+	response.Profile = &profileResponse{
+		Timezone: profile.Timezone, Method: profile.Method, Madhab: profile.Madhab,
+		HighLatitudeRule: string(profile.HighLatitudeRule), HijriAdjustment: profile.HijriAdjustment,
+		Adjustments: adjustmentMap(profile.Adjustments),
+	}
+	response.LocationName = profile.Timezone
+	now := h.now()
+	today, err := h.calculator.Day(ctx, now, profile)
+	if err != nil {
+		return bootstrapResponse{}, fmt.Errorf("calculate today: %w", err)
+	}
+	tomorrow, err := h.calculator.Day(ctx, now.In(today.Date.Location()).AddDate(0, 0, 1), profile)
+	if err != nil {
+		return bootstrapResponse{}, fmt.Errorf("calculate tomorrow: %w", err)
+	}
+	formattedToday := formatSchedule(today, profile, locale)
+	formattedTomorrow := formatSchedule(tomorrow, profile, locale)
+	response.Today = &formattedToday
+	response.Tomorrow = &formattedTomorrow
+	return response, nil
+}
+
+func (h *Handler) ensureChat(ctx context.Context, identity Identity) error {
+	language := i18n.Resolve(identity.LanguageCode).Code
+	if err := h.store.UpsertChat(ctx, domain.Chat{
+		TelegramChatID: identity.UserID, Type: "private", LanguageCode: language,
+	}); err != nil {
+		return fmt.Errorf("save chat: %w", err)
+	}
+	return nil
+}
+
+func (h *Handler) reminderState(ctx context.Context, chatID int64) (reminderResponse, error) {
+	rules, err := h.store.EnabledRules(ctx, chatID)
+	if err != nil {
+		return reminderResponse{}, fmt.Errorf("load reminders: %w", err)
+	}
+	var state reminderResponse
+	for _, rule := range rules {
+		switch rule.Kind {
+		case domain.ReminderWeeklyFasting:
+			state.Fasting = true
+		case domain.ReminderWeeklyKahf:
+			state.Kahf = true
+		default:
+			state.Prayer = true
+		}
+	}
+	return state, nil
+}
+
+func formatSchedule(schedule domain.DaySchedule, profile domain.PrayerProfile, locale i18n.Locale) scheduleResponse {
+	result := scheduleResponse{
+		Gregorian: fmt.Sprintf("%d %s %d", schedule.Date.Day(), locale.Month(int(schedule.Date.Month())), schedule.Date.Year()),
+		Timezone:  profile.Timezone,
+	}
+	if date, err := hijri.FromGregorian(schedule.Date, profile.HijriAdjustment); err == nil {
+		result.Hijri = fmt.Sprintf("%d %s %d %s", date.Day, locale.HijriMonth(date.Month), date.Year, locale.Message("hijri_era"))
+	}
+	for _, prayer := range prayers() {
+		if at, ok := schedule.At(prayer); ok {
+			result.Prayers = append(result.Prayers, prayerResponse{
+				ID: prayer, Name: locale.Prayer(prayer), Emoji: prayerEmoji(prayer), Time: at.Format("15:04"),
+			})
+		}
+	}
+	return result
+}
+
+func options(locale i18n.Locale) optionsResponse {
+	result := optionsResponse{}
+	for _, language := range i18n.Supported() {
+		result.Languages = append(result.Languages, option{Value: language.Code, Label: language.NativeName})
+	}
+	for _, method := range domain.SupportedMethods() {
+		result.Methods = append(result.Methods, option{Value: string(method), Label: locale.Method(method)})
+	}
+	for _, madhab := range []domain.Madhab{domain.MadhabShafii, domain.MadhabHanafi} {
+		result.Madhabs = append(result.Madhabs, option{Value: string(madhab), Label: locale.Madhab(madhab)})
+	}
+	for _, rule := range []domain.HighLatitudeRule{domain.HighLatitudeAngleBased, domain.HighLatitudeMiddleNight, domain.HighLatitudeSeventhNight} {
+		result.HighLatitude = append(result.HighLatitude, option{Value: string(rule), Label: locale.HighLatitudeRule(rule)})
+	}
+	return result
+}
+
+func supportedLocale(code string) (i18n.Locale, bool) {
+	for _, locale := range i18n.Supported() {
+		if locale.Code == code {
+			return locale, true
+		}
+	}
+	return i18n.Locale{}, false
+}
+
+func parseAdjustments(values map[string]int) (domain.Adjustments, error) {
+	if len(values) != len(prayers()) {
+		return domain.Adjustments{}, fmt.Errorf("all prayer adjustments are required")
+	}
+	for _, prayer := range prayers() {
+		value, ok := values[string(prayer)]
+		if !ok || value < -30 || value > 30 {
+			return domain.Adjustments{}, fmt.Errorf("invalid prayer adjustment")
+		}
+	}
+	return domain.Adjustments{
+		Fajr: values["fajr"], Sunrise: values["sunrise"], Dhuhr: values["dhuhr"],
+		Asr: values["asr"], Maghrib: values["maghrib"], Isha: values["isha"],
+	}, nil
+}
+
+func adjustmentMap(value domain.Adjustments) map[string]int {
+	return map[string]int{
+		"fajr": value.Fajr, "sunrise": value.Sunrise, "dhuhr": value.Dhuhr,
+		"asr": value.Asr, "maghrib": value.Maghrib, "isha": value.Isha,
+	}
+}
+
+func prayers() []domain.Prayer {
+	return []domain.Prayer{domain.PrayerFajr, domain.PrayerSunrise, domain.PrayerDhuhr, domain.PrayerAsr, domain.PrayerMaghrib, domain.PrayerIsha}
+}
+
+func prayerEmoji(prayer domain.Prayer) string {
+	switch prayer {
+	case domain.PrayerFajr:
+		return "🌙"
+	case domain.PrayerSunrise:
+		return "🌅"
+	case domain.PrayerDhuhr:
+		return "☀️"
+	case domain.PrayerAsr:
+		return "🌤"
+	case domain.PrayerMaghrib:
+		return "🌇"
+	default:
+		return "🌌"
+	}
+}
+
+func decodeJSON(w http.ResponseWriter, r *http.Request, target any) error {
+	r.Body = http.MaxBytesReader(w, r.Body, 64<<10)
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return fmt.Errorf("multiple JSON values")
+	}
+	return nil
+}
+
+func writeJSON(w http.ResponseWriter, value any) error {
+	return json.NewEncoder(w).Encode(value)
+}
+
+func writeError(w http.ResponseWriter, status int, code string) {
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": code})
+}
+
+type requestError struct {
+	status int
+	code   string
+}
+
+func (e *requestError) Error() string { return e.code }
+func badRequest(code string) error    { return &requestError{status: http.StatusBadRequest, code: code} }
+func conflict(code string) error      { return &requestError{status: http.StatusConflict, code: code} }
+
+func labels(locale i18n.Locale) map[string]string {
+	copy := miniCopy[locale.Code]
+	return map[string]string{
+		"app_title": locale.BotName, "today": locale.Button(i18n.ActionToday),
+		"tomorrow": locale.Button(i18n.ActionTomorrow), "settings": locale.Button(i18n.ActionSettings),
+		"reminders": locale.Button(i18n.ActionReminders), "location": locale.Button(i18n.ActionLocation),
+		"share_location": locale.Button("share_location"), "language": locale.Button(i18n.ActionLanguage),
+		"method": locale.Message("method"), "madhab": locale.Message("madhab"),
+		"highlat": locale.Message("highlat"), "adjustments": locale.Message("adjustments"),
+		"hijri": locale.Message("hijri_date"), "prayer_reminders": locale.Button("prayer_reminders"),
+		"fasting_reminders": locale.Button("fasting_reminders"), "kahf_reminders": locale.Button("kahf_reminders"),
+		"fasting_schedule": locale.Message("fasting_schedule"), "kahf_schedule": locale.Message("kahf_schedule"),
+		"save": copy.Save, "saved": copy.Saved, "loading": copy.Loading,
+		"location_help": copy.LocationHelp, "location_error": copy.LocationError,
+		"open_in_telegram": copy.OpenInTelegram, "temporary_failure": copy.TemporaryFailure,
+		"calculated_locally": copy.CalculatedLocally, "companion": copy.Companion,
+		"update_location": copy.UpdateLocation,
+	}
+}
+
+type miniAppCopy struct {
+	Save, Saved, Loading, LocationHelp, LocationError   string
+	OpenInTelegram, TemporaryFailure, CalculatedLocally string
+	Companion, UpdateLocation                           string
+}
+
+var miniCopy = map[string]miniAppCopy{
+	"en": {"Save changes", "Saved", "Loading prayer times…", "Share your location to calculate accurate local prayer times.", "Location access failed. Check Telegram's location permission and try again.", "Open this page from the bot inside Telegram.", "Something went wrong. Please try again.", "Calculated locally for your saved timezone", "Prayer companion", "Update location"},
+	"ar": {"حفظ التغييرات", "تم الحفظ", "جارٍ تحميل مواقيت الصلاة…", "شارك موقعك لحساب مواقيت الصلاة المحلية بدقة.", "تعذر الوصول إلى الموقع. تحقق من إذن الموقع في تيليجرام وحاول مجددًا.", "افتح هذه الصفحة من داخل البوت في تيليجرام.", "حدث خطأ. حاول مرة أخرى.", "محسوبة محليًا حسب منطقتك الزمنية", "رفيق الصلاة", "تحديث الموقع"},
+	"es": {"Guardar cambios", "Guardado", "Cargando horarios de oración…", "Comparte tu ubicación para calcular horarios locales precisos.", "No se pudo obtener la ubicación. Revisa el permiso de Telegram e inténtalo de nuevo.", "Abre esta página desde el bot en Telegram.", "Algo salió mal. Inténtalo de nuevo.", "Calculado localmente para tu zona horaria", "Compañero de oración", "Actualizar ubicación"},
+	"fr": {"Enregistrer", "Enregistré", "Chargement des horaires de prière…", "Partagez votre position pour calculer des horaires locaux précis.", "Impossible d'accéder à la position. Vérifiez l'autorisation Telegram et réessayez.", "Ouvrez cette page depuis le bot dans Telegram.", "Une erreur est survenue. Réessayez.", "Calculé localement pour votre fuseau horaire", "Compagnon de prière", "Actualiser le lieu"},
+	"ru": {"Сохранить", "Сохранено", "Загружаем время намаза…", "Поделитесь геопозицией для точного расчёта местного времени намаза.", "Не удалось получить геопозицию. Проверьте разрешение Telegram и повторите попытку.", "Откройте эту страницу из бота в Telegram.", "Произошла ошибка. Попробуйте ещё раз.", "Рассчитано локально для вашего часового пояса", "Помощник для намаза", "Обновить геопозицию"},
+	"tr": {"Değişiklikleri kaydet", "Kaydedildi", "Namaz vakitleri yükleniyor…", "Doğru yerel namaz vakitleri için konumunuzu paylaşın.", "Konum alınamadı. Telegram konum iznini kontrol edip tekrar deneyin.", "Bu sayfayı Telegram içindeki bottan açın.", "Bir hata oluştu. Lütfen tekrar deneyin.", "Kayıtlı saat diliminiz için yerel olarak hesaplandı", "Namaz yardımcısı", "Konumu güncelle"},
+	"uz": {"O‘zgarishlarni saqlash", "Saqlandi", "Namoz vaqtlari yuklanmoqda…", "Aniq mahalliy namoz vaqtlari uchun joylashuvingizni ulashing.", "Joylashuv olinmadi. Telegram ruxsatini tekshirib, qayta urinib ko‘ring.", "Bu sahifani Telegram ichidagi botdan oching.", "Xatolik yuz berdi. Qayta urinib ko‘ring.", "Saqlangan vaqt mintaqangiz uchun mahalliy hisoblandi", "Namoz yordamchisi", "Joylashuvni yangilash"},
+	"tt": {"Үзгәрешләрне саклау", "Сакланды", "Намаз вакытлары йөкләнә…", "Төгәл җирле намаз вакытлары өчен урыныгызны бүлешегез.", "Урынны алып булмады. Telegram рөхсәтен тикшереп, кабатлап карагыз.", "Бу битне Telegram эчендәге боттан ачыгыз.", "Хата чыкты. Кабатлап карагыз.", "Сакланган сәгать поясы өчен җирле исәпләнде", "Намаз ярдәмчесе", "Урынны яңарту"},
+}

--- a/global/internal/miniapp/handler_test.go
+++ b/global/internal/miniapp/handler_test.go
@@ -1,0 +1,253 @@
+package miniapp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/escalopa/prayer-bot/global/internal/domain"
+	"github.com/escalopa/prayer-bot/global/internal/i18n"
+	"github.com/escalopa/prayer-bot/global/internal/location"
+	"github.com/escalopa/prayer-bot/global/internal/prayertime"
+	"github.com/jackc/pgx/v5"
+)
+
+func TestStaticMiniAppIsEmbeddedWithSecurityHeaders(t *testing.T) {
+	handler := NewHandler("token", nil, nil, nil, nil, nil)
+	mux := http.NewServeMux()
+	handler.Register(mux)
+
+	request := httptest.NewRequest(http.MethodGet, "/app/", nil)
+	response := httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d", response.Code)
+	}
+	if !strings.Contains(response.Body.String(), "telegram-web-app.js") {
+		t.Fatal("embedded Mini App HTML is missing Telegram SDK")
+	}
+	if !strings.Contains(response.Header().Get("Content-Security-Policy"), "telegram.org") {
+		t.Fatal("Mini App response is missing its CSP")
+	}
+}
+
+func TestMiniAppAPIRejectsUnsignedRequests(t *testing.T) {
+	handler := NewHandler("token", nil, nil, nil, nil, nil)
+	mux := http.NewServeMux()
+	handler.Register(mux)
+
+	request := httptest.NewRequest(http.MethodPost, "/api/miniapp/bootstrap", nil)
+	response := httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+
+	if response.Code != http.StatusUnauthorized || !strings.Contains(response.Body.String(), "unauthorized") {
+		t.Fatalf("unexpected response: %d %s", response.Code, response.Body.String())
+	}
+}
+
+func TestFormatScheduleIncludesLocalizedGregorianAndHijriDates(t *testing.T) {
+	location := time.FixedZone("test", 2*60*60)
+	date := time.Date(2026, time.July, 17, 12, 0, 0, 0, location)
+	schedule := domain.DaySchedule{
+		Date: date, Timezone: "Africa/Cairo",
+		Times: map[domain.Prayer]time.Time{
+			domain.PrayerFajr: time.Date(2026, time.July, 17, 4, 12, 0, 0, location),
+		},
+	}
+	profile := domain.PrayerProfile{Timezone: "Africa/Cairo", Method: domain.MethodEgyptian}
+
+	result := formatSchedule(schedule, profile, i18n.Resolve("ar"))
+	if !strings.Contains(result.Gregorian, "يوليو") || !strings.Contains(result.Hijri, "هـ") {
+		t.Fatalf("unexpected localized dates: %+v", result)
+	}
+	if len(result.Prayers) != 1 || result.Prayers[0].Time != "04:12" || result.Prayers[0].Name != "الفجر" {
+		t.Fatalf("unexpected prayers: %+v", result.Prayers)
+	}
+}
+
+func TestBootstrapUsesSignedTelegramIdentityAndReturnsLocationGate(t *testing.T) {
+	now := time.Date(2026, time.July, 17, 12, 0, 0, 0, time.UTC)
+	storage := newFakeStorage()
+	handler := NewHandler("test-token", storage, nil, nil, nil, nil)
+	handler.now = func() time.Time { return now }
+	mux := http.NewServeMux()
+	handler.Register(mux)
+
+	request := httptest.NewRequest(http.MethodPost, "/api/miniapp/bootstrap", nil)
+	request.Header.Set("X-Telegram-Init-Data", signedInitData(t, "test-token", now, initDataUser{
+		ID: 42, FirstName: "Amina", LanguageCode: "ar",
+	}))
+	response := httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	var data bootstrapResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &data); err != nil {
+		t.Fatal(err)
+	}
+	if data.User.ID != 42 || data.User.FirstName != "Amina" || data.Locale != "ar" || !data.NeedsLocation {
+		t.Fatalf("unexpected bootstrap response: %+v", data)
+	}
+	if chat := storage.chats[42]; chat.TelegramChatID != 42 || chat.LanguageCode != "ar" || chat.Type != "private" {
+		t.Fatalf("unexpected stored chat: %+v", chat)
+	}
+}
+
+func TestLocationUpdatePreservesCalculationSettingsAndRoundsCoordinates(t *testing.T) {
+	now := time.Date(2026, time.July, 17, 12, 0, 0, 0, time.UTC)
+	storage := newFakeStorage()
+	storage.chats[42] = domain.Chat{TelegramChatID: 42, Type: "private", LanguageCode: "en"}
+	storage.profiles[42] = domain.PrayerProfile{
+		ChatID: 42, Latitude: 1, Longitude: 2, Timezone: "UTC", PlaceID: "old",
+		Method: domain.MethodISNA, Madhab: domain.MadhabHanafi,
+		HighLatitudeRule: domain.HighLatitudeMiddleNight, HijriAdjustment: 1,
+		Adjustments: domain.Adjustments{Fajr: 2},
+	}
+	resolver := &fakeResolver{resolved: location.Resolved{
+		Timezone: "Africa/Cairo", PlaceID: "cairo", City: "Cairo", CountryCode: "EG",
+	}}
+	planner := &fakePlanner{}
+	handler := NewHandler("test-token", storage, resolver, prayertime.New(), planner, nil)
+	handler.now = func() time.Time { return now }
+	mux := http.NewServeMux()
+	handler.Register(mux)
+
+	request := httptest.NewRequest(http.MethodPut, "/api/miniapp/location", strings.NewReader(`{"latitude":30.04442,"longitude":31.23571}`))
+	request.Header.Set("X-Telegram-Init-Data", signedInitData(t, "test-token", now, initDataUser{ID: 42, FirstName: "Amina", LanguageCode: "en"}))
+	response := httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	profile := storage.profiles[42]
+	if profile.Latitude != 30.044 || profile.Longitude != 31.236 || profile.Timezone != "Africa/Cairo" {
+		t.Fatalf("unexpected saved location: %+v", profile)
+	}
+	if profile.Method != domain.MethodISNA || profile.Madhab != domain.MadhabHanafi || profile.HijriAdjustment != 1 || profile.Adjustments.Fajr != 2 {
+		t.Fatalf("existing calculation settings were not preserved: %+v", profile)
+	}
+	if resolver.latitude != 30.04442 || resolver.longitude != 31.23571 || planner.rebuilds != 1 {
+		t.Fatalf("resolver/planner calls = %+v / %d", resolver, planner.rebuilds)
+	}
+	var data bootstrapResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &data); err != nil {
+		t.Fatal(err)
+	}
+	if data.LocationName != "Cairo" || data.Today == nil || data.Tomorrow == nil {
+		t.Fatalf("unexpected response: %+v", data)
+	}
+}
+
+func TestParseAdjustmentsRequiresCompleteSnapshot(t *testing.T) {
+	if _, err := parseAdjustments(map[string]int{"fajr": 1}); err == nil {
+		t.Fatal("expected an incomplete adjustment snapshot to fail")
+	}
+	values := map[string]int{"fajr": 1, "sunrise": 0, "dhuhr": 0, "asr": 0, "maghrib": 0, "isha": -1}
+	adjustments, err := parseAdjustments(values)
+	if err != nil || adjustments.Fajr != 1 || adjustments.Isha != -1 {
+		t.Fatalf("unexpected adjustments: %+v, %v", adjustments, err)
+	}
+}
+
+type fakeStorage struct {
+	chats    map[int64]domain.Chat
+	profiles map[int64]domain.PrayerProfile
+	rules    map[int64][]domain.ReminderRule
+}
+
+func newFakeStorage() *fakeStorage {
+	return &fakeStorage{
+		chats: make(map[int64]domain.Chat), profiles: make(map[int64]domain.PrayerProfile),
+		rules: make(map[int64][]domain.ReminderRule),
+	}
+}
+
+func (s *fakeStorage) UpsertChat(_ context.Context, chat domain.Chat) error {
+	if current, ok := s.chats[chat.TelegramChatID]; ok {
+		chat.LanguageCode = current.LanguageCode
+	}
+	s.chats[chat.TelegramChatID] = chat
+	return nil
+}
+
+func (s *fakeStorage) Chat(_ context.Context, chatID int64) (domain.Chat, error) {
+	chat, ok := s.chats[chatID]
+	if !ok {
+		return domain.Chat{}, pgx.ErrNoRows
+	}
+	return chat, nil
+}
+
+func (s *fakeStorage) SetLanguage(_ context.Context, chatID int64, language string) error {
+	chat := s.chats[chatID]
+	chat.LanguageCode = language
+	s.chats[chatID] = chat
+	return nil
+}
+
+func (s *fakeStorage) Profile(_ context.Context, chatID int64) (domain.PrayerProfile, error) {
+	profile, ok := s.profiles[chatID]
+	if !ok {
+		return domain.PrayerProfile{}, pgx.ErrNoRows
+	}
+	return profile, nil
+}
+
+func (s *fakeStorage) UpsertProfile(_ context.Context, profile domain.PrayerProfile) (domain.PrayerProfile, error) {
+	s.profiles[profile.ChatID] = profile
+	return profile, nil
+}
+
+func (s *fakeStorage) EnabledRules(_ context.Context, chatID int64) ([]domain.ReminderRule, error) {
+	return s.rules[chatID], nil
+}
+
+func (s *fakeStorage) EnableDefaultRules(_ context.Context, chatID int64) error {
+	s.rules[chatID] = append(s.rules[chatID], domain.ReminderRule{ChatID: chatID, Kind: domain.ReminderAt, Enabled: true})
+	return nil
+}
+
+func (s *fakeStorage) DisableRules(_ context.Context, chatID int64) error {
+	for index := range s.rules[chatID] {
+		if !s.rules[chatID][index].Kind.Weekly() {
+			s.rules[chatID][index].Enabled = false
+		}
+	}
+	return nil
+}
+
+func (s *fakeStorage) SetWeeklyRule(_ context.Context, chatID int64, kind domain.ReminderKind, enabled bool) error {
+	for index := range s.rules[chatID] {
+		if s.rules[chatID][index].Kind == kind {
+			s.rules[chatID][index].Enabled = enabled
+			return nil
+		}
+	}
+	s.rules[chatID] = append(s.rules[chatID], domain.ReminderRule{ChatID: chatID, Kind: kind, Enabled: enabled})
+	return nil
+}
+
+type fakeResolver struct {
+	resolved            location.Resolved
+	latitude, longitude float64
+}
+
+func (r *fakeResolver) Resolve(_ context.Context, latitude, longitude float64) (location.Resolved, error) {
+	r.latitude, r.longitude = latitude, longitude
+	return r.resolved, nil
+}
+
+type fakePlanner struct{ rebuilds int }
+
+func (p *fakePlanner) RebuildChat(context.Context, int64, time.Time) error {
+	p.rebuilds++
+	return nil
+}

--- a/global/internal/miniapp/static/app.css
+++ b/global/internal/miniapp/static/app.css
@@ -1,0 +1,171 @@
+:root {
+  --app-bg: var(--tg-theme-bg-color, #f4f1e8);
+  --app-text: var(--tg-theme-text-color, #17231d);
+  --app-muted: var(--tg-theme-hint-color, #68756e);
+  --surface: var(--tg-theme-section-bg-color, #fffdf7);
+  --surface-alt: var(--tg-theme-secondary-bg-color, #e9eee8);
+  --accent: var(--tg-theme-button-color, #19745a);
+  --accent-text: var(--tg-theme-button-text-color, #ffffff);
+  --line: color-mix(in srgb, var(--app-muted) 20%, transparent);
+  --shadow: 0 18px 50px rgba(24, 54, 42, .09);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--app-text);
+  background:
+    radial-gradient(circle at 92% -5%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 34%),
+    radial-gradient(circle at -10% 28%, rgba(210, 171, 69, .14), transparent 31%),
+    var(--app-bg);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+button, select, input { font: inherit; }
+button { -webkit-tap-highlight-color: transparent; }
+
+.app-shell {
+  width: min(100%, 720px);
+  margin: 0 auto;
+  padding: max(20px, env(safe-area-inset-top)) 16px calc(32px + env(safe-area-inset-bottom));
+}
+
+.hero {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 4px 2px 20px;
+}
+
+.brand-mark {
+  display: grid;
+  place-items: center;
+  width: 58px;
+  height: 58px;
+  flex: 0 0 58px;
+  border-radius: 19px;
+  color: #fff8d6;
+  background: linear-gradient(145deg, #237f62, #0c4c3d);
+  box-shadow: 0 12px 30px rgba(17, 91, 70, .24);
+  font: 700 40px/1 Georgia, serif;
+  transform: rotate(-10deg);
+}
+
+.hero h1 { margin: 1px 0 2px; font-size: 25px; letter-spacing: -.03em; }
+.eyebrow, .section-kicker { margin: 0; color: var(--accent); font-size: 12px; font-weight: 750; letter-spacing: .09em; text-transform: uppercase; }
+.muted { margin: 0; color: var(--app-muted); font-size: 14px; }
+
+.hidden { display: none !important; }
+
+.state-card, .location-card, .panel, .schedule-card {
+  border: 1px solid var(--line);
+  border-radius: 24px;
+  background: color-mix(in srgb, var(--surface) 96%, transparent);
+  box-shadow: var(--shadow);
+}
+
+.state-card, .location-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 38px 24px;
+}
+
+.state-card { flex-direction: row; justify-content: center; gap: 12px; }
+.state-card p, .location-card p { color: var(--app-muted); line-height: 1.5; }
+.location-card h2 { margin: 8px 0 0; }
+.state-icon { font-size: 34px; color: var(--accent); }
+
+.spinner {
+  width: 20px;
+  height: 20px;
+  border: 2px solid color-mix(in srgb, var(--accent) 22%, transparent);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin .8s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.segmented {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px;
+  margin-bottom: 10px;
+  padding: 4px;
+  border-radius: 17px;
+  background: var(--surface-alt);
+}
+
+.segment {
+  min-height: 42px;
+  border: 0;
+  border-radius: 13px;
+  color: var(--app-muted);
+  background: transparent;
+  font-weight: 700;
+  cursor: pointer;
+}
+.segment.active { color: var(--app-text); background: var(--surface); box-shadow: 0 3px 14px rgba(31, 54, 45, .08); }
+
+.schedule-card { overflow: hidden; }
+.schedule-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; padding: 22px 20px 17px; }
+.date-primary { margin: 0 0 5px; font-size: 20px; font-weight: 800; letter-spacing: -.025em; }
+.date-secondary { margin: 0; color: #9a7424; font-size: 14px; font-weight: 650; }
+.timezone-pill { max-width: 44%; padding: 7px 10px; overflow: hidden; border-radius: 999px; color: var(--app-muted); background: var(--surface-alt); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
+
+.prayer-grid { display: grid; grid-template-columns: repeat(3, 1fr); border-top: 1px solid var(--line); }
+.prayer { padding: 17px 8px; text-align: center; border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.prayer:nth-child(3n) { border-right: 0; }
+.prayer:nth-last-child(-n+3) { border-bottom: 0; }
+.prayer-emoji { display: block; margin-bottom: 7px; font-size: 19px; }
+.prayer-name { display: block; min-height: 18px; color: var(--app-muted); font-size: 12px; }
+.prayer-time { display: block; margin-top: 4px; font-size: 18px; font-weight: 800; letter-spacing: .02em; }
+.card-note { margin: 0; padding: 13px 18px; border-top: 1px solid var(--line); color: var(--app-muted); background: color-mix(in srgb, var(--surface-alt) 55%, transparent); font-size: 11px; text-align: center; }
+
+.panel { margin-top: 14px; padding: 20px; }
+.panel-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 10px; }
+.panel-heading h2 { margin: 3px 0 0; font-size: 19px; letter-spacing: -.02em; }
+
+.toggle-row { position: relative; display: flex; align-items: center; justify-content: space-between; gap: 16px; min-height: 68px; border-bottom: 1px solid var(--line); cursor: pointer; }
+.toggle-row:last-child { border-bottom: 0; }
+.toggle-row strong, .toggle-row small { display: block; }
+.toggle-row strong { font-size: 14px; }
+.toggle-row small { margin-top: 4px; color: var(--app-muted); font-size: 11px; }
+.toggle-row input { position: absolute; opacity: 0; pointer-events: none; }
+.toggle { position: relative; width: 46px; height: 27px; flex: 0 0 46px; border-radius: 999px; background: color-mix(in srgb, var(--app-muted) 28%, transparent); transition: .2s ease; }
+.toggle::after { content: ""; position: absolute; top: 3px; left: 3px; width: 21px; height: 21px; border-radius: 50%; background: white; box-shadow: 0 2px 7px rgba(0,0,0,.18); transition: .2s ease; }
+.toggle-row input:checked + .toggle { background: var(--accent); }
+.toggle-row input:checked + .toggle::after { transform: translateX(19px); }
+[dir="rtl"] .toggle::after { left: auto; right: 3px; }
+[dir="rtl"] .toggle-row input:checked + .toggle::after { transform: translateX(-19px); }
+
+.form-grid { display: grid; gap: 13px; }
+.form-grid label { display: grid; gap: 7px; color: var(--app-muted); font-size: 12px; font-weight: 650; }
+select, input[type="number"] { width: 100%; min-height: 46px; padding: 0 13px; border: 1px solid var(--line); border-radius: 14px; outline: none; color: var(--app-text); background: var(--surface-alt); }
+select:focus, input[type="number"]:focus { border-color: var(--accent); box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 13%, transparent); }
+
+.adjustments { margin: 17px 0; border: 1px solid var(--line); border-radius: 16px; }
+.adjustments summary { padding: 14px; cursor: pointer; font-size: 13px; font-weight: 750; }
+.adjustment-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 11px; padding: 0 13px 14px; }
+.adjustment-grid label { color: var(--app-muted); font-size: 11px; }
+.adjustment-grid input { margin-top: 5px; text-align: center; }
+
+.primary-button { width: 100%; min-height: 50px; padding: 0 18px; border: 0; border-radius: 16px; color: var(--accent-text); background: var(--accent); font-weight: 800; cursor: pointer; box-shadow: 0 10px 24px color-mix(in srgb, var(--accent) 24%, transparent); }
+.primary-button:disabled { opacity: .55; cursor: wait; }
+.text-button { padding: 8px 0; border: 0; color: var(--accent); background: transparent; font-size: 12px; font-weight: 750; cursor: pointer; }
+
+.toast { position: fixed; z-index: 10; right: 16px; bottom: calc(18px + env(safe-area-inset-bottom)); left: 16px; max-width: 520px; margin: auto; padding: 14px 16px; border-radius: 15px; color: var(--accent-text); background: var(--accent); box-shadow: 0 12px 34px rgba(0,0,0,.2); font-size: 13px; font-weight: 700; text-align: center; }
+.toast.error { color: white; background: #a84040; }
+
+@media (min-width: 560px) {
+  .app-shell { padding-inline: 24px; }
+  .form-grid { grid-template-columns: 1fr 1fr; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { scroll-behavior: auto !important; animation-duration: .01ms !important; transition-duration: .01ms !important; }
+}

--- a/global/internal/miniapp/static/app.js
+++ b/global/internal/miniapp/static/app.js
@@ -1,0 +1,305 @@
+(() => {
+  "use strict";
+
+  const telegram = window.Telegram && window.Telegram.WebApp;
+  const initData = telegram ? telegram.initData : "";
+  let state = null;
+  let activeDay = "today";
+  let toastTimer = null;
+
+  const byId = (id) => document.getElementById(id);
+  const loading = byId("loading");
+  const standalone = byId("standalone");
+  const locationGate = byId("location-gate");
+  const dashboard = byId("dashboard");
+
+  if (telegram) {
+    telegram.ready();
+    telegram.expand();
+    try {
+      telegram.setHeaderColor("secondary_bg_color");
+      telegram.setBackgroundColor("bg_color");
+    } catch (_) {
+      // Older Telegram clients still render correctly with CSS theme variables.
+    }
+  }
+
+  async function request(path, method = "POST", body) {
+    const response = await fetch(path, {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        "X-Telegram-Init-Data": initData,
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+      credentials: "same-origin",
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const error = new Error(data.error || "temporary_failure");
+      error.code = data.error;
+      throw error;
+    }
+    return data;
+  }
+
+  function setText(id, value) {
+    const element = byId(id);
+    if (element) element.textContent = value || "";
+  }
+
+  function applyLabels(labels) {
+    document.documentElement.lang = state.locale;
+    document.documentElement.dir = state.locale === "ar" ? "rtl" : "ltr";
+    document.title = labels.app_title;
+    setText("eyebrow", labels.companion);
+    setText("app-title", labels.app_title);
+    setText("user-name", state.user.first_name || "");
+    setText("loading-text", labels.loading);
+    setText("standalone-text", labels.open_in_telegram);
+    setText("today-tab", labels.today);
+    setText("tomorrow-tab", labels.tomorrow);
+    setText("location-title", labels.location);
+    setText("location-help", labels.location_help);
+    setText("location-primary", labels.share_location);
+    setText("location-secondary", labels.update_location);
+    setText("reminders-title", labels.reminders);
+    setText("settings-title", labels.settings);
+    setText("prayer-reminders-label", labels.prayer_reminders);
+    setText("fasting-reminders-label", labels.fasting_reminders);
+    setText("kahf-reminders-label", labels.kahf_reminders);
+    setText("fasting-schedule", labels.fasting_schedule);
+    setText("kahf-schedule", labels.kahf_schedule);
+    setText("language-label", labels.language);
+    setText("method-label", labels.method);
+    setText("madhab-label", labels.madhab);
+    setText("highlat-label", labels.highlat);
+    setText("hijri-label", labels.hijri);
+    setText("adjustments-label", labels.adjustments);
+    setText("save-settings", labels.save);
+    setText("calculation-note", labels.calculated_locally);
+  }
+
+  function fillSelect(id, options, selected) {
+    const select = byId(id);
+    select.replaceChildren();
+    options.forEach((item) => {
+      const option = document.createElement("option");
+      option.value = item.value;
+      option.textContent = item.label;
+      option.selected = item.value === String(selected);
+      select.append(option);
+    });
+  }
+
+  function renderSettings() {
+    const profile = state.profile;
+    fillSelect("language", state.options.languages, state.locale);
+    fillSelect("method", state.options.methods, profile.method);
+    fillSelect("madhab", state.options.madhabs, profile.madhab);
+    fillSelect("highlat", state.options.high_latitude, profile.high_latitude_rule);
+    fillSelect("hijri-adjustment", [-2, -1, 0, 1, 2].map((value) => ({
+      value: String(value), label: value > 0 ? `+${value}` : String(value),
+    })), profile.hijri_adjustment);
+
+    const names = {};
+    [...state.today.prayers].forEach((prayer) => { names[prayer.id] = prayer.name; });
+    const grid = byId("adjustment-grid");
+    grid.replaceChildren();
+    Object.entries(profile.adjustments).forEach(([prayer, value]) => {
+      const label = document.createElement("label");
+      label.textContent = names[prayer] || prayer;
+      const input = document.createElement("input");
+      input.type = "number";
+      input.min = "-30";
+      input.max = "30";
+      input.step = "1";
+      input.value = String(value);
+      input.dataset.prayer = prayer;
+      label.append(input);
+      grid.append(label);
+    });
+  }
+
+  function renderSchedule() {
+    const schedule = state[activeDay];
+    setText("gregorian-date", schedule.gregorian);
+    setText("hijri-date", `☾ ${schedule.hijri}`);
+    setText("timezone", schedule.timezone);
+    const grid = byId("prayer-grid");
+    grid.replaceChildren();
+    schedule.prayers.forEach((prayer) => {
+      const item = document.createElement("div");
+      item.className = "prayer";
+      const emoji = document.createElement("span");
+      emoji.className = "prayer-emoji";
+      emoji.textContent = prayer.emoji;
+      const name = document.createElement("span");
+      name.className = "prayer-name";
+      name.textContent = prayer.name;
+      const time = document.createElement("strong");
+      time.className = "prayer-time";
+      time.textContent = prayer.time;
+      item.append(emoji, name, time);
+      grid.append(item);
+    });
+  }
+
+  function renderReminders() {
+    byId("prayer-reminders").checked = state.reminders.prayer;
+    byId("fasting-reminders").checked = state.reminders.fasting;
+    byId("kahf-reminders").checked = state.reminders.kahf;
+  }
+
+  function applyState(next) {
+    state = next;
+    loading.classList.add("hidden");
+    standalone.classList.add("hidden");
+    applyLabels(state.labels);
+    if (state.needs_location) {
+      dashboard.classList.add("hidden");
+      locationGate.classList.remove("hidden");
+      return;
+    }
+    locationGate.classList.add("hidden");
+    dashboard.classList.remove("hidden");
+    renderSchedule();
+    renderReminders();
+    renderSettings();
+  }
+
+  function showToast(message, isError = false) {
+    const toast = byId("toast");
+    toast.textContent = message;
+    toast.classList.toggle("error", isError);
+    toast.classList.remove("hidden");
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => toast.classList.add("hidden"), 3000);
+  }
+
+  function locationFromTelegram() {
+    return new Promise((resolve, reject) => {
+      const manager = telegram && telegram.LocationManager;
+      if (!manager || !telegram.isVersionAtLeast("8.0")) {
+        reject(new Error("telegram_location_unavailable"));
+        return;
+      }
+      manager.init(() => manager.getLocation((location) => {
+        if (location) resolve(location);
+        else reject(new Error("location_denied"));
+      }));
+    });
+  }
+
+  function locationFromBrowser() {
+    return new Promise((resolve, reject) => {
+      if (!navigator.geolocation) {
+        reject(new Error("browser_location_unavailable"));
+        return;
+      }
+      navigator.geolocation.getCurrentPosition(
+        (position) => resolve(position.coords), reject,
+        { enableHighAccuracy: false, timeout: 15000, maximumAge: 60000 },
+      );
+    });
+  }
+
+  async function updateLocation(button) {
+    button.disabled = true;
+    try {
+      let location;
+      try {
+        location = await locationFromTelegram();
+      } catch (_) {
+        location = await locationFromBrowser();
+      }
+      const next = await request("/api/miniapp/location", "PUT", {
+        latitude: location.latitude,
+        longitude: location.longitude,
+      });
+      applyState(next);
+      showToast(next.labels.saved);
+      if (telegram && telegram.HapticFeedback) telegram.HapticFeedback.notificationOccurred("success");
+    } catch (_) {
+      showToast(state ? state.labels.location_error : "Location access failed.", true);
+      if (telegram && telegram.HapticFeedback) telegram.HapticFeedback.notificationOccurred("error");
+    } finally {
+      button.disabled = false;
+    }
+  }
+
+  async function saveSettings() {
+    const button = byId("save-settings");
+    button.disabled = true;
+    const adjustments = {};
+    document.querySelectorAll("#adjustment-grid input").forEach((input) => {
+      adjustments[input.dataset.prayer] = Number(input.value);
+    });
+    try {
+      const next = await request("/api/miniapp/settings", "PUT", {
+        language: byId("language").value,
+        method: byId("method").value,
+        madhab: byId("madhab").value,
+        high_latitude_rule: byId("highlat").value,
+        hijri_adjustment: Number(byId("hijri-adjustment").value),
+        adjustments,
+      });
+      applyState(next);
+      showToast(next.labels.saved);
+      if (telegram && telegram.HapticFeedback) telegram.HapticFeedback.notificationOccurred("success");
+    } catch (_) {
+      showToast(state.labels.temporary_failure, true);
+    } finally {
+      button.disabled = false;
+    }
+  }
+
+  async function saveReminders() {
+    const controls = [byId("prayer-reminders"), byId("fasting-reminders"), byId("kahf-reminders")];
+    controls.forEach((control) => { control.disabled = true; });
+    try {
+      const next = await request("/api/miniapp/reminders", "PUT", {
+        prayer: controls[0].checked,
+        fasting: controls[1].checked,
+        kahf: controls[2].checked,
+      });
+      applyState(next);
+      showToast(next.labels.saved);
+    } catch (_) {
+      renderReminders();
+      showToast(state.labels.temporary_failure, true);
+    } finally {
+      controls.forEach((control) => { control.disabled = false; });
+    }
+  }
+
+  function selectDay(day) {
+    activeDay = day;
+    ["today", "tomorrow"].forEach((name) => {
+      const tab = byId(`${name}-tab`);
+      const active = name === day;
+      tab.classList.toggle("active", active);
+      tab.setAttribute("aria-selected", String(active));
+    });
+    renderSchedule();
+  }
+
+  byId("today-tab").addEventListener("click", () => selectDay("today"));
+  byId("tomorrow-tab").addEventListener("click", () => selectDay("tomorrow"));
+  byId("location-primary").addEventListener("click", (event) => updateLocation(event.currentTarget));
+  byId("location-secondary").addEventListener("click", (event) => updateLocation(event.currentTarget));
+  byId("save-settings").addEventListener("click", saveSettings);
+  ["prayer-reminders", "fasting-reminders", "kahf-reminders"].forEach((id) => byId(id).addEventListener("change", saveReminders));
+
+  if (!initData) {
+    loading.classList.add("hidden");
+    standalone.classList.remove("hidden");
+  } else {
+    request("/api/miniapp/bootstrap")
+      .then(applyState)
+      .catch(() => {
+        loading.classList.add("hidden");
+        standalone.classList.remove("hidden");
+      });
+  }
+})();

--- a/global/internal/miniapp/static/index.html
+++ b/global/internal/miniapp/static/index.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="color-scheme" content="light dark">
+  <title>Prayer Times</title>
+  <link rel="stylesheet" href="./app.css">
+  <script src="https://telegram.org/js/telegram-web-app.js?59"></script>
+  <script src="./app.js" defer></script>
+</head>
+<body>
+  <main class="app-shell">
+    <header class="hero">
+      <div class="brand-mark" aria-hidden="true">☾</div>
+      <div>
+        <p id="eyebrow" class="eyebrow">Prayer companion</p>
+        <h1 id="app-title">Prayer Times</h1>
+        <p id="user-name" class="muted"></p>
+      </div>
+    </header>
+
+    <div id="loading" class="state-card" role="status">
+      <span class="spinner" aria-hidden="true"></span>
+      <span id="loading-text">Loading prayer times…</span>
+    </div>
+
+    <section id="standalone" class="state-card hidden">
+      <div class="state-icon" aria-hidden="true">↗</div>
+      <p id="standalone-text">Open this page from the bot inside Telegram.</p>
+    </section>
+
+    <section id="location-gate" class="location-card hidden">
+      <div class="state-icon" aria-hidden="true">⌖</div>
+      <h2 id="location-title">Set location</h2>
+      <p id="location-help">Share your location to calculate accurate local prayer times.</p>
+      <button id="location-primary" class="primary-button" type="button">Share location</button>
+    </section>
+
+    <div id="dashboard" class="hidden">
+      <section class="schedule-section">
+        <div class="segmented" role="tablist" aria-label="Prayer schedule date">
+          <button id="today-tab" class="segment active" type="button" role="tab" aria-selected="true">Today</button>
+          <button id="tomorrow-tab" class="segment" type="button" role="tab" aria-selected="false">Tomorrow</button>
+        </div>
+
+        <article class="schedule-card">
+          <div class="schedule-heading">
+            <div>
+              <p id="gregorian-date" class="date-primary"></p>
+              <p id="hijri-date" class="date-secondary"></p>
+            </div>
+            <span id="timezone" class="timezone-pill"></span>
+          </div>
+          <div id="prayer-grid" class="prayer-grid"></div>
+          <p id="calculation-note" class="card-note"></p>
+        </article>
+      </section>
+
+      <section class="panel">
+        <div class="panel-heading">
+          <div>
+            <p class="section-kicker">🔔</p>
+            <h2 id="reminders-title">Reminders</h2>
+          </div>
+        </div>
+        <label class="toggle-row">
+          <span><strong id="prayer-reminders-label">Prayer times</strong></span>
+          <input id="prayer-reminders" type="checkbox">
+          <span class="toggle" aria-hidden="true"></span>
+        </label>
+        <label class="toggle-row">
+          <span><strong id="fasting-reminders-label">Monday &amp; Thursday fasting</strong><small id="fasting-schedule"></small></span>
+          <input id="fasting-reminders" type="checkbox">
+          <span class="toggle" aria-hidden="true"></span>
+        </label>
+        <label class="toggle-row">
+          <span><strong id="kahf-reminders-label">Friday Al-Kahf</strong><small id="kahf-schedule"></small></span>
+          <input id="kahf-reminders" type="checkbox">
+          <span class="toggle" aria-hidden="true"></span>
+        </label>
+      </section>
+
+      <section class="panel settings-panel">
+        <div class="panel-heading">
+          <div>
+            <p class="section-kicker">⚙️</p>
+            <h2 id="settings-title">Settings</h2>
+          </div>
+          <button id="location-secondary" class="text-button" type="button">Update location</button>
+        </div>
+
+        <div class="form-grid">
+          <label><span id="language-label">Language</span><select id="language"></select></label>
+          <label><span id="method-label">Calculation method</span><select id="method"></select></label>
+          <label><span id="madhab-label">Madhab</span><select id="madhab"></select></label>
+          <label><span id="highlat-label">High latitude rule</span><select id="highlat"></select></label>
+          <label><span id="hijri-label">Hijri date correction</span><select id="hijri-adjustment"></select></label>
+        </div>
+
+        <details class="adjustments">
+          <summary id="adjustments-label">Prayer adjustments</summary>
+          <div id="adjustment-grid" class="adjustment-grid"></div>
+        </details>
+
+        <button id="save-settings" class="primary-button" type="button">Save changes</button>
+      </section>
+    </div>
+  </main>
+
+  <div id="toast" class="toast hidden" role="status" aria-live="polite"></div>
+</body>
+</html>

--- a/global/internal/telegram/feedback.go
+++ b/global/internal/telegram/feedback.go
@@ -1,0 +1,78 @@
+package telegram
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	botapi "github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+
+	"github.com/escalopa/prayer-bot/global/internal/i18n"
+)
+
+type feedbackSender interface {
+	SendMessage(context.Context, *botapi.SendMessageParams) (*models.Message, error)
+	CopyMessage(context.Context, *botapi.CopyMessageParams) (*models.MessageID, error)
+}
+
+func (h *Handler) requestFeedback(ctx context.Context, chat models.Chat, locale i18n.Locale) error {
+	if chat.Type != models.ChatTypePrivate {
+		return h.send(ctx, chat.ID, locale.Message("feedback_private"), mainKeyboard(locale))
+	}
+	return h.send(ctx, chat.ID, locale.Message("feedback_prompt"), &models.ForceReply{
+		ForceReply: true, InputFieldPlaceholder: locale.Message("feedback_placeholder"), Selective: true,
+	})
+}
+
+func (h *Handler) submitFeedback(ctx context.Context, message *models.Message, locale i18n.Locale) error {
+	if message.Chat.Type != models.ChatTypePrivate || message.From == nil {
+		return nil
+	}
+	if err := deliverFeedback(ctx, h.bot, h.ownerID, message, locale.Code); err != nil {
+		return err
+	}
+	return h.send(ctx, message.Chat.ID, locale.Message("feedback_sent"), mainKeyboard(locale))
+}
+
+func deliverFeedback(ctx context.Context, sender feedbackSender, ownerID int64, message *models.Message, languageCode string) error {
+	name := strings.TrimSpace(message.From.FirstName + " " + message.From.LastName)
+	if name == "" {
+		name = "Telegram user"
+	}
+	username := "not set"
+	if message.From.Username != "" {
+		username = "@" + message.From.Username
+	}
+	header := fmt.Sprintf(
+		"<b>New bot feedback</b> 💬\nFrom: <a href=\"tg://user?id=%d\">%s</a>\nUsername: %s\nUser ID: <code>%d</code>\nBot language: <code>%s</code>",
+		message.From.ID, escape(name), escape(username), message.From.ID, escape(languageCode),
+	)
+	notification, err := sender.SendMessage(ctx, &botapi.SendMessageParams{
+		ChatID: ownerID, Text: header, ParseMode: models.ParseModeHTML,
+	})
+	if err != nil {
+		return fmt.Errorf("send feedback metadata: %w", err)
+	}
+	if _, err := sender.CopyMessage(ctx, &botapi.CopyMessageParams{
+		ChatID: ownerID, FromChatID: message.Chat.ID, MessageID: message.ID,
+		ReplyParameters: &models.ReplyParameters{MessageID: notification.ID},
+	}); err != nil {
+		return fmt.Errorf("copy feedback content: %w", err)
+	}
+	return nil
+}
+
+func isFeedbackReply(message *models.Message) bool {
+	reply := message.ReplyToMessage
+	return message.Chat.Type == models.ChatTypePrivate && reply != nil && reply.From != nil && reply.From.IsBot && isFeedbackPrompt(reply.Text)
+}
+
+func isFeedbackPrompt(text string) bool {
+	for _, locale := range i18n.Supported() {
+		if text == locale.Message("feedback_prompt") {
+			return true
+		}
+	}
+	return false
+}

--- a/global/internal/telegram/feedback_test.go
+++ b/global/internal/telegram/feedback_test.go
@@ -1,0 +1,64 @@
+package telegram
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	botapi "github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+
+	"github.com/escalopa/prayer-bot/global/internal/i18n"
+)
+
+func TestFeedbackReplyRequiresPrivateReplyToBotPrompt(t *testing.T) {
+	prompt := i18n.Resolve("ar").Message("feedback_prompt")
+	message := &models.Message{
+		Chat:           models.Chat{ID: 42, Type: models.ChatTypePrivate},
+		ReplyToMessage: &models.Message{Text: prompt, From: &models.User{IsBot: true}},
+	}
+	if !isFeedbackReply(message) {
+		t.Fatal("expected a reply to a localized bot prompt to be recognized")
+	}
+	message.ReplyToMessage.From.IsBot = false
+	if isFeedbackReply(message) {
+		t.Fatal("a user-authored lookalike prompt must not be accepted")
+	}
+}
+
+func TestDeliverFeedbackSendsPrivateContextAndCopiesOriginal(t *testing.T) {
+	sender := &fakeFeedbackSender{}
+	message := &models.Message{
+		ID: 77, Chat: models.Chat{ID: 42, Type: models.ChatTypePrivate}, Text: "The date is wrong",
+		From: &models.User{ID: 99, FirstName: "Amina <Admin>", Username: "amina"},
+	}
+	if err := deliverFeedback(context.Background(), sender, 1234, message, "ar"); err != nil {
+		t.Fatal(err)
+	}
+	if sender.sent == nil || sender.sent.ChatID != int64(1234) || !strings.Contains(sender.sent.Text, "Amina &lt;Admin&gt;") || !strings.Contains(sender.sent.Text, "<code>99</code>") {
+		t.Fatalf("unexpected owner notification: %+v", sender.sent)
+	}
+	if sender.copied == nil || sender.copied.ChatID != int64(1234) || sender.copied.FromChatID != int64(42) || sender.copied.MessageID != 77 {
+		t.Fatalf("unexpected copied feedback: %+v", sender.copied)
+	}
+	if sender.copied.ReplyParameters == nil || sender.copied.ReplyParameters.MessageID != 500 {
+		t.Fatalf("feedback copy is not attached to its context: %+v", sender.copied.ReplyParameters)
+	}
+}
+
+type fakeFeedbackSender struct {
+	sent   *botapi.SendMessageParams
+	copied *botapi.CopyMessageParams
+}
+
+func (f *fakeFeedbackSender) SendMessage(_ context.Context, params *botapi.SendMessageParams) (*models.Message, error) {
+	f.sent = params
+	return &models.Message{ID: 500}, nil
+}
+
+func (f *fakeFeedbackSender) CopyMessage(_ context.Context, params *botapi.CopyMessageParams) (*models.MessageID, error) {
+	f.copied = params
+	return &models.MessageID{ID: 501}, nil
+}
+
+var _ feedbackSender = (*fakeFeedbackSender)(nil)

--- a/global/internal/telegram/handler.go
+++ b/global/internal/telegram/handler.go
@@ -24,6 +24,7 @@ type Bot interface {
 	SendMessage(context.Context, *botapi.SendMessageParams) (*models.Message, error)
 	SendPhoto(context.Context, *botapi.SendPhotoParams) (*models.Message, error)
 	EditMessageText(context.Context, *botapi.EditMessageTextParams) (*models.Message, error)
+	CopyMessage(context.Context, *botapi.CopyMessageParams) (*models.MessageID, error)
 	AnswerCallbackQuery(context.Context, *botapi.AnswerCallbackQueryParams) (bool, error)
 	GetChatMember(context.Context, *botapi.GetChatMemberParams) (*models.ChatMember, error)
 }
@@ -64,6 +65,9 @@ func (h *Handler) Handle(ctx context.Context, update models.Update) error {
 	locale, err := h.chatLocale(ctx, message.Chat.ID, languageHint)
 	if err != nil {
 		return err
+	}
+	if isFeedbackReply(message) {
+		return h.submitFeedback(ctx, message, locale)
 	}
 
 	if message.Location != nil {
@@ -116,6 +120,8 @@ func (h *Handler) Handle(ctx context.Context, update models.Update) error {
 		return h.setReminders(ctx, message.Chat.ID, argument, locale)
 	case i18n.ActionLanguage:
 		return h.send(ctx, message.Chat.ID, locale.Message("choose_language"), languageKeyboard(locale.Code))
+	case i18n.ActionFeedback:
+		return h.requestFeedback(ctx, message.Chat, locale)
 	case "method", "madhab", "highlat", "adjust", "delete_me":
 		ok, err := h.canConfigure(ctx, message, locale)
 		if err != nil || !ok {

--- a/global/internal/telegram/keyboards.go
+++ b/global/internal/telegram/keyboards.go
@@ -16,6 +16,7 @@ func mainKeyboard(locale i18n.Locale) *models.ReplyKeyboardMarkup {
 			{{Text: locale.Button(i18n.ActionNext)}, {Text: locale.Button(i18n.ActionLocation)}},
 			{{Text: locale.Button(i18n.ActionSettings)}, {Text: locale.Button(i18n.ActionReminders)}},
 			{{Text: locale.Button(i18n.ActionLanguage)}, {Text: locale.Button(i18n.ActionHelp)}},
+			{{Text: locale.Button(i18n.ActionFeedback)}},
 		},
 		IsPersistent:   true,
 		ResizeKeyboard: true,

--- a/global/internal/telegram/ui_test.go
+++ b/global/internal/telegram/ui_test.go
@@ -24,10 +24,16 @@ func TestMainKeyboardIsPersistentAndButtonFirst(t *testing.T) {
 	if !keyboard.IsPersistent || !keyboard.ResizeKeyboard {
 		t.Fatal("main keyboard should be persistent and resized")
 	}
-	if len(keyboard.Keyboard) != 4 {
-		t.Fatalf("main keyboard has %d rows, want 4", len(keyboard.Keyboard))
+	if len(keyboard.Keyboard) != 5 {
+		t.Fatalf("main keyboard has %d rows, want 5", len(keyboard.Keyboard))
 	}
-	for _, row := range keyboard.Keyboard {
+	for index, row := range keyboard.Keyboard {
+		if index == len(keyboard.Keyboard)-1 {
+			if len(row) != 1 || row[0].Text != i18n.Resolve("ar").Button(i18n.ActionFeedback) {
+				t.Fatalf("unexpected feedback row: %+v", row)
+			}
+			continue
+		}
 		if len(row) != 2 {
 			t.Fatalf("main keyboard row has %d buttons, want 2", len(row))
 		}


### PR DESCRIPTION
## What changed

- embeds a responsive Telegram Mini App in the existing webhook Cloud Run service
- validates signed Telegram Mini App init data and derives the user identity server-side
- exposes authenticated APIs for schedules, location, calculation settings, Hijri correction, and reminders
- configures the Mini App as the bot's default chat menu button during deployment
- keeps one stable public bot name, description, and command menu, and removes older localized global profile variants
- adds a localized private feedback and bug-report flow with text/media delivery to `GLOBAL_OWNER_ID`
- documents architecture, privacy, deployment, and operational verification

## User and operator impact

Users can manage the global bot from either the existing Telegram controls or the Mini App. Changing the saved bot language affects only that chat's messages, keyboards, reminders, dates, and Mini App; it no longer changes Telegram-facing profile metadata. Feedback is copied privately to the configured owner and is not persisted in PostgreSQL.

The owner must send `/start` once to each testing/production bot before feedback can be delivered. No new secret, migration, Terraform resource, service, or database is required.

## Validation

- `go test ./...`
- `go vet ./...`
- `node --check internal/miniapp/static/app.js`
- `git diff --check`
