### PR TITLE
[codex] Add owner analytics dashboard

### DIFF
--- a/global/README.md
+++ b/global/README.md
@@ -16,12 +16,19 @@ This directory is a separate application derived from the existing city bots. It
 - Opt-in weekly reminders for Monday/Thursday voluntary fasting (20:00 on the preceding evening) and reading Surah Al-Kahf on Friday (09:00), scheduled in the saved local timezone.
 - An embedded welcome illustration sent on `/start` and a generated bot avatar installed during profile synchronization.
 - A localized feedback and bug-report flow that accepts text or screenshots in a private chat and delivers them directly to the configured owner with the sender's disclosed Telegram identity.
+- An owner-only `/admin` dashboard with aggregate user activity, onboarding, language, calculation-method, reminder-adoption, queue, and delivery-health metrics.
 - Indexed reminder scheduling through Cloud Scheduler, an outbox, Cloud Tasks, a private sender service, leases, and delivery idempotency keys.
 - Dedicated `global_bot_testing` and `global_bot_production` PostgreSQL schemas, each with its own Goose migration table.
 
 The initial UI language follows the user's Telegram language when supported and otherwise falls back to English. A language selected inside the bot is persisted and is not overwritten by later Telegram updates.
 
 Hijri dates use the calculated Umm al-Qura calendar. Because official local moon-sighting dates can differ by a day or two, users can correct the displayed date under **Settings → Hijri date correction**. The correction is applied only to the Hijri display; it never shifts prayer calculations.
+
+## Owner dashboard and feedback
+
+The Telegram account configured by `GLOBAL_OWNER_ID` can open the private owner dashboard with `/admin` or the backward-compatible `/status` command. The command is intentionally absent from the public command menu, is ignored for every other user, and is unavailable in groups. Its inline buttons show aggregate metrics only; the dashboard never lists Telegram IDs, coordinates, or individual user records.
+
+Feedback arrives in the owner's private bot chat as a metadata message followed by a copy of the user's original text or screenshot. A **Contact user** button opens the sender's Telegram profile. Replies typed inside the bot chat are not forwarded, so contact the sender through that button or the linked username.
 
 ## Services
 

--- a/global/internal/store/postgres.go
+++ b/global/internal/store/postgres.go
@@ -150,22 +150,139 @@ func (s *Store) DeleteChat(ctx context.Context, chatID int64) error {
 	return err
 }
 
-type Stats struct {
-	Chats            int64
-	Profiles         int64
-	EnabledRules     int64
-	PendingSchedules int64
+type MetricCount struct {
+	Key   string
+	Count int64
 }
 
-func (s *Store) Stats(ctx context.Context) (Stats, error) {
-	var stats Stats
+type AdminDashboard struct {
+	Users                   int64
+	Groups                  int64
+	ConfiguredUsers         int64
+	NewUsers24Hours         int64
+	NewUsers7Days           int64
+	NewUsers30Days          int64
+	ActiveUsers24Hours      int64
+	ActiveUsers7Days        int64
+	ActiveUsers30Days       int64
+	ReminderUsers           int64
+	EnabledRules            int64
+	PendingSchedules        int64
+	QueuedTasks             int64
+	SentDeliveries24Hours   int64
+	FailedDeliveries24Hours int64
+	StaleDeliveries24Hours  int64
+	ProcessingDeliveries    int64
+	FailedUpdates24Hours    int64
+	Languages               []MetricCount
+	Methods                 []MetricCount
+	ReminderKinds           []MetricCount
+}
+
+func (s *Store) AdminMetrics(ctx context.Context) (AdminDashboard, error) {
+	var dashboard AdminDashboard
 	err := s.pool.QueryRow(ctx, `SELECT
-		(SELECT count(*) FROM global_bot.chats),
-		(SELECT count(*) FROM global_bot.prayer_profiles),
+		(SELECT count(*) FROM global_bot.chats WHERE chat_type = 'private'),
+		(SELECT count(*) FROM global_bot.chats WHERE chat_type IN ('group', 'supergroup')),
+		(SELECT count(*) FROM global_bot.prayer_profiles p
+			JOIN global_bot.chats c ON c.telegram_chat_id = p.chat_id
+			WHERE c.chat_type = 'private'),
+		(SELECT count(*) FROM global_bot.chats WHERE chat_type = 'private' AND created_at >= now() - interval '24 hours'),
+		(SELECT count(*) FROM global_bot.chats WHERE chat_type = 'private' AND created_at >= now() - interval '7 days'),
+		(SELECT count(*) FROM global_bot.chats WHERE chat_type = 'private' AND created_at >= now() - interval '30 days'),
+		(SELECT count(*) FROM global_bot.chats WHERE chat_type = 'private' AND updated_at >= now() - interval '24 hours'),
+		(SELECT count(*) FROM global_bot.chats WHERE chat_type = 'private' AND updated_at >= now() - interval '7 days'),
+		(SELECT count(*) FROM global_bot.chats WHERE chat_type = 'private' AND updated_at >= now() - interval '30 days'),
+		(SELECT count(DISTINCT r.chat_id) FROM global_bot.reminder_rules r
+			JOIN global_bot.chats c ON c.telegram_chat_id = r.chat_id
+			WHERE r.enabled AND c.chat_type = 'private'),
 		(SELECT count(*) FROM global_bot.reminder_rules WHERE enabled),
-		(SELECT count(*) FROM global_bot.reminder_schedules WHERE state = 'pending')`).Scan(
-		&stats.Chats, &stats.Profiles, &stats.EnabledRules, &stats.PendingSchedules)
-	return stats, err
+		(SELECT count(*) FROM global_bot.reminder_schedules WHERE state = 'pending'),
+		(SELECT count(*) FROM global_bot.task_outbox),
+		(SELECT count(*) FROM global_bot.notification_deliveries
+			WHERE status = 'sent' AND updated_at >= now() - interval '24 hours'),
+		(SELECT count(*) FROM global_bot.notification_deliveries
+			WHERE status = 'failed' AND updated_at >= now() - interval '24 hours'),
+		(SELECT count(*) FROM global_bot.notification_deliveries
+			WHERE status = 'stale' AND updated_at >= now() - interval '24 hours'),
+		(SELECT count(*) FROM global_bot.notification_deliveries WHERE status = 'processing'),
+		(SELECT count(*) FROM global_bot.processed_updates
+			WHERE status = 'failed' AND updated_at >= now() - interval '24 hours')`).Scan(
+		&dashboard.Users,
+		&dashboard.Groups,
+		&dashboard.ConfiguredUsers,
+		&dashboard.NewUsers24Hours,
+		&dashboard.NewUsers7Days,
+		&dashboard.NewUsers30Days,
+		&dashboard.ActiveUsers24Hours,
+		&dashboard.ActiveUsers7Days,
+		&dashboard.ActiveUsers30Days,
+		&dashboard.ReminderUsers,
+		&dashboard.EnabledRules,
+		&dashboard.PendingSchedules,
+		&dashboard.QueuedTasks,
+		&dashboard.SentDeliveries24Hours,
+		&dashboard.FailedDeliveries24Hours,
+		&dashboard.StaleDeliveries24Hours,
+		&dashboard.ProcessingDeliveries,
+		&dashboard.FailedUpdates24Hours,
+	)
+	if err != nil {
+		return AdminDashboard{}, err
+	}
+	if dashboard.Languages, err = s.metricCounts(ctx, `
+		SELECT language_code, count(*)
+		FROM global_bot.chats
+		WHERE chat_type = 'private'
+		GROUP BY language_code
+		ORDER BY count(*) DESC, language_code`); err != nil {
+		return AdminDashboard{}, err
+	}
+	if dashboard.Methods, err = s.metricCounts(ctx, `
+		SELECT p.method, count(*)
+		FROM global_bot.prayer_profiles p
+		JOIN global_bot.chats c ON c.telegram_chat_id = p.chat_id
+		WHERE c.chat_type = 'private'
+		GROUP BY p.method
+		ORDER BY count(*) DESC, p.method`); err != nil {
+		return AdminDashboard{}, err
+	}
+	dashboard.ReminderKinds, err = s.metricCounts(ctx, `
+		SELECT category, count(DISTINCT chat_id)
+		FROM (
+			SELECT r.chat_id, CASE
+				WHEN kind IN ('before', 'at', 'tomorrow') THEN 'prayer'
+				WHEN kind = 'weekly_fasting' THEN 'fasting'
+				WHEN kind = 'weekly_kahf' THEN 'kahf'
+			END AS category
+			FROM global_bot.reminder_rules r
+			JOIN global_bot.chats c ON c.telegram_chat_id = r.chat_id
+			WHERE r.enabled AND c.chat_type = 'private'
+		) enabled_rules
+		WHERE category IS NOT NULL
+		GROUP BY category
+		ORDER BY count(DISTINCT chat_id) DESC, category`)
+	if err != nil {
+		return AdminDashboard{}, err
+	}
+	return dashboard, nil
+}
+
+func (s *Store) metricCounts(ctx context.Context, query string) ([]MetricCount, error) {
+	rows, err := s.pool.Query(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var metrics []MetricCount
+	for rows.Next() {
+		var metric MetricCount
+		if err := rows.Scan(&metric.Key, &metric.Count); err != nil {
+			return nil, err
+		}
+		metrics = append(metrics, metric)
+	}
+	return metrics, rows.Err()
 }
 
 func (s *Store) Profile(ctx context.Context, chatID int64) (domain.PrayerProfile, error) {

--- a/global/internal/telegram/admin.go
+++ b/global/internal/telegram/admin.go
@@ -1,0 +1,261 @@
+package telegram
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-telegram/bot/models"
+
+	"github.com/escalopa/prayer-bot/global/internal/domain"
+	"github.com/escalopa/prayer-bot/global/internal/i18n"
+	"github.com/escalopa/prayer-bot/global/internal/store"
+)
+
+type adminView string
+
+const (
+	adminViewOverview  adminView = "overview"
+	adminViewActivity  adminView = "activity"
+	adminViewLanguages adminView = "languages"
+	adminViewMethods   adminView = "methods"
+	adminViewReminders adminView = "reminders"
+	adminViewHealth    adminView = "health"
+	adminViewFeedback  adminView = "feedback"
+)
+
+func (h *Handler) isOwner(chat models.Chat, user *models.User) bool {
+	return h.ownerID != 0 &&
+		chat.Type == models.ChatTypePrivate &&
+		user != nil &&
+		user.ID == h.ownerID
+}
+
+func (h *Handler) sendAdminDashboard(ctx context.Context, chatID int64, view adminView) error {
+	metrics, err := h.store.AdminMetrics(ctx)
+	if err != nil {
+		return fmt.Errorf("load owner dashboard: %w", err)
+	}
+	return h.send(ctx, chatID, formatAdminDashboard(metrics, view, h.now()), adminKeyboard(view))
+}
+
+func (h *Handler) editAdminDashboard(ctx context.Context, message *models.Message, view adminView) error {
+	metrics, err := h.store.AdminMetrics(ctx)
+	if err != nil {
+		return fmt.Errorf("load owner dashboard: %w", err)
+	}
+	return h.edit(ctx, message.Chat.ID, message.ID, formatAdminDashboard(metrics, view, h.now()), adminKeyboard(view))
+}
+
+func parseAdminView(data string) (adminView, bool) {
+	view := adminView(strings.TrimPrefix(data, "admin:"))
+	switch view {
+	case adminViewOverview, adminViewActivity, adminViewLanguages, adminViewMethods, adminViewReminders, adminViewHealth, adminViewFeedback:
+		return view, true
+	default:
+		return "", false
+	}
+}
+
+func adminKeyboard(current adminView) *models.InlineKeyboardMarkup {
+	button := func(label string, view adminView) models.InlineKeyboardButton {
+		return callbackButton(selectedLabel(label, current == view), "admin:"+string(view))
+	}
+	return inlineKeyboard(
+		[]models.InlineKeyboardButton{
+			button("📊 Overview", adminViewOverview),
+			button("⚡ Activity", adminViewActivity),
+		},
+		[]models.InlineKeyboardButton{
+			button("🌐 Languages", adminViewLanguages),
+			button("🧭 Methods", adminViewMethods),
+		},
+		[]models.InlineKeyboardButton{
+			button("🔔 Reminders", adminViewReminders),
+			button("🩺 Delivery health", adminViewHealth),
+		},
+		[]models.InlineKeyboardButton{
+			button("💬 Feedback help", adminViewFeedback),
+			{Text: "🔄 Refresh", CallbackData: "admin:" + string(current)},
+		},
+	)
+}
+
+func formatAdminDashboard(metrics store.AdminDashboard, view adminView, now time.Time) string {
+	var body string
+	switch view {
+	case adminViewActivity:
+		body = formatAdminActivity(metrics)
+	case adminViewLanguages:
+		body = formatAdminLanguages(metrics)
+	case adminViewMethods:
+		body = formatAdminMethods(metrics)
+	case adminViewReminders:
+		body = formatAdminReminders(metrics)
+	case adminViewHealth:
+		body = formatAdminHealth(metrics)
+	case adminViewFeedback:
+		body = formatAdminFeedback()
+	default:
+		body = formatAdminOverview(metrics)
+	}
+	return body + fmt.Sprintf(
+		"\n\n<i>Aggregate data only · refreshed %s UTC</i>",
+		now.UTC().Format("02 Jan 2006 15:04"),
+	)
+}
+
+func formatAdminOverview(metrics store.AdminDashboard) string {
+	return fmt.Sprintf(
+		"<b>Owner dashboard</b> 🔐\n\n"+
+			"👤 <b>Users</b>: %d\n"+
+			"👥 <b>Groups</b>: %d\n"+
+			"📍 <b>Configured</b>: %d · %.1f%%\n"+
+			"🔔 <b>Using reminders</b>: %d · %.1f%%\n\n"+
+			"⚡ <b>Active users</b>\n"+
+			"24 hours: %d\n"+
+			"7 days: %d\n"+
+			"30 days: %d\n\n"+
+			"🌱 <b>New users</b>\n"+
+			"24 hours: %d\n"+
+			"7 days: %d\n"+
+			"30 days: %d",
+		metrics.Users,
+		metrics.Groups,
+		metrics.ConfiguredUsers,
+		percentage(metrics.ConfiguredUsers, metrics.Users),
+		metrics.ReminderUsers,
+		percentage(metrics.ReminderUsers, metrics.Users),
+		metrics.ActiveUsers24Hours,
+		metrics.ActiveUsers7Days,
+		metrics.ActiveUsers30Days,
+		metrics.NewUsers24Hours,
+		metrics.NewUsers7Days,
+		metrics.NewUsers30Days,
+	)
+}
+
+func formatAdminActivity(metrics store.AdminDashboard) string {
+	return fmt.Sprintf(
+		"<b>User activity</b> ⚡\n\n"+
+			"<b>Active private chats</b>\n"+
+			"24 hours: %d · %.1f%%\n"+
+			"7 days: %d · %.1f%%\n"+
+			"30 days: %d · %.1f%%\n\n"+
+			"<b>New private chats</b>\n"+
+			"24 hours: %d\n"+
+			"7 days: %d\n"+
+			"30 days: %d\n\n"+
+			"<i>Activity means the user interacted with the bot during the period.</i>",
+		metrics.ActiveUsers24Hours,
+		percentage(metrics.ActiveUsers24Hours, metrics.Users),
+		metrics.ActiveUsers7Days,
+		percentage(metrics.ActiveUsers7Days, metrics.Users),
+		metrics.ActiveUsers30Days,
+		percentage(metrics.ActiveUsers30Days, metrics.Users),
+		metrics.NewUsers24Hours,
+		metrics.NewUsers7Days,
+		metrics.NewUsers30Days,
+	)
+}
+
+func formatAdminLanguages(metrics store.AdminDashboard) string {
+	var builder strings.Builder
+	builder.WriteString("<b>User languages</b> 🌐\n")
+	if len(metrics.Languages) == 0 {
+		builder.WriteString("\nNo users yet.")
+		return builder.String()
+	}
+	for _, metric := range metrics.Languages {
+		locale := i18n.Resolve(metric.Key)
+		fmt.Fprintf(&builder, "\n%s · <b>%d</b> · %.1f%%",
+			escape(locale.NativeName), metric.Count, percentage(metric.Count, metrics.Users))
+	}
+	return builder.String()
+}
+
+func formatAdminMethods(metrics store.AdminDashboard) string {
+	var builder strings.Builder
+	builder.WriteString("<b>Calculation methods</b> 🧭\n")
+	if len(metrics.Methods) == 0 {
+		builder.WriteString("\nNo configured users yet.")
+		return builder.String()
+	}
+	english := i18n.Resolve("en")
+	for _, metric := range metrics.Methods {
+		method := domain.Method(metric.Key)
+		label := metric.Key
+		if method.Valid() {
+			label = english.Method(method)
+		}
+		fmt.Fprintf(&builder, "\n%s · <b>%d</b> · %.1f%%",
+			escape(label), metric.Count, percentage(metric.Count, metrics.ConfiguredUsers))
+	}
+	return builder.String()
+}
+
+func formatAdminReminders(metrics store.AdminDashboard) string {
+	counts := make(map[string]int64, len(metrics.ReminderKinds))
+	for _, metric := range metrics.ReminderKinds {
+		counts[metric.Key] = metric.Count
+	}
+	return fmt.Sprintf(
+		"<b>Reminder adoption</b> 🔔\n\n"+
+			"🕌 Prayer times: <b>%d</b>\n"+
+			"🌙 Monday &amp; Thursday fasting: <b>%d</b>\n"+
+			"📖 Friday Al-Kahf: <b>%d</b>\n\n"+
+			"Users with any reminder: %d · %.1f%%\n"+
+			"Enabled rules: %d\n"+
+			"Pending schedules: %d",
+		counts["prayer"],
+		counts["fasting"],
+		counts["kahf"],
+		metrics.ReminderUsers,
+		percentage(metrics.ReminderUsers, metrics.Users),
+		metrics.EnabledRules,
+		metrics.PendingSchedules,
+	)
+}
+
+func formatAdminHealth(metrics store.AdminDashboard) string {
+	totalDeliveries := metrics.SentDeliveries24Hours +
+		metrics.FailedDeliveries24Hours +
+		metrics.StaleDeliveries24Hours
+	return fmt.Sprintf(
+		"<b>Delivery health</b> 🩺\n\n"+
+			"<b>Last 24 hours</b>\n"+
+			"✅ Sent: %d\n"+
+			"❌ Failed: %d\n"+
+			"⏭ Stale: %d\n"+
+			"Success rate: %.1f%%\n\n"+
+			"<b>Current queues</b>\n"+
+			"Processing deliveries: %d\n"+
+			"Task outbox: %d\n"+
+			"Pending schedules: %d\n\n"+
+			"⚠️ Failed bot updates (24h): %d",
+		metrics.SentDeliveries24Hours,
+		metrics.FailedDeliveries24Hours,
+		metrics.StaleDeliveries24Hours,
+		percentage(metrics.SentDeliveries24Hours, totalDeliveries),
+		metrics.ProcessingDeliveries,
+		metrics.QueuedTasks,
+		metrics.PendingSchedules,
+		metrics.FailedUpdates24Hours,
+	)
+}
+
+func formatAdminFeedback() string {
+	return "<b>Feedback workflow</b> 💬\n\n" +
+		"1. The bot sends you the user's identity and language.\n" +
+		"2. The next message is a copy of their text or screenshot.\n" +
+		"3. Tap <b>✉️ Contact user</b> to open their Telegram profile and answer directly.\n\n" +
+		"⚠️ Replying to either message inside this bot chat does not forward your response to the user."
+}
+
+func percentage(value, total int64) float64 {
+	if total == 0 {
+		return 0
+	}
+	return float64(value) * 100 / float64(total)
+}

--- a/global/internal/telegram/admin_test.go
+++ b/global/internal/telegram/admin_test.go
@@ -1,0 +1,106 @@
+package telegram
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-telegram/bot/models"
+
+	"github.com/escalopa/prayer-bot/global/internal/store"
+)
+
+func TestOwnerDashboardRequiresOwnerPrivateChat(t *testing.T) {
+	handler := &Handler{ownerID: 42}
+	owner := &models.User{ID: 42}
+	if !handler.isOwner(models.Chat{Type: models.ChatTypePrivate}, owner) {
+		t.Fatal("owner should have access in a private chat")
+	}
+	if handler.isOwner(models.Chat{Type: models.ChatTypeGroup}, owner) {
+		t.Fatal("owner dashboard must not be available in a group")
+	}
+	if handler.isOwner(models.Chat{Type: models.ChatTypePrivate}, &models.User{ID: 7}) {
+		t.Fatal("non-owner should not have access")
+	}
+	if handler.isOwner(models.Chat{Type: models.ChatTypePrivate}, nil) {
+		t.Fatal("missing Telegram user should not have access")
+	}
+}
+
+func TestAdminKeyboardProvidesEveryDashboardView(t *testing.T) {
+	keyboard := adminKeyboard(adminViewOverview)
+	seen := make(map[adminView]bool)
+	for _, row := range keyboard.InlineKeyboard {
+		for _, button := range row {
+			view, ok := parseAdminView(button.CallbackData)
+			if !ok {
+				t.Fatalf("invalid admin callback %q", button.CallbackData)
+			}
+			seen[view] = true
+		}
+	}
+	for _, view := range []adminView{
+		adminViewOverview,
+		adminViewActivity,
+		adminViewLanguages,
+		adminViewMethods,
+		adminViewReminders,
+		adminViewHealth,
+		adminViewFeedback,
+	} {
+		if !seen[view] {
+			t.Errorf("dashboard keyboard is missing %q", view)
+		}
+	}
+}
+
+func TestAdminDashboardFormatsAggregateViews(t *testing.T) {
+	metrics := store.AdminDashboard{
+		Users:                   100,
+		Groups:                  4,
+		ConfiguredUsers:         80,
+		NewUsers24Hours:         2,
+		NewUsers7Days:           12,
+		NewUsers30Days:          40,
+		ActiveUsers24Hours:      15,
+		ActiveUsers7Days:        50,
+		ActiveUsers30Days:       90,
+		ReminderUsers:           30,
+		EnabledRules:            120,
+		PendingSchedules:        110,
+		QueuedTasks:             3,
+		SentDeliveries24Hours:   95,
+		FailedDeliveries24Hours: 5,
+		StaleDeliveries24Hours:  2,
+		ProcessingDeliveries:    1,
+		FailedUpdates24Hours:    4,
+		Languages:               []store.MetricCount{{Key: "en", Count: 70}, {Key: "ar", Count: 30}},
+		Methods:                 []store.MetricCount{{Key: "egyptian", Count: 60}, {Key: "mwl", Count: 20}},
+		ReminderKinds:           []store.MetricCount{{Key: "prayer", Count: 30}, {Key: "fasting", Count: 10}, {Key: "kahf", Count: 8}},
+	}
+	now := time.Date(2026, time.July, 17, 12, 30, 0, 0, time.FixedZone("EET", 2*60*60))
+	expectations := map[adminView]string{
+		adminViewOverview:  "Owner dashboard",
+		adminViewActivity:  "User activity",
+		adminViewLanguages: "العربية",
+		adminViewMethods:   "Egyptian General Authority",
+		adminViewReminders: "Monday &amp; Thursday fasting",
+		adminViewHealth:    "Failed bot updates",
+		adminViewFeedback:  "Contact user",
+	}
+	for view, expected := range expectations {
+		formatted := formatAdminDashboard(metrics, view, now)
+		if !strings.Contains(formatted, expected) {
+			t.Errorf("%s dashboard does not contain %q: %s", view, expected, formatted)
+		}
+		if !strings.Contains(formatted, "17 Jul 2026 10:30 UTC") {
+			t.Errorf("%s dashboard has an unexpected refresh time: %s", view, formatted)
+		}
+	}
+}
+
+func TestPercentageHandlesEmptyDashboard(t *testing.T) {
+	if got := percentage(0, 0); got != 0 {
+		t.Fatalf("percentage(0, 0) = %v, want 0", got)
+	}
+}

--- a/global/internal/telegram/callbacks.go
+++ b/global/internal/telegram/callbacks.go
@@ -35,6 +35,17 @@ func (h *Handler) handleCallback(ctx context.Context, query *models.CallbackQuer
 		return err
 	}
 
+	if strings.HasPrefix(query.Data, "admin:") {
+		if !h.isOwner(message.Chat, &query.From) {
+			return nil
+		}
+		view, ok := parseAdminView(query.Data)
+		if !ok {
+			return nil
+		}
+		return h.editAdminDashboard(ctx, message, view)
+	}
+
 	if strings.HasPrefix(query.Data, "language:") {
 		if ok, err := h.canConfigureActor(ctx, message.Chat, &query.From, locale); err != nil || !ok {
 			return err

--- a/global/internal/telegram/feedback.go
+++ b/global/internal/telegram/feedback.go
@@ -45,11 +45,14 @@ func deliverFeedback(ctx context.Context, sender feedbackSender, ownerID int64, 
 		username = "@" + message.From.Username
 	}
 	header := fmt.Sprintf(
-		"<b>New bot feedback</b> 💬\nFrom: <a href=\"tg://user?id=%d\">%s</a>\nUsername: %s\nUser ID: <code>%d</code>\nBot language: <code>%s</code>",
+		"<b>New bot feedback</b> 💬\nFrom: <a href=\"tg://user?id=%d\">%s</a>\nUsername: %s\nUser ID: <code>%d</code>\nBot language: <code>%s</code>\n\n<i>Use the button below to contact this user directly. Replying inside the bot chat will not forward your message.</i>",
 		message.From.ID, escape(name), escape(username), message.From.ID, escape(languageCode),
 	)
 	notification, err := sender.SendMessage(ctx, &botapi.SendMessageParams{
 		ChatID: ownerID, Text: header, ParseMode: models.ParseModeHTML,
+		ReplyMarkup: inlineKeyboard([]models.InlineKeyboardButton{{
+			Text: "✉️ Contact user", URL: fmt.Sprintf("tg://user?id=%d", message.From.ID),
+		}}),
 	})
 	if err != nil {
 		return fmt.Errorf("send feedback metadata: %w", err)

--- a/global/internal/telegram/feedback_test.go
+++ b/global/internal/telegram/feedback_test.go
@@ -38,6 +38,14 @@ func TestDeliverFeedbackSendsPrivateContextAndCopiesOriginal(t *testing.T) {
 	if sender.sent == nil || sender.sent.ChatID != int64(1234) || !strings.Contains(sender.sent.Text, "Amina &lt;Admin&gt;") || !strings.Contains(sender.sent.Text, "<code>99</code>") {
 		t.Fatalf("unexpected owner notification: %+v", sender.sent)
 	}
+	if !strings.Contains(sender.sent.Text, "will not forward") {
+		t.Fatalf("owner notification does not explain how replies work: %q", sender.sent.Text)
+	}
+	markup, ok := sender.sent.ReplyMarkup.(*models.InlineKeyboardMarkup)
+	if !ok || len(markup.InlineKeyboard) != 1 || len(markup.InlineKeyboard[0]) != 1 ||
+		markup.InlineKeyboard[0][0].URL != "tg://user?id=99" {
+		t.Fatalf("owner notification is missing the direct-contact button: %+v", sender.sent.ReplyMarkup)
+	}
 	if sender.copied == nil || sender.copied.ChatID != int64(1234) || sender.copied.FromChatID != int64(42) || sender.copied.MessageID != 77 {
 		t.Fatalf("unexpected copied feedback: %+v", sender.copied)
 	}

--- a/global/internal/telegram/handler.go
+++ b/global/internal/telegram/handler.go
@@ -143,17 +143,11 @@ func (h *Handler) Handle(ctx context.Context, update models.Update) error {
 		return h.send(ctx, message.Chat.ID, locale.Message("privacy"), mainKeyboard(locale))
 	case i18n.ActionHelp:
 		return h.send(ctx, message.Chat.ID, locale.Message("help"), mainKeyboard(locale))
-	case "status":
-		if h.ownerID == 0 || message.From == nil || message.From.ID != h.ownerID {
+	case "admin", "status":
+		if !h.isOwner(message.Chat, message.From) {
 			return nil
 		}
-		stats, err := h.store.Stats(ctx)
-		if err != nil {
-			return err
-		}
-		return h.send(ctx, message.Chat.ID, fmt.Sprintf(
-			"<b>Global bot status</b>\nChats: %d\nProfiles: %d\nEnabled reminder rules: %d\nPending schedules: %d",
-			stats.Chats, stats.Profiles, stats.EnabledRules, stats.PendingSchedules), nil)
+		return h.sendAdminDashboard(ctx, message.Chat.ID, adminViewOverview)
 	default:
 		return h.send(ctx, message.Chat.ID, locale.Message("unknown"), mainKeyboard(locale))
 	}


### PR DESCRIPTION
## What changed

- add an owner-only `/admin` dashboard with inline views for overview, activity, languages, calculation methods, reminder adoption, delivery health, and feedback guidance
- keep `/status` as a backward-compatible alias
- restrict the panel to `GLOBAL_OWNER_ID` in a private chat and omit it from the public command menu
- calculate aggregate metrics from the existing global schema, without adding invasive event tracking or exposing individual users and coordinates
- add a direct **Contact user** button and explicit reply guidance to owner feedback notifications
- document the dashboard and feedback workflow

## Useful metrics

- total private users and groups
- configured/onboarded users
- new and active users over 24 hours, 7 days, and 30 days
- language and calculation-method distribution
- prayer, fasting, and Al-Kahf reminder adoption
- sent, failed, stale, processing, queued, and failed-update health signals

## Validation

- `GOCACHE=/tmp/prayer-bot-go-cache go vet ./...` from `global/`
- `GOCACHE=/tmp/prayer-bot-go-cache go test ./...` from `global/`
- `git diff --check`

No database migration or legacy-bot change is included.