### PR TITLE
[codex] Fix Mini App launch and preference saving

### DIFF
--- a/global/internal/miniapp/handler.go
+++ b/global/internal/miniapp/handler.go
@@ -73,6 +73,7 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	})
 	mux.HandleFunc("POST /api/miniapp/bootstrap", h.api(h.bootstrap))
 	mux.HandleFunc("PUT /api/miniapp/location", h.api(h.updateLocation))
+	mux.HandleFunc("PUT /api/miniapp/preferences", h.api(h.updatePreferences))
 	mux.HandleFunc("PUT /api/miniapp/settings", h.api(h.updateSettings))
 	mux.HandleFunc("PUT /api/miniapp/reminders", h.api(h.updateReminders))
 }
@@ -185,17 +186,9 @@ func (h *Handler) updateSettings(w http.ResponseWriter, r *http.Request, identit
 	if err := decodeJSON(w, r, &request); err != nil {
 		return badRequest("invalid_request")
 	}
-	locale, ok := supportedLocale(request.Language)
-	if !ok || !request.Method.Valid() || !request.Madhab.Valid() {
-		return badRequest("invalid_settings")
-	}
-	highLatitude := domain.HighLatitudeRule(request.HighLatitudeRule)
-	if !highLatitude.Valid() || request.HijriAdjustment < -2 || request.HijriAdjustment > 2 {
-		return badRequest("invalid_settings")
-	}
-	adjustments, err := parseAdjustments(request.Adjustments)
+	validated, err := validateSettings(request)
 	if err != nil {
-		return badRequest("invalid_adjustments")
+		return err
 	}
 	profile, err := h.store.Profile(r.Context(), identity.UserID)
 	if store.IsNotFound(err) {
@@ -206,10 +199,10 @@ func (h *Handler) updateSettings(w http.ResponseWriter, r *http.Request, identit
 	}
 	profile.Method = request.Method
 	profile.Madhab = request.Madhab
-	profile.HighLatitudeRule = highLatitude
+	profile.HighLatitudeRule = validated.highLatitude
 	profile.HijriAdjustment = request.HijriAdjustment
-	profile.Adjustments = adjustments
-	if err := h.store.SetLanguage(r.Context(), identity.UserID, locale.Code); err != nil {
+	profile.Adjustments = validated.adjustments
+	if err := h.store.SetLanguage(r.Context(), identity.UserID, validated.locale.Code); err != nil {
 		return fmt.Errorf("save language: %w", err)
 	}
 	if _, err := h.store.UpsertProfile(r.Context(), profile); err != nil {
@@ -218,7 +211,7 @@ func (h *Handler) updateSettings(w http.ResponseWriter, r *http.Request, identit
 	if err := h.planner.RebuildChat(r.Context(), identity.UserID, h.now()); err != nil {
 		return fmt.Errorf("rebuild reminders: %w", err)
 	}
-	data, err := h.build(r.Context(), Identity{UserID: identity.UserID, FirstName: identity.FirstName, LanguageCode: locale.Code})
+	data, err := h.build(r.Context(), Identity{UserID: identity.UserID, FirstName: identity.FirstName, LanguageCode: validated.locale.Code})
 	if err != nil {
 		return err
 	}
@@ -231,45 +224,101 @@ type remindersRequest struct {
 	Kahf    *bool `json:"kahf"`
 }
 
+type preferencesRequest struct {
+	Settings  settingsRequest  `json:"settings"`
+	Reminders remindersRequest `json:"reminders"`
+}
+
+type validatedSettings struct {
+	locale       i18n.Locale
+	highLatitude domain.HighLatitudeRule
+	adjustments  domain.Adjustments
+}
+
+func validateSettings(request settingsRequest) (validatedSettings, error) {
+	locale, ok := supportedLocale(request.Language)
+	highLatitude := domain.HighLatitudeRule(request.HighLatitudeRule)
+	if !ok || !request.Method.Valid() || !request.Madhab.Valid() || !highLatitude.Valid() ||
+		request.HijriAdjustment < -2 || request.HijriAdjustment > 2 {
+		return validatedSettings{}, badRequest("invalid_settings")
+	}
+	adjustments, err := parseAdjustments(request.Adjustments)
+	if err != nil {
+		return validatedSettings{}, badRequest("invalid_adjustments")
+	}
+	return validatedSettings{locale: locale, highLatitude: highLatitude, adjustments: adjustments}, nil
+}
+
+func validateReminders(request remindersRequest) error {
+	if request.Prayer == nil || request.Fasting == nil || request.Kahf == nil {
+		return badRequest("invalid_request")
+	}
+	return nil
+}
+
+func (h *Handler) updatePreferences(w http.ResponseWriter, r *http.Request, identity Identity) error {
+	var request preferencesRequest
+	if err := decodeJSON(w, r, &request); err != nil {
+		return badRequest("invalid_request")
+	}
+	validated, err := validateSettings(request.Settings)
+	if err != nil {
+		return err
+	}
+	if err := validateReminders(request.Reminders); err != nil {
+		return err
+	}
+	profile, err := h.store.Profile(r.Context(), identity.UserID)
+	if store.IsNotFound(err) {
+		return conflict("location_required")
+	}
+	if err != nil {
+		return fmt.Errorf("load profile: %w", err)
+	}
+	profile.Method = request.Settings.Method
+	profile.Madhab = request.Settings.Madhab
+	profile.HighLatitudeRule = validated.highLatitude
+	profile.HijriAdjustment = request.Settings.HijriAdjustment
+	profile.Adjustments = validated.adjustments
+	if err := h.store.SetLanguage(r.Context(), identity.UserID, validated.locale.Code); err != nil {
+		return fmt.Errorf("save language: %w", err)
+	}
+	if _, err := h.store.UpsertProfile(r.Context(), profile); err != nil {
+		return fmt.Errorf("save profile: %w", err)
+	}
+	if _, _, err := h.applyReminders(r.Context(), identity.UserID, request.Reminders); err != nil {
+		return err
+	}
+	if err := h.planner.RebuildChat(r.Context(), identity.UserID, h.now()); err != nil {
+		return fmt.Errorf("rebuild reminders: %w", err)
+	}
+	data, err := h.build(r.Context(), Identity{
+		UserID: identity.UserID, FirstName: identity.FirstName, LanguageCode: validated.locale.Code,
+	})
+	if err != nil {
+		return err
+	}
+	return writeJSON(w, data)
+}
+
 func (h *Handler) updateReminders(w http.ResponseWriter, r *http.Request, identity Identity) error {
 	var request remindersRequest
 	if err := decodeJSON(w, r, &request); err != nil {
 		return badRequest("invalid_request")
 	}
-	if request.Prayer == nil || request.Fasting == nil || request.Kahf == nil {
-		return badRequest("invalid_request")
+	if err := validateReminders(request); err != nil {
+		return err
 	}
 	if _, err := h.store.Profile(r.Context(), identity.UserID); store.IsNotFound(err) {
 		return conflict("location_required")
 	} else if err != nil {
 		return fmt.Errorf("load profile: %w", err)
 	}
-	current, err := h.reminderState(r.Context(), identity.UserID)
+	changed, desired, err := h.applyReminders(r.Context(), identity.UserID, request)
 	if err != nil {
 		return err
 	}
-	if current.Prayer != *request.Prayer {
-		if *request.Prayer {
-			err = h.store.EnableDefaultRules(r.Context(), identity.UserID)
-		} else {
-			err = h.store.DisableRules(r.Context(), identity.UserID)
-		}
-		if err != nil {
-			return fmt.Errorf("update prayer reminders: %w", err)
-		}
-	}
-	if current.Fasting != *request.Fasting {
-		if err := h.store.SetWeeklyRule(r.Context(), identity.UserID, domain.ReminderWeeklyFasting, *request.Fasting); err != nil {
-			return fmt.Errorf("update fasting reminders: %w", err)
-		}
-	}
-	if current.Kahf != *request.Kahf {
-		if err := h.store.SetWeeklyRule(r.Context(), identity.UserID, domain.ReminderWeeklyKahf, *request.Kahf); err != nil {
-			return fmt.Errorf("update Al-Kahf reminders: %w", err)
-		}
-	}
-	changed := current != (reminderResponse{Prayer: *request.Prayer, Fasting: *request.Fasting, Kahf: *request.Kahf})
-	if changed && (*request.Prayer || *request.Fasting || *request.Kahf) {
+	if changed && (desired.Prayer || desired.Fasting || desired.Kahf) {
 		if err := h.planner.RebuildChat(r.Context(), identity.UserID, h.now()); err != nil {
 			return fmt.Errorf("rebuild reminders: %w", err)
 		}
@@ -279,6 +328,35 @@ func (h *Handler) updateReminders(w http.ResponseWriter, r *http.Request, identi
 		return err
 	}
 	return writeJSON(w, data)
+}
+
+func (h *Handler) applyReminders(ctx context.Context, chatID int64, request remindersRequest) (bool, reminderResponse, error) {
+	current, err := h.reminderState(ctx, chatID)
+	if err != nil {
+		return false, reminderResponse{}, err
+	}
+	desired := reminderResponse{Prayer: *request.Prayer, Fasting: *request.Fasting, Kahf: *request.Kahf}
+	if current.Prayer != desired.Prayer {
+		if *request.Prayer {
+			err = h.store.EnableDefaultRules(ctx, chatID)
+		} else {
+			err = h.store.DisableRules(ctx, chatID)
+		}
+		if err != nil {
+			return false, reminderResponse{}, fmt.Errorf("update prayer reminders: %w", err)
+		}
+	}
+	if current.Fasting != desired.Fasting {
+		if err := h.store.SetWeeklyRule(ctx, chatID, domain.ReminderWeeklyFasting, desired.Fasting); err != nil {
+			return false, reminderResponse{}, fmt.Errorf("update fasting reminders: %w", err)
+		}
+	}
+	if current.Kahf != desired.Kahf {
+		if err := h.store.SetWeeklyRule(ctx, chatID, domain.ReminderWeeklyKahf, desired.Kahf); err != nil {
+			return false, reminderResponse{}, fmt.Errorf("update Al-Kahf reminders: %w", err)
+		}
+	}
+	return current != desired, desired, nil
 }
 
 type bootstrapResponse struct {

--- a/global/internal/miniapp/handler_test.go
+++ b/global/internal/miniapp/handler_test.go
@@ -28,8 +28,19 @@ func TestStaticMiniAppIsEmbeddedWithSecurityHeaders(t *testing.T) {
 	if response.Code != http.StatusOK {
 		t.Fatalf("status = %d", response.Code)
 	}
-	if !strings.Contains(response.Body.String(), "telegram-web-app.js") {
+	html := response.Body.String()
+	if !strings.Contains(html, "telegram-web-app.js?63") {
 		t.Fatal("embedded Mini App HTML is missing Telegram SDK")
+	}
+	if strings.Contains(html, "section-kicker") {
+		t.Fatal("Mini App HTML contains a duplicate section icon")
+	}
+	script, err := embeddedStatic.ReadFile("static/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(script), "tgWebAppData") || !strings.Contains(string(script), "/api/miniapp/preferences") {
+		t.Fatal("Mini App script is missing resilient Telegram launch data or unified preference saving")
 	}
 	if !strings.Contains(response.Header().Get("Content-Security-Policy"), "telegram.org") {
 		t.Fatal("Mini App response is missing its CSP")
@@ -146,6 +157,48 @@ func TestLocationUpdatePreservesCalculationSettingsAndRoundsCoordinates(t *testi
 	}
 }
 
+func TestPreferencesUpdateSavesSettingsAndRemindersTogether(t *testing.T) {
+	now := time.Date(2026, time.July, 17, 12, 0, 0, 0, time.UTC)
+	storage := newFakeStorage()
+	storage.chats[42] = domain.Chat{TelegramChatID: 42, Type: "private", LanguageCode: "en"}
+	storage.profiles[42] = domain.PrayerProfile{
+		ChatID: 42, Latitude: 30.044, Longitude: 31.236, Timezone: "UTC",
+		Method: domain.MethodEgyptian, Madhab: domain.MadhabShafii,
+		HighLatitudeRule: domain.HighLatitudeAngleBased,
+	}
+	planner := &fakePlanner{}
+	handler := NewHandler("test-token", storage, nil, prayertime.New(), planner, nil)
+	handler.now = func() time.Time { return now }
+	mux := http.NewServeMux()
+	handler.Register(mux)
+
+	body := `{
+		"settings":{"language":"ar","method":"isna","madhab":"hanafi","high_latitude_rule":"middle_of_night","hijri_adjustment":1,
+		"adjustments":{"fajr":2,"sunrise":0,"dhuhr":0,"asr":1,"maghrib":0,"isha":-1}},
+		"reminders":{"prayer":true,"fasting":true,"kahf":false}
+	}`
+	request := httptest.NewRequest(http.MethodPut, "/api/miniapp/preferences", strings.NewReader(body))
+	request.Header.Set("X-Telegram-Init-Data", signedInitData(t, "test-token", now, initDataUser{ID: 42, FirstName: "Amina", LanguageCode: "en"}))
+	response := httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	profile := storage.profiles[42]
+	if storage.chats[42].LanguageCode != "ar" || profile.Method != domain.MethodISNA || profile.Madhab != domain.MadhabHanafi ||
+		profile.HighLatitudeRule != domain.HighLatitudeMiddleNight || profile.HijriAdjustment != 1 || profile.Adjustments.Fajr != 2 {
+		t.Fatalf("preferences were not saved together: chat=%+v profile=%+v", storage.chats[42], profile)
+	}
+	var data bootstrapResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &data); err != nil {
+		t.Fatal(err)
+	}
+	if data.Locale != "ar" || !data.Reminders.Prayer || !data.Reminders.Fasting || data.Reminders.Kahf || planner.rebuilds != 1 {
+		t.Fatalf("unexpected updated state: response=%+v rebuilds=%d", data.Reminders, planner.rebuilds)
+	}
+}
+
 func TestParseAdjustmentsRequiresCompleteSnapshot(t *testing.T) {
 	if _, err := parseAdjustments(map[string]int{"fajr": 1}); err == nil {
 		t.Fatal("expected an incomplete adjustment snapshot to fail")
@@ -207,7 +260,13 @@ func (s *fakeStorage) UpsertProfile(_ context.Context, profile domain.PrayerProf
 }
 
 func (s *fakeStorage) EnabledRules(_ context.Context, chatID int64) ([]domain.ReminderRule, error) {
-	return s.rules[chatID], nil
+	var enabled []domain.ReminderRule
+	for _, rule := range s.rules[chatID] {
+		if rule.Enabled {
+			enabled = append(enabled, rule)
+		}
+	}
+	return enabled, nil
 }
 
 func (s *fakeStorage) EnableDefaultRules(_ context.Context, chatID int64) error {

--- a/global/internal/miniapp/static/app.css
+++ b/global/internal/miniapp/static/app.css
@@ -55,7 +55,7 @@ button { -webkit-tap-highlight-color: transparent; }
 }
 
 .hero h1 { margin: 1px 0 2px; font-size: 25px; letter-spacing: -.03em; }
-.eyebrow, .section-kicker { margin: 0; color: var(--accent); font-size: 12px; font-weight: 750; letter-spacing: .09em; text-transform: uppercase; }
+.eyebrow { margin: 0; color: var(--accent); font-size: 12px; font-weight: 750; letter-spacing: .09em; text-transform: uppercase; }
 .muted { margin: 0; color: var(--app-muted); font-size: 14px; }
 
 .hidden { display: none !important; }
@@ -75,8 +75,9 @@ button { -webkit-tap-highlight-color: transparent; }
   padding: 38px 24px;
 }
 
-.state-card { flex-direction: row; justify-content: center; gap: 12px; }
+.state-card { justify-content: center; gap: 12px; }
 .state-card p, .location-card p { color: var(--app-muted); line-height: 1.5; }
+.state-action { margin-top: 6px; }
 .location-card h2 { margin: 8px 0 0; }
 .state-icon { font-size: 34px; color: var(--accent); }
 
@@ -157,6 +158,15 @@ select:focus, input[type="number"]:focus { border-color: var(--accent); box-shad
 .primary-button { width: 100%; min-height: 50px; padding: 0 18px; border: 0; border-radius: 16px; color: var(--accent-text); background: var(--accent); font-weight: 800; cursor: pointer; box-shadow: 0 10px 24px color-mix(in srgb, var(--accent) 24%, transparent); }
 .primary-button:disabled { opacity: .55; cursor: wait; }
 .text-button { padding: 8px 0; border: 0; color: var(--accent); background: transparent; font-size: 12px; font-weight: 750; cursor: pointer; }
+
+.save-bar {
+  position: sticky;
+  z-index: 5;
+  bottom: 0;
+  margin: 14px -8px -16px;
+  padding: 12px 8px calc(12px + env(safe-area-inset-bottom));
+  background: linear-gradient(transparent, var(--app-bg) 24%);
+}
 
 .toast { position: fixed; z-index: 10; right: 16px; bottom: calc(18px + env(safe-area-inset-bottom)); left: 16px; max-width: 520px; margin: auto; padding: 14px 16px; border-radius: 15px; color: var(--accent-text); background: var(--accent); box-shadow: 0 12px 34px rgba(0,0,0,.2); font-size: 13px; font-weight: 700; text-align: center; }
 .toast.error { color: white; background: #a84040; }

--- a/global/internal/miniapp/static/app.js
+++ b/global/internal/miniapp/static/app.js
@@ -2,16 +2,42 @@
   "use strict";
 
   const telegram = window.Telegram && window.Telegram.WebApp;
-  const initData = telegram ? telegram.initData : "";
+  let initData = "";
   let state = null;
   let activeDay = "today";
   let toastTimer = null;
+  let dirty = false;
+
+  const launchCopy = {
+    en: { open: "Open this page from the bot inside Telegram.", expired: "Your Telegram session expired. Close this window and reopen the app from the bot menu.", failed: "The app could not load. Please try again.", retry: "Try again" },
+    ar: { open: "افتح هذه الصفحة من البوت داخل تيليجرام.", expired: "انتهت جلسة تيليجرام. أغلق هذه النافذة وافتح التطبيق مجددًا من قائمة البوت.", failed: "تعذر تحميل التطبيق. حاول مرة أخرى.", retry: "حاول مرة أخرى" },
+    es: { open: "Abre esta página desde el bot en Telegram.", expired: "Tu sesión de Telegram caducó. Cierra esta ventana y vuelve a abrir la app desde el menú del bot.", failed: "No se pudo cargar la app. Inténtalo de nuevo.", retry: "Intentar de nuevo" },
+    fr: { open: "Ouvrez cette page depuis le bot dans Telegram.", expired: "Votre session Telegram a expiré. Fermez cette fenêtre et rouvrez l’application depuis le menu du bot.", failed: "Impossible de charger l’application. Réessayez.", retry: "Réessayer" },
+    ru: { open: "Откройте эту страницу через бота в Telegram.", expired: "Сессия Telegram истекла. Закройте окно и снова откройте приложение из меню бота.", failed: "Не удалось загрузить приложение. Попробуйте ещё раз.", retry: "Повторить" },
+    tr: { open: "Bu sayfayı Telegram’daki bot üzerinden açın.", expired: "Telegram oturumunuz sona erdi. Bu pencereyi kapatıp uygulamayı bot menüsünden yeniden açın.", failed: "Uygulama yüklenemedi. Tekrar deneyin.", retry: "Tekrar dene" },
+    uz: { open: "Bu sahifani Telegram ichidagi botdan oching.", expired: "Telegram seansi tugadi. Oynani yoping va ilovani bot menyusidan qayta oching.", failed: "Ilovani yuklab bo‘lmadi. Qayta urinib ko‘ring.", retry: "Qayta urinish" },
+    tt: { open: "Бу битне Telegram эчендәге боттан ачыгыз.", expired: "Telegram сеансы тәмамланды. Тәрәзәне ябып, кушымтаны бот менюсыннан яңадан ачыгыз.", failed: "Кушымтаны йөкләп булмады. Кабатлап карагыз.", retry: "Кабатлау" },
+  };
 
   const byId = (id) => document.getElementById(id);
   const loading = byId("loading");
   const standalone = byId("standalone");
   const locationGate = byId("location-gate");
   const dashboard = byId("dashboard");
+
+  function currentInitData() {
+    if (telegram && telegram.initData) initData = telegram.initData;
+    if (!initData && window.location.hash) {
+      initData = new URLSearchParams(window.location.hash.slice(1)).get("tgWebAppData") || "";
+    }
+    return initData;
+  }
+
+  function launchLanguage() {
+    const code = telegram && telegram.initDataUnsafe && telegram.initDataUnsafe.user
+      ? telegram.initDataUnsafe.user.language_code : "en";
+    return String(code || "en").toLowerCase().split("-")[0];
+  }
 
   if (telegram) {
     telegram.ready();
@@ -25,11 +51,12 @@
   }
 
   async function request(path, method = "POST", body) {
+    const signedData = currentInitData();
     const response = await fetch(path, {
       method,
       headers: {
         "Content-Type": "application/json",
-        "X-Telegram-Init-Data": initData,
+        "X-Telegram-Init-Data": signedData,
       },
       body: body === undefined ? undefined : JSON.stringify(body),
       credentials: "same-origin",
@@ -38,6 +65,7 @@
     if (!response.ok) {
       const error = new Error(data.error || "temporary_failure");
       error.code = data.error;
+      error.status = response.status;
       throw error;
     }
     return data;
@@ -76,7 +104,7 @@
     setText("highlat-label", labels.highlat);
     setText("hijri-label", labels.hijri);
     setText("adjustments-label", labels.adjustments);
-    setText("save-settings", labels.save);
+    setText("save-preferences", labels.save);
     setText("calculation-note", labels.calculated_locally);
   }
 
@@ -155,10 +183,12 @@
     state = next;
     loading.classList.add("hidden");
     standalone.classList.add("hidden");
+    byId("retry-app").classList.add("hidden");
     applyLabels(state.labels);
     if (state.needs_location) {
       dashboard.classList.add("hidden");
       locationGate.classList.remove("hidden");
+      setDirty(false);
       return;
     }
     locationGate.classList.add("hidden");
@@ -166,6 +196,12 @@
     renderSchedule();
     renderReminders();
     renderSettings();
+    setDirty(false);
+  }
+
+  function setDirty(value) {
+    dirty = value;
+    byId("save-bar").classList.toggle("hidden", !dirty);
   }
 
   function showToast(message, isError = false) {
@@ -228,21 +264,43 @@
     }
   }
 
-  async function saveSettings() {
-    const button = byId("save-settings");
-    button.disabled = true;
+  function collectSettings() {
     const adjustments = {};
     document.querySelectorAll("#adjustment-grid input").forEach((input) => {
       adjustments[input.dataset.prayer] = Number(input.value);
     });
+    return {
+      language: byId("language").value,
+      method: byId("method").value,
+      madhab: byId("madhab").value,
+      high_latitude_rule: byId("highlat").value,
+      hijri_adjustment: Number(byId("hijri-adjustment").value),
+      adjustments,
+    };
+  }
+
+  function collectReminders() {
+    return {
+      prayer: byId("prayer-reminders").checked,
+      fasting: byId("fasting-reminders").checked,
+      kahf: byId("kahf-reminders").checked,
+    };
+  }
+
+  function setPreferencesDisabled(value) {
+    byId("save-preferences").disabled = value;
+    document.querySelectorAll("#dashboard select, #dashboard input").forEach((control) => {
+      control.disabled = value;
+    });
+  }
+
+  async function savePreferences() {
+    if (!dirty) return;
+    setPreferencesDisabled(true);
     try {
-      const next = await request("/api/miniapp/settings", "PUT", {
-        language: byId("language").value,
-        method: byId("method").value,
-        madhab: byId("madhab").value,
-        high_latitude_rule: byId("highlat").value,
-        hijri_adjustment: Number(byId("hijri-adjustment").value),
-        adjustments,
+      const next = await request("/api/miniapp/preferences", "PUT", {
+        settings: collectSettings(),
+        reminders: collectReminders(),
       });
       applyState(next);
       showToast(next.labels.saved);
@@ -250,26 +308,32 @@
     } catch (_) {
       showToast(state.labels.temporary_failure, true);
     } finally {
-      button.disabled = false;
+      setPreferencesDisabled(false);
     }
   }
 
-  async function saveReminders() {
-    const controls = [byId("prayer-reminders"), byId("fasting-reminders"), byId("kahf-reminders")];
-    controls.forEach((control) => { control.disabled = true; });
+  function showLaunchError(kind) {
+    const copy = launchCopy[launchLanguage()] || launchCopy.en;
+    loading.classList.add("hidden");
+    locationGate.classList.add("hidden");
+    dashboard.classList.add("hidden");
+    setText("standalone-text", copy[kind]);
+    setText("retry-app", copy.retry);
+    byId("retry-app").classList.toggle("hidden", kind === "open");
+    standalone.classList.remove("hidden");
+  }
+
+  async function bootstrapApp() {
+    if (!currentInitData()) {
+      showLaunchError("open");
+      return;
+    }
+    standalone.classList.add("hidden");
+    loading.classList.remove("hidden");
     try {
-      const next = await request("/api/miniapp/reminders", "PUT", {
-        prayer: controls[0].checked,
-        fasting: controls[1].checked,
-        kahf: controls[2].checked,
-      });
-      applyState(next);
-      showToast(next.labels.saved);
-    } catch (_) {
-      renderReminders();
-      showToast(state.labels.temporary_failure, true);
-    } finally {
-      controls.forEach((control) => { control.disabled = false; });
+      applyState(await request("/api/miniapp/bootstrap"));
+    } catch (error) {
+      showLaunchError(error.status === 401 ? "expired" : "failed");
     }
   }
 
@@ -288,18 +352,14 @@
   byId("tomorrow-tab").addEventListener("click", () => selectDay("tomorrow"));
   byId("location-primary").addEventListener("click", (event) => updateLocation(event.currentTarget));
   byId("location-secondary").addEventListener("click", (event) => updateLocation(event.currentTarget));
-  byId("save-settings").addEventListener("click", saveSettings);
-  ["prayer-reminders", "fasting-reminders", "kahf-reminders"].forEach((id) => byId(id).addEventListener("change", saveReminders));
+  byId("save-preferences").addEventListener("click", savePreferences);
+  byId("retry-app").addEventListener("click", bootstrapApp);
+  ["prayer-reminders", "fasting-reminders", "kahf-reminders", "language", "method", "madhab", "highlat", "hijri-adjustment"]
+    .forEach((id) => byId(id).addEventListener("change", () => setDirty(true)));
+  byId("adjustment-grid").addEventListener("input", () => setDirty(true));
+  window.addEventListener("pageshow", (event) => {
+    if (event.persisted) bootstrapApp();
+  });
 
-  if (!initData) {
-    loading.classList.add("hidden");
-    standalone.classList.remove("hidden");
-  } else {
-    request("/api/miniapp/bootstrap")
-      .then(applyState)
-      .catch(() => {
-        loading.classList.add("hidden");
-        standalone.classList.remove("hidden");
-      });
-  }
+  bootstrapApp();
 })();

--- a/global/internal/miniapp/static/index.html
+++ b/global/internal/miniapp/static/index.html
@@ -6,7 +6,7 @@
   <meta name="color-scheme" content="light dark">
   <title>Prayer Times</title>
   <link rel="stylesheet" href="./app.css">
-  <script src="https://telegram.org/js/telegram-web-app.js?59"></script>
+  <script src="https://telegram.org/js/telegram-web-app.js?63"></script>
   <script src="./app.js" defer></script>
 </head>
 <body>
@@ -28,6 +28,7 @@
     <section id="standalone" class="state-card hidden">
       <div class="state-icon" aria-hidden="true">↗</div>
       <p id="standalone-text">Open this page from the bot inside Telegram.</p>
+      <button id="retry-app" class="primary-button state-action hidden" type="button">Try again</button>
     </section>
 
     <section id="location-gate" class="location-card hidden">
@@ -59,10 +60,7 @@
 
       <section class="panel">
         <div class="panel-heading">
-          <div>
-            <p class="section-kicker">🔔</p>
-            <h2 id="reminders-title">Reminders</h2>
-          </div>
+          <h2 id="reminders-title">Reminders</h2>
         </div>
         <label class="toggle-row">
           <span><strong id="prayer-reminders-label">Prayer times</strong></span>
@@ -83,10 +81,7 @@
 
       <section class="panel settings-panel">
         <div class="panel-heading">
-          <div>
-            <p class="section-kicker">⚙️</p>
-            <h2 id="settings-title">Settings</h2>
-          </div>
+          <h2 id="settings-title">Settings</h2>
           <button id="location-secondary" class="text-button" type="button">Update location</button>
         </div>
 
@@ -102,9 +97,11 @@
           <summary id="adjustments-label">Prayer adjustments</summary>
           <div id="adjustment-grid" class="adjustment-grid"></div>
         </details>
-
-        <button id="save-settings" class="primary-button" type="button">Save changes</button>
       </section>
+
+      <div id="save-bar" class="save-bar hidden">
+        <button id="save-preferences" class="primary-button" type="button">Save changes</button>
+      </div>
     </div>
   </main>
 


### PR DESCRIPTION
## Root causes

The Mini App treated every bootstrap failure as missing Telegram context and captured launch data only once. Reminder toggles also saved immediately through a separate flow, while section headings rendered both a fixed icon and an icon already present in localized labels.

## Changes

- read signed Telegram launch data from the current SDK state with the signed URL-hash fallback
- refresh restored pages and distinguish missing, expired, and temporary startup failures
- update the Telegram Web App SDK reference
- remove duplicate reminder and settings icons
- show one sticky Save button only after settings or reminders change
- save language, calculation settings, and reminders through one validated endpoint
- rerender the complete localized screen after saving
- keep the previous settings and reminders endpoints for compatibility

## Validation

- node --check global/internal/miniapp/static/app.js
- go test ./...
- go vet ./...
- git diff --check

No legacy bot code, database schema, Terraform resource, or existing deployment workflow is changed.