### PR TITLE
[codex] Fix Telegram Mini App launch and preference saving

### DIFF
--- a/global/internal/botprofile/sync.go
+++ b/global/internal/botprofile/sync.go
@@ -62,7 +62,10 @@ func Sync(ctx context.Context, client *botapi.Bot, token, miniAppURL string) err
 }
 
 func miniAppMenuButton(url string) models.MenuButtonWebApp {
-	return models.MenuButtonWebApp{Text: "🕌 Prayer App", WebApp: models.WebAppInfo{URL: url}}
+	return models.MenuButtonWebApp{
+		Type: models.MenuButtonTypeWebApp,
+		Text: "🕌 Prayer App", WebApp: models.WebAppInfo{URL: url},
+	}
 }
 
 type identityClient interface {

--- a/global/internal/botprofile/sync_test.go
+++ b/global/internal/botprofile/sync_test.go
@@ -2,10 +2,12 @@ package botprofile
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"unicode/utf8"
 
 	botapi "github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
 
 	"github.com/escalopa/prayer-bot/global/internal/i18n"
 )
@@ -32,8 +34,16 @@ func TestLocalizedCommandsAreCompleteAndWithinTelegramLimits(t *testing.T) {
 
 func TestMiniAppMenuButtonUsesDeploymentURL(t *testing.T) {
 	button := miniAppMenuButton("https://example.run.app/app/")
-	if button.Text != "🕌 Prayer App" || button.WebApp.URL != "https://example.run.app/app/" {
+	if button.Type != models.MenuButtonTypeWebApp || button.Text != "🕌 Prayer App" || button.WebApp.URL != "https://example.run.app/app/" {
 		t.Fatalf("unexpected Mini App menu button: %+v", button)
+	}
+	payload, err := json.Marshal(button)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"type":"web_app","text":"🕌 Prayer App","web_app":{"url":"https://example.run.app/app/"}}`
+	if string(payload) != want {
+		t.Fatalf("Mini App menu button JSON = %s, want %s", payload, want)
 	}
 }
 


### PR DESCRIPTION
## Root causes

Telegram rejected the profile sync because the Mini App menu button omitted its required web_app type. In the Mini App itself, every bootstrap failure was shown as if Telegram launch data were missing, launch data was captured only once, and reminder toggles saved immediately through a separate flow. Section headings also rendered both a fixed icon and an icon already present in localized labels.

## Changes

- send the required web_app menu-button type to Telegram
- read signed Telegram launch data from the current SDK state with the signed URL-hash fallback
- refresh restored pages and distinguish missing, expired, and temporary startup failures
- update the Telegram Web App SDK reference
- remove duplicate reminder and settings icons
- show one sticky Save button only after settings or reminders change
- save language, calculation settings, and reminders through one validated endpoint
- rerender the complete localized screen after saving
- keep the previous settings and reminders endpoints for compatibility

## Validation

- node --check global/internal/miniapp/static/app.js
- go test ./...
- go vet ./...
- git diff --check

No legacy bot code, database schema, Terraform resource, or existing deployment workflow was changed by the Mini App preference update.