### PR TITLE
Add Qibla direction and calendar export

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ A serverless Telegram bot that provides Muslim prayer times and sends notificati
 
 The global bot's solar equations, supported calculation methods, high-latitude rules, and Gregorian--Hijri conversion are documented on the public [calculation methodology site](https://escalopa.github.io/prayer-bot/). The versioned [LaTeX source](docs/calculation-methods.tex) is maintained in this repository.
 
+The separate worldwide bot under [`global/`](global/) has its own
+[engineering and architecture guide](global/docs/README.md). Use that guide for
+the global runtime, Mini App, reminder pipeline, database schemas, and GCP
+deployment; the architecture below describes only the legacy city bots.
+
 [![wakatime](https://wakatime.com/badge/user/965e81db-2a88-4564-b236-537c4a901130/project/635dffc4-6a06-4e43-9a87-5bb977437cdb.svg)](https://wakatime.com/badge/user/965e81db-2a88-4564-b236-537c4a901130/project/635dffc4-6a06-4e43-9a87-5bb977437cdb)
 [![Report card](https://goreportcard.com/badge/github.com/escalopa/gopray)](https://goreportcard.com/report/github.com/escalopa/gopray)
 

--- a/global/README.md
+++ b/global/README.md
@@ -16,6 +16,8 @@ This directory is a separate application derived from the existing city bots. It
 - Opt-in weekly reminders for Monday/Thursday voluntary fasting (20:00 on the preceding evening) and reading Surah Al-Kahf on Friday (09:00), scheduled in the saved local timezone.
 - Configurable pre-prayer reminders at 5, 10, 15, 20, 30, 45, or 60 minutes before each obligatory prayer, followed by the normal prayer-time notification.
 - Category-aware notification cleanup: a new prayer notice replaces the preceding prayer/pre-prayer message, weekly categories are independent, and every reminder expires within Telegram's deletion window.
+- A Qibla tool that calculates the initial great-circle bearing and distance to the Kaaba from the saved rounded coordinates, with optional live compass orientation on supported Telegram clients.
+- Localized 7-day and 30-day prayer-calendar exports in standard `.ics` format for Apple Calendar, Google Calendar, Outlook, and other compatible clients.
 - An embedded welcome illustration sent on `/start` and a generated bot avatar installed during profile synchronization.
 - A localized feedback and bug-report flow that accepts text or screenshots in a private chat and delivers them directly to the configured owner with the sender's disclosed Telegram identity.
 - An owner-only `/admin` dashboard with aggregate user activity, onboarding, language, calculation-method, reminder-adoption, queue, and delivery-health metrics.
@@ -41,6 +43,8 @@ Feedback arrives in the owner's private bot chat as a metadata message followed 
 | `sender` | Cloud Tasks service account only | Idempotent Telegram delivery, category cleanup, and next-occurrence planning |
 
 The three services use one immutable image and select `/webhook`, `/dispatch`, or `/send` as the command. The webhook binary embeds the Mini App and serves it at `/app/`, so the feature does not add another Cloud Run service, container image, database, migration, or secret.
+
+Calendar downloads use a short-lived, encrypted and authenticated URL created only after the Mini App session has been authenticated. The link expires after five minutes and exposes neither the Telegram user ID nor the bot token. Qibla calculations and calendar generation use the existing saved profile and prayer engine, so neither feature adds an external API call or recurring job.
 
 ## Testing and production secrets
 

--- a/global/README.md
+++ b/global/README.md
@@ -2,6 +2,14 @@
 
 This directory is a separate application derived from the existing city bots. It has its own Go module, container image, Cloud Run services, Terraform state, Telegram token, Secret Manager entries, and PostgreSQL schema. Nothing under `global/` imports or changes the legacy runtime.
 
+## Engineering documentation
+
+Start with [`docs/README.md`](docs/README.md) before changing the global bot. It
+links the system architecture, package ownership, request flows, data model,
+reminder delivery semantics, runtime/deployment topology, and operational
+runbook. Architectural or persistence changes should update the owning document
+in the same pull request.
+
 ## What is implemented
 
 - Location onboarding from Telegram coordinates, with group changes restricted to group administrators.

--- a/global/docs/README.md
+++ b/global/docs/README.md
@@ -1,0 +1,49 @@
+# Global bot engineering guide
+
+This directory is the durable map of the global prayer bot. Start here before
+tracing source code or changing infrastructure.
+
+The global bot is intentionally independent from the two legacy city bots.
+Unless a document explicitly says otherwise, paths and database objects in this
+guide belong to `global/` and the `global_bot_testing` or
+`global_bot_production` PostgreSQL schema.
+
+## Choose the document for the task
+
+| Task or question | Read first |
+| --- | --- |
+| Understand the complete system and its trust boundaries | [Architecture](architecture.md) |
+| Find the package, binary, or API endpoint to change | [Code map](code-map.md) |
+| Follow a Telegram update, Mini App request, or location change | [Request flows](request-flows.md) |
+| Understand tables, ownership, and data invariants | [Data model](data-model.md) |
+| Change reminders, retries, idempotency, or message deletion | [Reminder delivery](reminder-delivery.md) |
+| Change Cloud Run, Cloud Tasks, Scheduler, secrets, or environments | [Runtime and deployment](runtime-and-deployment.md) |
+| Diagnose an incident or perform an operational action | [Operations](operations.md) |
+
+## Five-minute mental model
+
+1. Telegram sends bot updates to the public `webhook` Cloud Run service.
+2. The same service embeds the Mini App and exposes its authenticated API.
+3. Profiles, preferences, reminder rules, schedules, delivery state, and update
+   idempotency live in an environment-specific PostgreSQL schema.
+4. Prayer times, Hijri dates, Qibla direction, and calendar files are calculated
+   locally. Google APIs are used only when a location changes.
+5. Cloud Scheduler invokes `dispatch`, which atomically claims due schedules and
+   writes an outbox.
+6. `dispatch` creates deterministic Cloud Tasks. The private `sender` service
+   leases each delivery, sends through Telegram, advances the schedule, and
+   manages deletion of older notification messages.
+7. Testing and production reuse the same GCP project and PostgreSQL database but
+   use different Cloud resources, bot tokens, secrets, Terraform state, and
+   database schemas.
+
+## Documentation rules
+
+- Update the relevant document in the same pull request as an architectural,
+  deployment, persistence, or delivery-semantics change.
+- Describe invariants and failure behavior, not line-by-line implementation.
+- Link to the owning package instead of duplicating source code.
+- Never place tokens, database URLs, coordinates, Telegram IDs, or other
+  production values in these documents.
+- If observed production behavior differs from these documents, treat that as
+  either a code defect or a documentation defect and correct both.

--- a/global/docs/architecture.md
+++ b/global/docs/architecture.md
@@ -20,6 +20,10 @@ The webhook service embeds and serves a dependency-free HTML/CSS/JavaScript Mini
 
 The backend never trusts a Telegram user ID sent in JSON. Every Mini App API request carries the exact `Telegram.WebApp.initData` string in a header. The server verifies Telegram's HMAC signature with the environment's bot token, rejects duplicate fields and sessions older than 24 hours, and derives the private chat ID from the signed user object. The app is private-chat scoped; group configuration remains in the bot, where administrator authorization is enforced.
 
+The Qibla tool derives a great-circle bearing from the rounded coordinates already present in the profile and sends only the resulting bearing and distance to the browser. Supported Telegram clients can rotate the displayed needle with absolute device-orientation data; unsupported clients retain the numeric bearing and static compass.
+
+Calendar export first creates a five-minute encrypted and authenticated download token from an authenticated Mini App request. The opaque token exposes neither the Telegram identity nor the bot token. The resulting same-origin URL generates a localized 7-day or 30-day iCalendar file on demand. Events are emitted as UTC instants for broad calendar-client compatibility, while the source timezone and calculation method remain in the calendar metadata. No exported event UID contains a Telegram user or chat ID.
+
 ## Data ownership
 
 The legacy `public.chats` and `public.prayers` tables remain untouched. Global testing data is owned by `global_bot_testing`, production data is owned by `global_bot_production`, foreign keys cascade from each schema's `chats` table, and `/delete_me` deletes the chat root.

--- a/global/docs/architecture.md
+++ b/global/docs/architecture.md
@@ -1,5 +1,9 @@
 # Architecture and rollout
 
+This document defines the global system boundary and major trust relationships.
+For package ownership, state, detailed flows, and operations, use the
+[engineering guide](README.md).
+
 ```mermaid
 flowchart LR
     T[Telegram] -->|secret-protected webhook| W[Cloud Run webhook]
@@ -51,6 +55,10 @@ Telegram only permits message deletion for messages sent less than 48 hours ago.
 Outbox rows are removed after Cloud Tasks accepts them. A daily authenticated maintenance request deletes processed update keys after 7 days and terminal delivery records after 30 days, in bounded batches.
 
 This prevents ordinary duplicate deliveries. A process crash after Telegram accepts a message but before PostgreSQL records it can still cause a retry because Telegram's Bot API has no idempotency parameter; delivery is therefore at-least-once in that narrow failure window.
+
+The exact delivery state machine, cleanup categories, and required compensation
+for post-send failures are documented in
+[Reminder delivery](reminder-delivery.md).
 
 ## Rollout gates
 

--- a/global/docs/code-map.md
+++ b/global/docs/code-map.md
@@ -1,0 +1,59 @@
+# Code map
+
+Use this map to locate the owner of a behavior before searching the repository.
+All paths are relative to `global/`.
+
+## Executables
+
+| Path | Runtime | Responsibility |
+| --- | --- | --- |
+| `cmd/webhook` | Public Cloud Run service | Telegram webhook, commands, callbacks, feedback, owner dashboard, Mini App static files and APIs |
+| `cmd/dispatch` | Private Cloud Run service called by Scheduler | Claims due reminder schedules, drains the transactional outbox into Cloud Tasks, runs retention cleanup |
+| `cmd/send` | Private Cloud Run service called by Cloud Tasks | Sends reminder messages, advances recurring schedules, and deletes notification messages |
+| `cmd/botprofile` | Deployment command | Synchronizes the webhook, stable public profile, command menu, Mini App menu button, and avatar |
+| `cmd/bootstrapdb` | Deployment command | Creates only the selected global PostgreSQL schema before Goose runs |
+
+The production image contains all executables. Terraform selects the executable
+with the container command, so the three Cloud Run services use the same build.
+
+## Internal packages
+
+| Package | Owns | Depends on |
+| --- | --- | --- |
+| `internal/domain` | Shared value types for chats, profiles, prayers, reminders, schedules, and task payloads | Standard library only |
+| `internal/config` | Environment parsing and validation for each executable | `internal/database` for allowed schemas |
+| `internal/database` | Environment-schema names and schema validation | Standard library only |
+| `internal/store` | All PostgreSQL queries and transaction boundaries | `domain`, pgx |
+| `internal/prayertime` | Prayer calculation interface and `go-prayer` adapter | `domain` |
+| `internal/hijri` | Umm al-Qura conversion and per-chat display correction | `go-hijri` |
+| `internal/location` | Google Time Zone and reverse-geocoding integration | Google HTTP APIs |
+| `internal/reminders` | Recurrence planning, due dispatch, Cloud Tasks enqueueing, Telegram delivery, and cleanup categories | `domain`, `store`, `prayertime`, Telegram and GCP clients |
+| `internal/telegram` | Bot commands, callbacks, keyboards, update routing, feedback, and owner dashboard | `store`, `location`, `prayertime`, `reminders`, `i18n` |
+| `internal/miniapp` | Embedded web UI, signed init-data authentication, settings APIs, Qibla/bootstrap data, and calendar downloads | `store`, `location`, `prayertime`, `reminders`, `qibla`, `calendarfile`, `i18n` |
+| `internal/i18n` | All supported locales, messages, buttons, prayer names, method names, and dates | `domain` |
+| `internal/qibla` | Great-circle bearing and distance to the Kaaba | Standard library only |
+| `internal/calendarfile` | Localized RFC 5545 prayer-calendar generation | `domain`, `i18n`, `prayertime` |
+| `internal/botprofile` | Read-before-write Telegram profile synchronization and rate-limit handling | Telegram Bot API |
+| `internal/assets` | Embedded bot avatar and welcome media | Go embed |
+| `internal/httpx` | Shared HTTP response helpers | Standard library only |
+
+## Persistence and infrastructure
+
+| Path | Responsibility |
+| --- | --- |
+| `migrations/` | Versioned schema changes for both global environments |
+| `infra/gcp/` | Cloud Run, Cloud Tasks, Scheduler, service accounts, IAM, Secret Manager, Artifact Registry, and Maps key |
+| `.github/workflows/global-ci.yaml` | Global Go tests, image build, and Terraform validation |
+| `.github/workflows/global-deploy.yaml` | Manual testing/production build, migration, Terraform apply, and Telegram profile synchronization |
+
+## Change routing
+
+| Desired change | Primary files | Documents to update |
+| --- | --- | --- |
+| Add a command or button | `internal/telegram`, `internal/i18n` | [Request flows](request-flows.md) if the flow is new |
+| Add a Mini App setting | `internal/miniapp`, `internal/store`, possibly migrations | [Request flows](request-flows.md), [Data model](data-model.md) |
+| Add a calculation method | `internal/domain`, `internal/prayertime`, `internal/i18n` | Public calculation methodology and [Architecture](architecture.md) |
+| Change reminder timing | `internal/reminders/planner.go`, `internal/store` | [Reminder delivery](reminder-delivery.md) |
+| Change retry or deletion behavior | `internal/reminders/sender.go`, `internal/store`, `infra/gcp` | [Reminder delivery](reminder-delivery.md), [Operations](operations.md) |
+| Add persistent state | `migrations`, `internal/store`, `internal/domain` | [Data model](data-model.md) |
+| Add a service or cloud dependency | `infra/gcp`, `internal/config`, relevant `cmd` | [Architecture](architecture.md), [Runtime and deployment](runtime-and-deployment.md) |

--- a/global/docs/data-model.md
+++ b/global/docs/data-model.md
@@ -1,0 +1,160 @@
+# Data model
+
+Testing and production use the same PostgreSQL database but different schemas:
+
+- `global_bot_testing`
+- `global_bot_production`
+
+Every SQL query passes through `internal/store`, which qualifies the logical
+`global_bot` schema with the configured environment schema. The legacy `public`
+tables are outside this boundary.
+
+## Entity relationships
+
+```mermaid
+erDiagram
+    chats ||--o| prayer_profiles : configures
+    chats ||--o{ reminder_rules : enables
+    reminder_rules ||--o| reminder_schedules : schedules
+    reminder_schedules ||--o{ notification_deliveries : attempts
+    reminder_schedules ||--o{ task_outbox : queues
+    chats ||--o{ notification_message_slots : owns
+
+    chats {
+        bigint telegram_chat_id PK
+        text chat_type
+        text language_code
+        timestamptz blocked_at
+    }
+    prayer_profiles {
+        bigint chat_id PK
+        numeric latitude
+        numeric longitude
+        text timezone_id
+        text method
+        text madhab
+        text high_latitude_rule
+        jsonb adjustments
+        bigint version
+        integer hijri_adjustment
+    }
+    reminder_rules {
+        bigint id PK
+        bigint chat_id FK
+        text kind
+        text prayer
+        integer offset_minutes
+        text local_time
+        boolean enabled
+    }
+    reminder_schedules {
+        bigint id PK
+        bigint rule_id FK
+        bigint chat_id FK
+        bigint profile_version
+        date local_date
+        timestamptz prayer_at
+        timestamptz next_run_at
+        text state
+    }
+    notification_deliveries {
+        text delivery_key PK
+        bigint schedule_id FK
+        text status
+        integer attempts
+        timestamptz lease_until
+        bigint telegram_message_id
+    }
+    task_outbox {
+        bigint id PK
+        bigint schedule_id FK
+        text delivery_key UK
+        text endpoint
+        timestamptz run_at
+        jsonb payload
+    }
+    notification_message_slots {
+        bigint chat_id PK
+        text category PK
+        bigint telegram_message_id
+    }
+```
+
+`processed_updates` is independent from this graph. Its primary key is the
+Telegram `update_id`, and it stores only processing status, lease, attempts, and
+an abbreviated error.
+
+## Table responsibilities and invariants
+
+### `chats`
+
+The root of user-owned global-bot data. It stores chat type, saved language, and
+whether Telegram has blocked delivery. Deleting a chat cascades to its profile,
+rules, schedules, deliveries, outbox rows, and message slots.
+
+### `prayer_profiles`
+
+One row per configured chat. Coordinates are rounded to three decimals. The
+profile version increases whenever a change can affect calculated times.
+Queued tasks carry this version and become stale instead of sending after a
+profile change.
+
+### `reminder_rules`
+
+Represents desired behavior, not a queued job. The unique key prevents duplicate
+rules with the same chat, kind, prayer, and offset. Weekly reminders use their
+own kinds and local times.
+
+### `reminder_schedules`
+
+Exactly one current occurrence per rule because `rule_id` is unique. The
+schedule stores both the prayer instant and the notification run time. Its state
+moves from `pending` to `queued`, then back to `pending` when the sender writes
+the next occurrence.
+
+### `task_outbox`
+
+The transaction boundary between PostgreSQL and Cloud Tasks. A due schedule and
+its send payload are committed together. Deletion tasks also use this table but
+have no schedule ID. `delivery_key` is unique.
+
+### `notification_deliveries`
+
+The idempotency and retry lease for sender tasks. The deterministic delivery key
+is based on schedule, run instant, and profile version. Terminal states are
+`sent`, `failed`, and `stale`; `processing` has a two-minute lease.
+
+### `notification_message_slots`
+
+Stores the latest successfully committed Telegram message ID for each cleanup
+category:
+
+- `prayer`
+- `tomorrow`
+- `weekly_fasting`
+- `weekly_kahf`
+
+Before-prayer and at-prayer messages deliberately share `prayer`.
+
+## Retention
+
+| Data | Retention behavior |
+| --- | --- |
+| Completed or failed webhook update keys | Deleted after 7 days |
+| Sent, failed, or stale notification deliveries | Deleted after 30 days |
+| Telegram notification messages | Scheduled for deletion after 36 hours |
+| Profiles and reminder configuration | Kept until `/delete_me` or chat deletion |
+| Feedback content | Never stored in PostgreSQL |
+
+Retention runs in bounded batches from the authenticated maintenance Scheduler
+job.
+
+## Migration rules
+
+- Bootstrap the target schema before the first Goose migration.
+- Always give Goose the environment-specific version table:
+  `-table="${GLOBAL_DB_SCHEMA}.goose_db_version"`.
+- Deploy migrations before application revisions that require them.
+- Prefer forward corrective migrations in production.
+- Never run global migrations against the legacy default migration table or
+  `public` schema.

--- a/global/docs/operations.md
+++ b/global/docs/operations.md
@@ -6,6 +6,44 @@ All services expose `GET /healthz`. Application logs include update IDs or deliv
 
 Useful alerts are Cloud Run 5xx rate, Cloud Tasks oldest task age, queue retry count, Scheduler failures, PostgreSQL connection errors, and Google Time Zone/Geocoding non-`OK` statuses.
 
+## Incident triage
+
+Start with the [engineering guide](README.md) and use the stable identifiers in
+structured logs:
+
+- Telegram webhook problems: `update_id`;
+- reminder delivery problems: `delivery_key`;
+- Cloud Tasks HTTP requests: service name, timestamp, status, and latency;
+- profile deployment problems: the named profile operation and Telegram retry
+  interval.
+
+Do not search logs by bot token, database URL, coordinates, or full Telegram
+payload.
+
+| Symptom | Likely evidence | First document |
+| --- | --- | --- |
+| Duplicate reminder messages in the same minute | A sender 5xx after Telegram accepted the first message, followed by a successful Cloud Tasks retry of the same delivery key | [Reminder delivery](reminder-delivery.md) |
+| `prepared statement ... already exists` (`42P05`) | pgx named statement caching used through a transaction pooler | [Runtime and deployment](runtime-and-deployment.md#database-connections) |
+| `prepared statement ... does not exist` (`26000`) | The pooler moved a cached statement to a different PostgreSQL connection | [Runtime and deployment](runtime-and-deployment.md#database-connections) |
+| Reminder is late but eventually arrives | Cloud Run cold start, queue backoff, or transient sender 5xx | [Reminder delivery](reminder-delivery.md#retry-configuration) |
+| Old notification remains | Immediate Telegram deletion failed and its durable deletion task is retrying or expired past Telegram's limit | [Reminder delivery](reminder-delivery.md#cleanup-categories) |
+| Existing schedules work but location update fails | Google Time Zone or Geocoding failure | [Maps failure mode](#maps-failure-mode) |
+| Mini App says to open it in Telegram | Missing, expired, or invalid signed Telegram init data | [Request flows](request-flows.md#mini-app-session-and-api) |
+
+For a duplicate reminder, reconstruct the sequence in this order:
+
+1. Find sender requests near the displayed local time.
+2. Convert the displayed time with the profile's IANA timezone.
+3. Group application errors by `delivery_key`.
+4. Determine whether the failure happened before or after `sendMessage`.
+5. Look for the subsequent Cloud Tasks retry and successful HTTP 204.
+6. Check deletion-task requests for the same period.
+
+An error labelled `complete delivery` is post-send: Telegram already returned a
+message ID, but PostgreSQL did not commit it. Normal slot cleanup cannot discover
+that uncommitted message; the sender needs compensating deletion before it
+returns a retryable error.
+
 ## Secret rotation
 
 - Bot token: add a Secret Manager version, deploy a new revision, then revoke the old token through BotFather if required.

--- a/global/docs/reminder-delivery.md
+++ b/global/docs/reminder-delivery.md
@@ -1,0 +1,123 @@
+# Reminder delivery
+
+This is the source of truth for reminder planning, dispatch, retries,
+idempotency, and Telegram message cleanup.
+
+## Components
+
+| Component | Responsibility |
+| --- | --- |
+| Planner | Calculates the next occurrence in the profile's IANA timezone |
+| PostgreSQL schedule | Stores one next occurrence for each enabled rule |
+| Dispatcher | Claims due schedules and writes the outbox |
+| Cloud Tasks | Delivers authenticated HTTP tasks with retry and backoff |
+| Sender | Leases a delivery key, validates freshness, calls Telegram, and advances recurrence |
+| Message slot | Identifies the last successfully committed Telegram message in a cleanup category |
+
+## End-to-end state flow
+
+```mermaid
+stateDiagram-v2
+    [*] --> Pending: planner upserts occurrence
+    Pending --> Queued: dispatcher claims due row\nand commits outbox
+    Queued --> CloudTask: dispatcher creates deterministic task
+    CloudTask --> Processing: sender acquires delivery lease
+    Processing --> Stale: rule/profile/schedule changed
+    Processing --> Failed: pre-send or post-send operation failed
+    Failed --> Processing: Cloud Tasks retry acquires again
+    Processing --> Sent: Telegram send and completion transaction succeed
+    Sent --> Pending: same transaction stores next occurrence
+```
+
+The dispatcher uses `FOR UPDATE SKIP LOCKED`, so concurrent dispatcher
+instances cannot claim the same pending row. The outbox insertion and
+`pending → queued` transition share a transaction.
+
+The Cloud Task name is a hash of the deterministic delivery key. Creating the
+same task twice returns `AlreadyExists` and is treated as success.
+
+## Sender algorithm
+
+1. Load the referenced schedule.
+2. Acquire the delivery key, or return success if another request owns it or it
+   is already sent.
+3. Load the profile, rule, and chat locale.
+4. Reject the task as stale if rule state, schedule identity, run time, or
+   profile version changed.
+5. Send the localized message through Telegram.
+6. Calculate the next occurrence.
+7. In one PostgreSQL transaction:
+   - mark the delivery `sent` and store the Telegram message ID;
+   - advance the schedule to its next occurrence and return it to `pending`;
+   - replace the category's message slot;
+   - enqueue deletion of the prior slot message;
+   - enqueue 36-hour expiry of the new message.
+8. Attempt immediate best-effort deletion of the prior slot message.
+
+## Cleanup categories
+
+| Notification | Category | Replacement behavior |
+| --- | --- | --- |
+| Pre-prayer | `prayer` | Replaces the preceding prayer notification |
+| Prayer time | `prayer` | Replaces its pre-reminder, or the preceding prayer |
+| Tomorrow reminder | `tomorrow` | Replaces the prior tomorrow reminder |
+| Monday/Thursday fasting | `weekly_fasting` | Replaces only the prior fasting reminder |
+| Friday Al-Kahf | `weekly_kahf` | Replaces only the prior Al-Kahf reminder |
+
+Every message also expires after 36 hours because Telegram cannot delete bot
+messages once they are older than 48 hours.
+
+## Delivery guarantee
+
+The system prevents ordinary duplicate queueing and concurrent processing, but
+the Telegram API call and PostgreSQL commit cannot be one atomic transaction.
+The delivery guarantee is therefore **at least once** in this narrow sequence:
+
+```mermaid
+sequenceDiagram
+    participant S as sender
+    participant T as Telegram
+    participant P as PostgreSQL
+    participant Q as Cloud Tasks
+
+    S->>T: sendMessage
+    T-->>S: success + message_id
+    S->>P: complete delivery transaction
+    P--xS: database error or process loss
+    S-->>Q: HTTP 500
+    Q->>S: retry same delivery
+    S->>T: sendMessage again
+```
+
+If completion fails, the first Telegram message ID was never committed to the
+message slot. A retry cannot discover that copy, so normal replacement cleanup
+cannot delete it.
+
+Required safeguards for this boundary are:
+
+1. Database connectivity must be compatible with the runtime connection pool.
+   The Supabase transaction pooler must not be used with pgx's named
+   prepared-statement cache; configure runtime connections with
+   `pgx.QueryExecModeExec`.
+2. If any operation after a successful `sendMessage` fails, the sender should
+   make a compensating `deleteMessages` call for the just-sent message before
+   returning a retryable error.
+3. Tests must simulate “Telegram send succeeds, completion fails, task retries”
+   and assert that only the retry's message remains.
+
+Compensation greatly reduces visible duplicates but still depends on Telegram
+accepting the delete request. Exactly-once delivery is not possible without an
+idempotency facility on the external send API.
+
+## Retry configuration
+
+The notification queue currently uses:
+
+- maximum 8 attempts;
+- maximum retry duration of 1 hour;
+- minimum backoff of 5 seconds;
+- maximum backoff of 5 minutes;
+- maximum 50 concurrent dispatches and 20 dispatches per second.
+
+Changing these values affects incident amplification and delivery delay. Update
+this document and the operational alerts whenever queue policy changes.

--- a/global/docs/request-flows.md
+++ b/global/docs/request-flows.md
@@ -1,0 +1,119 @@
+# Request flows
+
+This document follows user-facing requests through authentication, business
+logic, persistence, and external APIs.
+
+## Telegram webhook update
+
+```mermaid
+sequenceDiagram
+    participant T as Telegram
+    participant W as webhook service
+    participant U as update lease
+    participant H as Telegram handler
+    participant P as PostgreSQL
+
+    T->>W: POST webhook + secret header
+    W->>W: validate Telegram secret
+    W->>U: acquire update_id
+    U->>P: insert/lease processed_updates
+    alt already completed or currently leased
+        U-->>W: not acquired
+        W-->>T: 200
+    else acquired
+        W->>H: route command, callback, location, or feedback
+        H->>P: load/update chat state
+        H->>T: Bot API response
+        H->>P: mark update completed
+        W-->>T: 200
+    end
+```
+
+The webhook header protects the endpoint. `update_id` leasing protects against
+Telegram retrying the same update. Update records are retained for seven days.
+Full Telegram update bodies are never persisted.
+
+## Location onboarding or change
+
+Location writes are the only normal user flow that calls Google APIs.
+
+1. Telegram supplies latitude and longitude from a location message or the Mini
+   App location manager.
+2. The handler validates coordinate bounds.
+3. `internal/location` resolves an IANA timezone and approximate place with the
+   Google Time Zone and Geocoding APIs.
+4. Persistence rounds coordinates to three decimal places and stores the
+   timezone and Google Place ID. The formatted Google address is not stored.
+5. The profile version increases.
+6. The reminder planner rebuilds schedules using the new version and timezone.
+7. The response calculates schedules locally with the saved rounded profile.
+
+If Google is unavailable, existing profiles, schedules, commands, reminders,
+Qibla direction, and calendar exports continue working. Only location writes
+fail.
+
+## Mini App session and API
+
+```mermaid
+sequenceDiagram
+    participant A as Telegram Mini App
+    participant M as miniapp API
+    participant P as PostgreSQL
+
+    A->>M: X-Telegram-Init-Data + request
+    M->>M: verify HMAC, age, and signed user
+    M->>P: upsert/load private chat
+    M->>P: load profile, rules, and schedules
+    M-->>A: localized bootstrap snapshot
+```
+
+The backend never accepts a Telegram user ID from the JSON body. It derives the
+identity only from signed `initData`, rejects duplicate signed fields, and
+rejects sessions older than 24 hours.
+
+Settings and reminder controls are edited in the browser but persisted as one
+snapshot only after the user presses **Save changes**. A successful response is
+a new complete bootstrap snapshot, allowing the UI to re-render immediately in
+the newly selected language.
+
+## Prayer schedule display
+
+Both the conversational bot and Mini App use the same profile and
+`prayertime.Calculator`:
+
+1. Load the saved profile and locale.
+2. Calculate the requested local day.
+3. Apply the selected method, madhab, high-latitude rule, and minute
+   adjustments.
+4. Format Gregorian and corrected Hijri dates.
+5. Localize prayer names and explanatory labels.
+
+The Hijri correction changes only the displayed Hijri date. It never changes
+the Gregorian date or prayer instants.
+
+## Qibla and calendar tools
+
+Qibla direction is calculated from the saved rounded coordinates. The server
+returns only bearing and distance to the Mini App. On supported clients,
+Telegram's absolute device-orientation API rotates the needle; otherwise the
+numeric bearing remains available.
+
+Calendar export has two requests:
+
+1. An authenticated Mini App request asks for 7 or 30 days.
+2. The backend returns a same-origin URL containing a five-minute encrypted and
+   authenticated token.
+3. Telegram's native downloader, or an anchor fallback, downloads the `.ics`
+   file.
+4. The server loads the current profile, calculates each day on demand, and
+   emits localized events as UTC instants.
+
+The URL and event UIDs expose neither the Telegram user ID nor bot token.
+
+## Feedback
+
+Feedback is accepted only after an explicit localized prompt. Private text,
+media, or screenshots are copied to the configured owner's private bot chat
+with a disclosed sender identity and a **Contact user** button. PostgreSQL does
+not store feedback content. A normal reply in the owner's bot chat is not
+forwarded automatically.

--- a/global/docs/runtime-and-deployment.md
+++ b/global/docs/runtime-and-deployment.md
@@ -1,0 +1,112 @@
+# Runtime and deployment
+
+## Environment isolation
+
+Testing and production reuse the organization's existing GCP project setup and
+Supabase PostgreSQL database, but their global-bot state is isolated. The
+GitHub environments may point at the same GCP project or separate existing GCP
+projects; the isolation rules below apply in both cases.
+
+| Resource | Testing | Production |
+| --- | --- | --- |
+| Resource prefix | `global-prayer-test` | `global-prayer-prod` |
+| PostgreSQL schema | `global_bot_testing` | `global_bot_production` |
+| Terraform state prefix | `prayer-bot/global-testing` | `prayer-bot/global-production` |
+| GitHub environment | `dev` | `prod` |
+| Telegram token and webhook secret | Testing values | Production values |
+| Cloud Run services, queue, Scheduler jobs, service accounts | Separate | Separate |
+
+Neither environment reads or writes the legacy city-bot tables or runtime
+configuration.
+
+## Runtime topology
+
+| Resource | Ingress | Identity |
+| --- | --- | --- |
+| `global-prayer-*-webhook` | Public | Telegram secret header or signed Mini App init data |
+| `global-prayer-*-dispatch` | Cloud Scheduler only | Scheduler OIDC service account |
+| `global-prayer-*-sender` | Cloud Tasks only | Task-caller OIDC service account |
+| `global-prayer-*-notifications` | GCP API | Dispatcher service account can enqueue |
+
+All services scale to zero. A first request can therefore include Cloud Run cold
+start latency. No minimum instances are configured intentionally to control
+cost.
+
+## Secrets
+
+Runtime services read environment-specific Secret Manager values:
+
+- Telegram bot token;
+- Telegram webhook secret;
+- owner Telegram ID;
+- Supabase runtime database URL;
+- Terraform-managed Google Maps API key.
+
+Only the webhook receives the webhook secret, owner ID, and Maps key. The
+webhook and sender receive the bot token because both call Telegram; dispatch
+does not. IAM grants secret access per service account rather than project-wide
+runtime access.
+
+Do not print secret values in workflow summaries, application logs, commands,
+or documentation.
+
+## Database connections
+
+The deployment uses two connection types:
+
+| Connection | Consumer | Reason |
+| --- | --- | --- |
+| `SUPABASE_DB_DIRECT_URL` | Bootstrap and Goose migrations | Schema creation and DDL require a direct session |
+| `SUPABASE_DB_URL` | Cloud Run services through Secret Manager | Runtime connection pooling for scale-to-zero instances |
+
+When `SUPABASE_DB_URL` uses the transaction pooler, pgx runtime connections must
+disable the named prepared-statement cache by selecting
+`pgx.QueryExecModeExec`. Symptoms of an incompatible configuration include
+`SQLSTATE 42P05 prepared statement already exists` and
+`SQLSTATE 26000 prepared statement does not exist`.
+
+## Deployment workflow
+
+The **Deploy global prayer bot** workflow is manual and accepts `testing` or
+`production`.
+
+```mermaid
+flowchart LR
+    A[Go tests and Terraform checks] --> B[Authenticate to GCP]
+    B --> C[Sync environment secrets]
+    C --> D[Build and push one image]
+    D --> E[Bootstrap schema and run Goose]
+    E --> F[Terraform apply]
+    F --> G[Configure webhook and profile]
+    G --> H[Write deployment summary]
+```
+
+Terraform creates or updates cloud resources; it does not create Telegram bot
+tokens. The profile step reads current Telegram values and mutates only changed
+fields. Telegram profile rate limits are reported as a successful skipped step
+so infrastructure deployment is not rolled back by a cosmetic operation.
+
+## Change safety
+
+- Application-only changes create a new image and Cloud Run revisions.
+- Schema changes must be backward compatible with the previously running
+  revision because migrations run before Terraform applies the new image.
+- Terraform resource renames can destroy and recreate resources; inspect the
+  plan before applying them.
+- Testing and production state prefixes must never be interchanged.
+- A testing deployment must never use the production Telegram token.
+- Legacy workflows and resources are separate and must not be included in a
+  global-bot Terraform plan.
+
+## Post-deployment checks
+
+1. Confirm the workflow summary shows successful tests, migration, Terraform,
+   and webhook configuration.
+2. Check `GET /healthz` for all three services.
+3. Run `/start`, `/today`, and one settings save in the selected bot.
+4. Open the Mini App from Telegram and verify bootstrap, location state, and
+   today/tomorrow switching.
+5. Inspect Cloud Run 5xx and Cloud Tasks retries for at least one dispatch
+   interval.
+6. For reminder changes, test a pre-reminder, arrival notification, replacement
+   deletion, and a forced retry in testing.

--- a/global/internal/calendarfile/calendar.go
+++ b/global/internal/calendarfile/calendar.go
@@ -1,0 +1,126 @@
+package calendarfile
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/escalopa/prayer-bot/global/internal/domain"
+	"github.com/escalopa/prayer-bot/global/internal/i18n"
+	"github.com/escalopa/prayer-bot/global/internal/prayertime"
+)
+
+const eventDuration = 15 * time.Minute
+
+var calendarPrayers = []domain.Prayer{
+	domain.PrayerFajr,
+	domain.PrayerSunrise,
+	domain.PrayerDhuhr,
+	domain.PrayerAsr,
+	domain.PrayerMaghrib,
+	domain.PrayerIsha,
+}
+
+func Generate(
+	ctx context.Context,
+	calculator prayertime.Calculator,
+	profile domain.PrayerProfile,
+	locale i18n.Locale,
+	start time.Time,
+	days int,
+	createdAt time.Time,
+) ([]byte, error) {
+	if days < 1 || days > 31 {
+		return nil, fmt.Errorf("calendar range must be between 1 and 31 days")
+	}
+	location, err := time.LoadLocation(profile.Timezone)
+	if err != nil {
+		return nil, fmt.Errorf("load timezone: %w", err)
+	}
+	start = start.In(location)
+
+	var calendar bytes.Buffer
+	writeLine(&calendar, "BEGIN:VCALENDAR")
+	writeLine(&calendar, "VERSION:2.0")
+	writeLine(&calendar, "PRODID:-//Global Prayer Times//Prayer Calendar//EN")
+	writeLine(&calendar, "CALSCALE:GREGORIAN")
+	writeLine(&calendar, "METHOD:PUBLISH")
+	writeLine(&calendar, "X-WR-CALNAME:"+escapeText(locale.BotName))
+	writeLine(&calendar, "X-WR-TIMEZONE:"+escapeText(profile.Timezone))
+
+	for day := 0; day < days; day++ {
+		schedule, err := calculator.Day(ctx, start.AddDate(0, 0, day), profile)
+		if err != nil {
+			return nil, fmt.Errorf("calculate day %d: %w", day+1, err)
+		}
+		for _, prayer := range calendarPrayers {
+			at, ok := schedule.At(prayer)
+			if !ok {
+				continue
+			}
+			writeEvent(&calendar, profile, locale, prayer, at, createdAt)
+		}
+	}
+	writeLine(&calendar, "END:VCALENDAR")
+	return calendar.Bytes(), nil
+}
+
+func Filename(start time.Time, days int) string {
+	return fmt.Sprintf("prayer-times-%s-%d-days.ics", start.Format("2006-01-02"), days)
+}
+
+func writeEvent(
+	calendar *bytes.Buffer,
+	profile domain.PrayerProfile,
+	locale i18n.Locale,
+	prayer domain.Prayer,
+	at time.Time,
+	createdAt time.Time,
+) {
+	uidSource := fmt.Sprintf("%s|%.3f|%.3f|%s|%s", profile.Timezone, profile.Latitude, profile.Longitude, prayer, at.UTC().Format(time.RFC3339))
+	digest := sha256.Sum256([]byte(uidSource))
+	description := fmt.Sprintf("%s · %s · %s", locale.BotName, locale.Method(profile.Method), profile.Timezone)
+
+	writeLine(calendar, "BEGIN:VEVENT")
+	writeLine(calendar, "UID:"+hex.EncodeToString(digest[:12])+"@global-prayer-bot")
+	writeLine(calendar, "DTSTAMP:"+createdAt.UTC().Format("20060102T150405Z"))
+	writeLine(calendar, "DTSTART:"+at.UTC().Format("20060102T150405Z"))
+	writeLine(calendar, "DTEND:"+at.Add(eventDuration).UTC().Format("20060102T150405Z"))
+	writeLine(calendar, "SUMMARY:"+escapeText(locale.Prayer(prayer)))
+	writeLine(calendar, "DESCRIPTION:"+escapeText(description))
+	writeLine(calendar, "CATEGORIES:Prayer Times")
+	writeLine(calendar, "END:VEVENT")
+}
+
+func escapeText(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, "\r\n", `\n`)
+	value = strings.ReplaceAll(value, "\r", `\n`)
+	value = strings.ReplaceAll(value, "\n", `\n`)
+	value = strings.ReplaceAll(value, ";", `\;`)
+	return strings.ReplaceAll(value, ",", `\,`)
+}
+
+// RFC 5545 content lines are limited to 75 octets. Continuation lines begin
+// with a single space, so they contain at most 74 octets of content.
+func writeLine(target *bytes.Buffer, line string) {
+	remaining := line
+	limit := 75
+	for len(remaining) > limit {
+		cut := limit
+		for cut > 0 && !utf8.RuneStart(remaining[cut]) {
+			cut--
+		}
+		target.WriteString(remaining[:cut])
+		target.WriteString("\r\n ")
+		remaining = remaining[cut:]
+		limit = 74
+	}
+	target.WriteString(remaining)
+	target.WriteString("\r\n")
+}

--- a/global/internal/calendarfile/calendar_test.go
+++ b/global/internal/calendarfile/calendar_test.go
@@ -1,0 +1,72 @@
+package calendarfile
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/escalopa/prayer-bot/global/internal/domain"
+	"github.com/escalopa/prayer-bot/global/internal/i18n"
+)
+
+type fakeCalculator struct{}
+
+func (fakeCalculator) Day(_ context.Context, date time.Time, profile domain.PrayerProfile) (domain.DaySchedule, error) {
+	location, _ := time.LoadLocation(profile.Timezone)
+	local := date.In(location)
+	day := time.Date(local.Year(), local.Month(), local.Day(), 0, 0, 0, 0, location)
+	times := make(map[domain.Prayer]time.Time)
+	for index, prayer := range calendarPrayers {
+		times[prayer] = day.Add(time.Duration(4+index*2) * time.Hour)
+	}
+	return domain.DaySchedule{Date: day, Timezone: profile.Timezone, Times: times}, nil
+}
+
+func TestGenerateCreatesPortableLocalizedCalendar(t *testing.T) {
+	profile := domain.PrayerProfile{
+		Latitude: 30.044, Longitude: 31.236, Timezone: "Africa/Cairo",
+		Method: domain.MethodEgyptian, Madhab: domain.MadhabShafii,
+		HighLatitudeRule: domain.HighLatitudeAngleBased,
+	}
+	start := time.Date(2026, time.July, 17, 12, 0, 0, 0, time.UTC)
+	data, err := Generate(context.Background(), fakeCalculator{}, profile, i18n.Resolve("ar"), start, 2, start)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.HasPrefix(content, "BEGIN:VCALENDAR\r\n") || !strings.HasSuffix(content, "END:VCALENDAR\r\n") {
+		t.Fatalf("invalid calendar envelope:\n%s", content)
+	}
+	if count := strings.Count(content, "BEGIN:VEVENT\r\n"); count != 12 {
+		t.Fatalf("event count = %d, want 12", count)
+	}
+	if !strings.Contains(content, "SUMMARY:الفجر\r\n") || !strings.Contains(content, "DTSTART:20260717T010000Z\r\n") {
+		t.Fatalf("calendar is missing localized prayer or UTC timestamp:\n%s", content)
+	}
+	if strings.Contains(content, "42@") {
+		t.Fatal("calendar must not expose a Telegram chat ID")
+	}
+}
+
+func TestGenerateValidatesRange(t *testing.T) {
+	profile := domain.PrayerProfile{Timezone: "UTC"}
+	if _, err := Generate(context.Background(), fakeCalculator{}, profile, i18n.Resolve("en"), time.Now(), 32, time.Now()); err == nil {
+		t.Fatal("expected oversized calendar export to fail")
+	}
+}
+
+func TestWriteLineFoldsUTF8WithoutSplittingRunes(t *testing.T) {
+	var buffer bytes.Buffer
+	writeLine(&buffer, "SUMMARY:"+strings.Repeat("الفجر", 20))
+	for _, line := range strings.Split(strings.TrimSuffix(buffer.String(), "\r\n"), "\r\n") {
+		if len(line) > 75 {
+			t.Fatalf("folded line contains %d octets", len(line))
+		}
+		if !utf8.ValidString(line) {
+			t.Fatal("folding split a UTF-8 sequence")
+		}
+	}
+}

--- a/global/internal/miniapp/calendar.go
+++ b/global/internal/miniapp/calendar.go
@@ -1,0 +1,167 @@
+package miniapp
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/escalopa/prayer-bot/global/internal/calendarfile"
+	"github.com/escalopa/prayer-bot/global/internal/i18n"
+	"github.com/escalopa/prayer-bot/global/internal/store"
+)
+
+const calendarTokenLifetime = 5 * time.Minute
+
+type calendarLinkRequest struct {
+	Days int `json:"days"`
+}
+
+type calendarLinkResponse struct {
+	Path     string `json:"path"`
+	Filename string `json:"filename"`
+}
+
+type calendarTokenPayload struct {
+	ChatID    int64 `json:"chat_id"`
+	Days      int   `json:"days"`
+	ExpiresAt int64 `json:"expires_at"`
+}
+
+func (h *Handler) calendarLink(w http.ResponseWriter, r *http.Request, identity Identity) error {
+	var request calendarLinkRequest
+	if err := decodeJSON(w, r, &request); err != nil || !validCalendarDays(request.Days) {
+		return badRequest("invalid_calendar_range")
+	}
+	profile, err := h.store.Profile(r.Context(), identity.UserID)
+	if store.IsNotFound(err) {
+		return conflict("location_required")
+	}
+	if err != nil {
+		return fmt.Errorf("load profile: %w", err)
+	}
+	location, err := time.LoadLocation(profile.Timezone)
+	if err != nil {
+		return fmt.Errorf("load profile timezone: %w", err)
+	}
+	token, err := signCalendarToken(h.botToken, calendarTokenPayload{
+		ChatID: identity.UserID, Days: request.Days,
+		ExpiresAt: h.now().Add(calendarTokenLifetime).Unix(),
+	})
+	if err != nil {
+		return fmt.Errorf("sign calendar token: %w", err)
+	}
+	return writeJSON(w, calendarLinkResponse{
+		Path:     "/api/miniapp/calendar.ics?token=" + url.QueryEscape(token),
+		Filename: calendarfile.Filename(h.now().In(location), request.Days),
+	})
+}
+
+func (h *Handler) calendarDownload(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "private, no-store")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	payload, err := verifyCalendarToken(h.botToken, r.URL.Query().Get("token"), h.now())
+	if err != nil {
+		http.Error(w, "invalid or expired calendar link", http.StatusUnauthorized)
+		return
+	}
+	chat, err := h.store.Chat(r.Context(), payload.ChatID)
+	if err != nil {
+		if !store.IsNotFound(err) {
+			h.logger.Error("Calendar export chat lookup failed", "error", err)
+		}
+		http.NotFound(w, r)
+		return
+	}
+	profile, err := h.store.Profile(r.Context(), payload.ChatID)
+	if err != nil {
+		if !store.IsNotFound(err) {
+			h.logger.Error("Calendar export profile lookup failed", "error", err)
+		}
+		http.NotFound(w, r)
+		return
+	}
+	location, err := time.LoadLocation(profile.Timezone)
+	if err != nil {
+		h.logger.Error("Calendar export timezone lookup failed", "timezone", profile.Timezone, "error", err)
+		http.Error(w, "calendar generation failed", http.StatusInternalServerError)
+		return
+	}
+	start := h.now().In(location)
+	data, err := calendarfile.Generate(
+		r.Context(), h.calculator, profile, i18n.Resolve(chat.LanguageCode), start, payload.Days, h.now(),
+	)
+	if err != nil {
+		h.logger.Error("Calendar export generation failed", "days", payload.Days, "error", err)
+		http.Error(w, "calendar generation failed", http.StatusInternalServerError)
+		return
+	}
+	filename := calendarfile.Filename(start, payload.Days)
+	w.Header().Set("Content-Type", "text/calendar; charset=utf-8")
+	w.Header().Set("Content-Disposition", `attachment; filename="`+filename+`"`)
+	w.Header().Set("Access-Control-Allow-Origin", "https://web.telegram.org")
+	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
+func signCalendarToken(secret string, payload calendarTokenPayload) (string, error) {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	aead, err := calendarTokenCipher(secret)
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return "", err
+	}
+	sealed := aead.Seal(nonce, nonce, data, []byte("global-prayer-calendar-v1"))
+	return base64.RawURLEncoding.EncodeToString(sealed), nil
+}
+
+func verifyCalendarToken(secret, token string, now time.Time) (calendarTokenPayload, error) {
+	sealed, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return calendarTokenPayload{}, fmt.Errorf("decode token")
+	}
+	aead, err := calendarTokenCipher(secret)
+	if err != nil || len(sealed) <= aead.NonceSize() {
+		return calendarTokenPayload{}, fmt.Errorf("malformed token")
+	}
+	nonce, ciphertext := sealed[:aead.NonceSize()], sealed[aead.NonceSize():]
+	data, err := aead.Open(nil, nonce, ciphertext, []byte("global-prayer-calendar-v1"))
+	if err != nil {
+		return calendarTokenPayload{}, fmt.Errorf("invalid token")
+	}
+	var payload calendarTokenPayload
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return calendarTokenPayload{}, fmt.Errorf("decode payload")
+	}
+	expiresAt := time.Unix(payload.ExpiresAt, 0)
+	if payload.ChatID <= 0 || !validCalendarDays(payload.Days) || !expiresAt.After(now) ||
+		expiresAt.After(now.Add(2*calendarTokenLifetime)) {
+		return calendarTokenPayload{}, fmt.Errorf("invalid payload")
+	}
+	return payload, nil
+}
+
+func calendarTokenCipher(secret string) (cipher.AEAD, error) {
+	key := sha256.Sum256([]byte("global-prayer-calendar-key-v1\x00" + secret))
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCM(block)
+}
+
+func validCalendarDays(days int) bool { return days == 7 || days == 30 }

--- a/global/internal/miniapp/handler.go
+++ b/global/internal/miniapp/handler.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/fs"
 	"log/slog"
+	"math"
 	"net/http"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/escalopa/prayer-bot/global/internal/i18n"
 	"github.com/escalopa/prayer-bot/global/internal/location"
 	"github.com/escalopa/prayer-bot/global/internal/prayertime"
+	"github.com/escalopa/prayer-bot/global/internal/qibla"
 	"github.com/escalopa/prayer-bot/global/internal/store"
 )
 
@@ -77,6 +79,8 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("PUT /api/miniapp/preferences", h.api(h.updatePreferences))
 	mux.HandleFunc("PUT /api/miniapp/settings", h.api(h.updateSettings))
 	mux.HandleFunc("PUT /api/miniapp/reminders", h.api(h.updateReminders))
+	mux.HandleFunc("POST /api/miniapp/calendar-link", h.api(h.calendarLink))
+	mux.HandleFunc("GET /api/miniapp/calendar.ics", h.calendarDownload)
 }
 
 type endpoint func(http.ResponseWriter, *http.Request, Identity) error
@@ -372,6 +376,7 @@ type bootstrapResponse struct {
 	Profile       *profileResponse  `json:"profile,omitempty"`
 	Today         *scheduleResponse `json:"today,omitempty"`
 	Tomorrow      *scheduleResponse `json:"tomorrow,omitempty"`
+	Qibla         *qiblaResponse    `json:"qibla,omitempty"`
 	Reminders     reminderResponse  `json:"reminders"`
 	Options       optionsResponse   `json:"options"`
 	Labels        map[string]string `json:"labels"`
@@ -403,6 +408,11 @@ type prayerResponse struct {
 	Name  string        `json:"name"`
 	Emoji string        `json:"emoji"`
 	Time  string        `json:"time"`
+}
+
+type qiblaResponse struct {
+	BearingDegrees     float64 `json:"bearing_degrees"`
+	DistanceKilometres int     `json:"distance_kilometres"`
 }
 
 type reminderResponse struct {
@@ -454,6 +464,14 @@ func (h *Handler) build(ctx context.Context, identity Identity) (bootstrapRespon
 		Timezone: profile.Timezone, Method: profile.Method, Madhab: profile.Madhab,
 		HighLatitudeRule: string(profile.HighLatitudeRule), HijriAdjustment: profile.HijriAdjustment,
 		Adjustments: adjustmentMap(profile.Adjustments),
+	}
+	direction, err := qibla.Calculate(profile.Latitude, profile.Longitude)
+	if err != nil {
+		return bootstrapResponse{}, fmt.Errorf("calculate Qibla direction: %w", err)
+	}
+	response.Qibla = &qiblaResponse{
+		BearingDegrees:     math.Round(direction.BearingDegrees*10) / 10,
+		DistanceKilometres: int(math.Round(direction.DistanceKilometres)),
 	}
 	response.LocationName = profile.Timezone
 	now := h.now()
@@ -647,22 +665,129 @@ func labels(locale i18n.Locale) map[string]string {
 		"open_in_telegram": copy.OpenInTelegram, "temporary_failure": copy.TemporaryFailure,
 		"calculated_locally": copy.CalculatedLocally, "companion": copy.Companion,
 		"update_location": copy.UpdateLocation,
+		"tools":           copy.Tools, "qibla_title": copy.QiblaTitle, "qibla_help": copy.QiblaHelp,
+		"qibla_bearing": copy.QiblaBearing, "qibla_distance": copy.QiblaDistance,
+		"compass_start": copy.CompassStart, "compass_active": copy.CompassActive,
+		"compass_unavailable": copy.CompassUnavailable,
+		"calendar_title":      copy.CalendarTitle, "calendar_help": copy.CalendarHelp,
+		"export_week": copy.ExportWeek, "export_month": copy.ExportMonth,
+		"export_preparing": copy.ExportPreparing, "export_ready": copy.ExportReady,
 	}
 }
 
 type miniAppCopy struct {
-	Save, Saved, Loading, LocationHelp, LocationError   string
-	OpenInTelegram, TemporaryFailure, CalculatedLocally string
-	Companion, UpdateLocation                           string
+	Save, Saved, Loading, LocationHelp, LocationError     string
+	OpenInTelegram, TemporaryFailure, CalculatedLocally   string
+	Companion, UpdateLocation                             string
+	Tools, QiblaTitle, QiblaHelp, QiblaBearing            string
+	QiblaDistance, CompassStart, CompassActive            string
+	CompassUnavailable, CalendarTitle, CalendarHelp       string
+	ExportWeek, ExportMonth, ExportPreparing, ExportReady string
 }
 
 var miniCopy = map[string]miniAppCopy{
-	"en": {"Save changes", "Saved", "Loading prayer times…", "Share your location to calculate accurate local prayer times.", "Location access failed. Check Telegram's location permission and try again.", "Open this page from the bot inside Telegram.", "Something went wrong. Please try again.", "Calculated locally for your saved timezone", "Prayer companion", "Update location"},
-	"ar": {"حفظ التغييرات", "تم الحفظ", "جارٍ تحميل مواقيت الصلاة…", "شارك موقعك لحساب مواقيت الصلاة المحلية بدقة.", "تعذر الوصول إلى الموقع. تحقق من إذن الموقع في تيليجرام وحاول مجددًا.", "افتح هذه الصفحة من داخل البوت في تيليجرام.", "حدث خطأ. حاول مرة أخرى.", "محسوبة محليًا حسب منطقتك الزمنية", "رفيق الصلاة", "تحديث الموقع"},
-	"es": {"Guardar cambios", "Guardado", "Cargando horarios de oración…", "Comparte tu ubicación para calcular horarios locales precisos.", "No se pudo obtener la ubicación. Revisa el permiso de Telegram e inténtalo de nuevo.", "Abre esta página desde el bot en Telegram.", "Algo salió mal. Inténtalo de nuevo.", "Calculado localmente para tu zona horaria", "Compañero de oración", "Actualizar ubicación"},
-	"fr": {"Enregistrer", "Enregistré", "Chargement des horaires de prière…", "Partagez votre position pour calculer des horaires locaux précis.", "Impossible d'accéder à la position. Vérifiez l'autorisation Telegram et réessayez.", "Ouvrez cette page depuis le bot dans Telegram.", "Une erreur est survenue. Réessayez.", "Calculé localement pour votre fuseau horaire", "Compagnon de prière", "Actualiser le lieu"},
-	"ru": {"Сохранить", "Сохранено", "Загружаем время намаза…", "Поделитесь геопозицией для точного расчёта местного времени намаза.", "Не удалось получить геопозицию. Проверьте разрешение Telegram и повторите попытку.", "Откройте эту страницу из бота в Telegram.", "Произошла ошибка. Попробуйте ещё раз.", "Рассчитано локально для вашего часового пояса", "Помощник для намаза", "Обновить геопозицию"},
-	"tr": {"Değişiklikleri kaydet", "Kaydedildi", "Namaz vakitleri yükleniyor…", "Doğru yerel namaz vakitleri için konumunuzu paylaşın.", "Konum alınamadı. Telegram konum iznini kontrol edip tekrar deneyin.", "Bu sayfayı Telegram içindeki bottan açın.", "Bir hata oluştu. Lütfen tekrar deneyin.", "Kayıtlı saat diliminiz için yerel olarak hesaplandı", "Namaz yardımcısı", "Konumu güncelle"},
-	"uz": {"O‘zgarishlarni saqlash", "Saqlandi", "Namoz vaqtlari yuklanmoqda…", "Aniq mahalliy namoz vaqtlari uchun joylashuvingizni ulashing.", "Joylashuv olinmadi. Telegram ruxsatini tekshirib, qayta urinib ko‘ring.", "Bu sahifani Telegram ichidagi botdan oching.", "Xatolik yuz berdi. Qayta urinib ko‘ring.", "Saqlangan vaqt mintaqangiz uchun mahalliy hisoblandi", "Namoz yordamchisi", "Joylashuvni yangilash"},
-	"tt": {"Үзгәрешләрне саклау", "Сакланды", "Намаз вакытлары йөкләнә…", "Төгәл җирле намаз вакытлары өчен урыныгызны бүлешегез.", "Урынны алып булмады. Telegram рөхсәтен тикшереп, кабатлап карагыз.", "Бу битне Telegram эчендәге боттан ачыгыз.", "Хата чыкты. Кабатлап карагыз.", "Сакланган сәгать поясы өчен җирле исәпләнде", "Намаз ярдәмчесе", "Урынны яңарту"},
+	"en": {
+		Save: "Save changes", Saved: "Saved", Loading: "Loading prayer times…",
+		LocationHelp:   "Share your location to calculate accurate local prayer times.",
+		LocationError:  "Location access failed. Check Telegram's location permission and try again.",
+		OpenInTelegram: "Open this page from the bot inside Telegram.", TemporaryFailure: "Something went wrong. Please try again.",
+		CalculatedLocally: "Calculated locally for your saved timezone", Companion: "Prayer companion", UpdateLocation: "Update location",
+		Tools: "Tools", QiblaTitle: "Qibla direction", QiblaHelp: "The arrow points from north toward the Kaaba.",
+		QiblaBearing: "{bearing}° from north", QiblaDistance: "Approximately {distance} km to the Kaaba",
+		CompassStart: "Use live compass", CompassActive: "Live compass active",
+		CompassUnavailable: "An absolute compass is unavailable on this device. Use the bearing above.",
+		CalendarTitle:      "Prayer calendar", CalendarHelp: "Export prayer times to Apple, Google, Outlook, or another calendar.",
+		ExportWeek: "Export 7 days", ExportMonth: "Export 30 days", ExportPreparing: "Preparing calendar…", ExportReady: "Calendar ready",
+	},
+	"ar": {
+		Save: "حفظ التغييرات", Saved: "تم الحفظ", Loading: "جارٍ تحميل مواقيت الصلاة…",
+		LocationHelp:   "شارك موقعك لحساب مواقيت الصلاة المحلية بدقة.",
+		LocationError:  "تعذر الوصول إلى الموقع. تحقق من إذن الموقع في تيليجرام وحاول مجددًا.",
+		OpenInTelegram: "افتح هذه الصفحة من داخل البوت في تيليجرام.", TemporaryFailure: "حدث خطأ. حاول مرة أخرى.",
+		CalculatedLocally: "محسوبة محليًا حسب منطقتك الزمنية", Companion: "رفيق الصلاة", UpdateLocation: "تحديث الموقع",
+		Tools: "الأدوات", QiblaTitle: "اتجاه القبلة", QiblaHelp: "يشير السهم من الشمال نحو الكعبة.",
+		QiblaBearing: "{bearing}° من الشمال", QiblaDistance: "حوالي {distance} كم إلى الكعبة",
+		CompassStart: "استخدام البوصلة المباشرة", CompassActive: "البوصلة المباشرة مفعّلة",
+		CompassUnavailable: "البوصلة المطلقة غير متاحة على هذا الجهاز. استخدم الزاوية الموضحة أعلاه.",
+		CalendarTitle:      "تقويم الصلاة", CalendarHelp: "صدّر مواقيت الصلاة إلى تقويم Apple أو Google أو Outlook أو أي تقويم آخر.",
+		ExportWeek: "تصدير 7 أيام", ExportMonth: "تصدير 30 يومًا", ExportPreparing: "جارٍ إعداد التقويم…", ExportReady: "التقويم جاهز",
+	},
+	"es": {
+		Save: "Guardar cambios", Saved: "Guardado", Loading: "Cargando horarios de oración…",
+		LocationHelp:   "Comparte tu ubicación para calcular horarios locales precisos.",
+		LocationError:  "No se pudo obtener la ubicación. Revisa el permiso de Telegram e inténtalo de nuevo.",
+		OpenInTelegram: "Abre esta página desde el bot en Telegram.", TemporaryFailure: "Algo salió mal. Inténtalo de nuevo.",
+		CalculatedLocally: "Calculado localmente para tu zona horaria", Companion: "Compañero de oración", UpdateLocation: "Actualizar ubicación",
+		Tools: "Herramientas", QiblaTitle: "Dirección de la alquibla", QiblaHelp: "La flecha apunta desde el norte hacia la Kaaba.",
+		QiblaBearing: "{bearing}° desde el norte", QiblaDistance: "Aproximadamente {distance} km hasta la Kaaba",
+		CompassStart: "Usar brújula en vivo", CompassActive: "Brújula en vivo activa",
+		CompassUnavailable: "Este dispositivo no ofrece una brújula absoluta. Usa el ángulo indicado arriba.",
+		CalendarTitle:      "Calendario de oración", CalendarHelp: "Exporta los horarios a Apple, Google, Outlook u otro calendario.",
+		ExportWeek: "Exportar 7 días", ExportMonth: "Exportar 30 días", ExportPreparing: "Preparando calendario…", ExportReady: "Calendario listo",
+	},
+	"fr": {
+		Save: "Enregistrer", Saved: "Enregistré", Loading: "Chargement des horaires de prière…",
+		LocationHelp:   "Partagez votre position pour calculer des horaires locaux précis.",
+		LocationError:  "Impossible d'accéder à la position. Vérifiez l'autorisation Telegram et réessayez.",
+		OpenInTelegram: "Ouvrez cette page depuis le bot dans Telegram.", TemporaryFailure: "Une erreur est survenue. Réessayez.",
+		CalculatedLocally: "Calculé localement pour votre fuseau horaire", Companion: "Compagnon de prière", UpdateLocation: "Actualiser le lieu",
+		Tools: "Outils", QiblaTitle: "Direction de la Qibla", QiblaHelp: "La flèche indique la direction de la Kaaba depuis le nord.",
+		QiblaBearing: "{bearing}° depuis le nord", QiblaDistance: "Environ {distance} km jusqu’à la Kaaba",
+		CompassStart: "Utiliser la boussole", CompassActive: "Boussole active",
+		CompassUnavailable: "La boussole absolue n’est pas disponible sur cet appareil. Utilisez l’angle ci-dessus.",
+		CalendarTitle:      "Calendrier des prières", CalendarHelp: "Exportez les horaires vers Apple, Google, Outlook ou un autre calendrier.",
+		ExportWeek: "Exporter 7 jours", ExportMonth: "Exporter 30 jours", ExportPreparing: "Préparation du calendrier…", ExportReady: "Calendrier prêt",
+	},
+	"ru": {
+		Save: "Сохранить", Saved: "Сохранено", Loading: "Загружаем время намаза…",
+		LocationHelp:   "Поделитесь геопозицией для точного расчёта местного времени намаза.",
+		LocationError:  "Не удалось получить геопозицию. Проверьте разрешение Telegram и повторите попытку.",
+		OpenInTelegram: "Откройте эту страницу из бота в Telegram.", TemporaryFailure: "Произошла ошибка. Попробуйте ещё раз.",
+		CalculatedLocally: "Рассчитано локально для вашего часового пояса", Companion: "Помощник для намаза", UpdateLocation: "Обновить геопозицию",
+		Tools: "Инструменты", QiblaTitle: "Направление Кыблы", QiblaHelp: "Стрелка показывает направление от севера к Каабе.",
+		QiblaBearing: "{bearing}° от севера", QiblaDistance: "Примерно {distance} км до Каабы",
+		CompassStart: "Включить компас", CompassActive: "Компас включён",
+		CompassUnavailable: "Абсолютный компас недоступен на этом устройстве. Используйте угол выше.",
+		CalendarTitle:      "Календарь намаза", CalendarHelp: "Экспортируйте время намаза в Apple, Google, Outlook или другой календарь.",
+		ExportWeek: "Экспорт на 7 дней", ExportMonth: "Экспорт на 30 дней", ExportPreparing: "Готовим календарь…", ExportReady: "Календарь готов",
+	},
+	"tr": {
+		Save: "Değişiklikleri kaydet", Saved: "Kaydedildi", Loading: "Namaz vakitleri yükleniyor…",
+		LocationHelp:   "Doğru yerel namaz vakitleri için konumunuzu paylaşın.",
+		LocationError:  "Konum alınamadı. Telegram konum iznini kontrol edip tekrar deneyin.",
+		OpenInTelegram: "Bu sayfayı Telegram içindeki bottan açın.", TemporaryFailure: "Bir hata oluştu. Lütfen tekrar deneyin.",
+		CalculatedLocally: "Kayıtlı saat diliminiz için yerel olarak hesaplandı", Companion: "Namaz yardımcısı", UpdateLocation: "Konumu güncelle",
+		Tools: "Araçlar", QiblaTitle: "Kıble yönü", QiblaHelp: "Ok, kuzeyden Kâbe’ye doğru yönü gösterir.",
+		QiblaBearing: "Kuzeyden {bearing}°", QiblaDistance: "Kâbe’ye yaklaşık {distance} km",
+		CompassStart: "Canlı pusulayı kullan", CompassActive: "Canlı pusula etkin",
+		CompassUnavailable: "Bu cihazda mutlak pusula kullanılamıyor. Yukarıdaki açıyı kullanın.",
+		CalendarTitle:      "Namaz takvimi", CalendarHelp: "Namaz vakitlerini Apple, Google, Outlook veya başka bir takvime aktarın.",
+		ExportWeek: "7 günü aktar", ExportMonth: "30 günü aktar", ExportPreparing: "Takvim hazırlanıyor…", ExportReady: "Takvim hazır",
+	},
+	"uz": {
+		Save: "O‘zgarishlarni saqlash", Saved: "Saqlandi", Loading: "Namoz vaqtlari yuklanmoqda…",
+		LocationHelp:   "Aniq mahalliy namoz vaqtlari uchun joylashuvingizni ulashing.",
+		LocationError:  "Joylashuv olinmadi. Telegram ruxsatini tekshirib, qayta urinib ko‘ring.",
+		OpenInTelegram: "Bu sahifani Telegram ichidagi botdan oching.", TemporaryFailure: "Xatolik yuz berdi. Qayta urinib ko‘ring.",
+		CalculatedLocally: "Saqlangan vaqt mintaqangiz uchun mahalliy hisoblandi", Companion: "Namoz yordamchisi", UpdateLocation: "Joylashuvni yangilash",
+		Tools: "Vositalar", QiblaTitle: "Qibla yo‘nalishi", QiblaHelp: "Ko‘rsatkich shimoldan Ka’ba tomon yo‘naladi.",
+		QiblaBearing: "Shimoldan {bearing}°", QiblaDistance: "Ka’bagacha taxminan {distance} km",
+		CompassStart: "Jonli kompasni yoqish", CompassActive: "Jonli kompas faol",
+		CompassUnavailable: "Bu qurilmada mutlaq kompas mavjud emas. Yuqoridagi burchakdan foydalaning.",
+		CalendarTitle:      "Namoz taqvimi", CalendarHelp: "Namoz vaqtlarini Apple, Google, Outlook yoki boshqa taqvimga eksport qiling.",
+		ExportWeek: "7 kunni eksport qilish", ExportMonth: "30 kunni eksport qilish", ExportPreparing: "Taqvim tayyorlanmoqda…", ExportReady: "Taqvim tayyor",
+	},
+	"tt": {
+		Save: "Үзгәрешләрне саклау", Saved: "Сакланды", Loading: "Намаз вакытлары йөкләнә…",
+		LocationHelp:   "Төгәл җирле намаз вакытлары өчен урыныгызны бүлешегез.",
+		LocationError:  "Урынны алып булмады. Telegram рөхсәтен тикшереп, кабатлап карагыз.",
+		OpenInTelegram: "Бу битне Telegram эчендәге боттан ачыгыз.", TemporaryFailure: "Хата чыкты. Кабатлап карагыз.",
+		CalculatedLocally: "Сакланган сәгать поясы өчен җирле исәпләнде", Companion: "Намаз ярдәмчесе", UpdateLocation: "Урынны яңарту",
+		Tools: "Кораллар", QiblaTitle: "Кыйбла юнәлеше", QiblaHelp: "Ук төньяктан Кәгъбә ягына юнәлешне күрсәтә.",
+		QiblaBearing: "Төньяктан {bearing}°", QiblaDistance: "Кәгъбәгә якынча {distance} км",
+		CompassStart: "Тере компасны кабызу", CompassActive: "Тере компас эшли",
+		CompassUnavailable: "Бу җайланмада абсолют компас юк. Өстәге почмакны кулланыгыз.",
+		CalendarTitle:      "Намаз календаре", CalendarHelp: "Намаз вакытларын Apple, Google, Outlook яки башка календарьга чыгарыгыз.",
+		ExportWeek: "7 көнне чыгару", ExportMonth: "30 көнне чыгару", ExportPreparing: "Календарь әзерләнә…", ExportReady: "Календарь әзер",
+	},
 }

--- a/global/internal/miniapp/handler_test.go
+++ b/global/internal/miniapp/handler_test.go
@@ -42,6 +42,10 @@ func TestStaticMiniAppIsEmbeddedWithSecurityHeaders(t *testing.T) {
 	if !strings.Contains(string(script), "tgWebAppData") || !strings.Contains(string(script), "/api/miniapp/preferences") {
 		t.Fatal("Mini App script is missing resilient Telegram launch data or unified preference saving")
 	}
+	if !strings.Contains(html, "qibla-compass") || !strings.Contains(html, "export-month") ||
+		!strings.Contains(string(script), "DeviceOrientation") || !strings.Contains(string(script), "downloadFile") {
+		t.Fatal("Mini App is missing Qibla compass or native calendar export support")
+	}
 	if !strings.Contains(response.Header().Get("Content-Security-Policy"), "telegram.org") {
 		t.Fatal("Mini App response is missing its CSP")
 	}
@@ -152,8 +156,82 @@ func TestLocationUpdatePreservesCalculationSettingsAndRoundsCoordinates(t *testi
 	if err := json.Unmarshal(response.Body.Bytes(), &data); err != nil {
 		t.Fatal(err)
 	}
-	if data.LocationName != "Cairo" || data.Today == nil || data.Tomorrow == nil {
+	if data.LocationName != "Cairo" || data.Today == nil || data.Tomorrow == nil || data.Qibla == nil {
 		t.Fatalf("unexpected response: %+v", data)
+	}
+	if data.Qibla.BearingDegrees < 135 || data.Qibla.BearingDegrees > 137 || data.Qibla.DistanceKilometres < 1250 {
+		t.Fatalf("unexpected Qibla result: %+v", data.Qibla)
+	}
+}
+
+func TestCalendarExportUsesShortLivedSignedDownload(t *testing.T) {
+	now := time.Date(2026, time.July, 17, 12, 0, 0, 0, time.UTC)
+	storage := newFakeStorage()
+	storage.chats[42] = domain.Chat{TelegramChatID: 42, Type: "private", LanguageCode: "en"}
+	storage.profiles[42] = domain.PrayerProfile{
+		ChatID: 42, Latitude: 30.044, Longitude: 31.236, Timezone: "Africa/Cairo",
+		Method: domain.MethodEgyptian, Madhab: domain.MadhabShafii,
+		HighLatitudeRule: domain.HighLatitudeAngleBased,
+	}
+	handler := NewHandler("test-token", storage, nil, prayertime.New(), nil, nil)
+	handler.now = func() time.Time { return now }
+	mux := http.NewServeMux()
+	handler.Register(mux)
+
+	linkRequest := httptest.NewRequest(http.MethodPost, "/api/miniapp/calendar-link", strings.NewReader(`{"days":7}`))
+	linkRequest.Header.Set("X-Telegram-Init-Data", signedInitData(t, "test-token", now, initDataUser{
+		ID: 42, FirstName: "Amina", LanguageCode: "en",
+	}))
+	linkResponse := httptest.NewRecorder()
+	mux.ServeHTTP(linkResponse, linkRequest)
+	if linkResponse.Code != http.StatusOK {
+		t.Fatalf("link status = %d, body = %s", linkResponse.Code, linkResponse.Body.String())
+	}
+	var link calendarLinkResponse
+	if err := json.Unmarshal(linkResponse.Body.Bytes(), &link); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(link.Path, "/api/miniapp/calendar.ics?token=") ||
+		link.Filename != "prayer-times-2026-07-17-7-days.ics" {
+		t.Fatalf("unexpected calendar link: %+v", link)
+	}
+
+	downloadRequest := httptest.NewRequest(http.MethodGet, link.Path, nil)
+	downloadResponse := httptest.NewRecorder()
+	mux.ServeHTTP(downloadResponse, downloadRequest)
+	if downloadResponse.Code != http.StatusOK {
+		t.Fatalf("download status = %d, body = %s", downloadResponse.Code, downloadResponse.Body.String())
+	}
+	if contentType := downloadResponse.Header().Get("Content-Type"); !strings.HasPrefix(contentType, "text/calendar") {
+		t.Fatalf("content type = %q", contentType)
+	}
+	if disposition := downloadResponse.Header().Get("Content-Disposition"); !strings.Contains(disposition, link.Filename) {
+		t.Fatalf("content disposition = %q", disposition)
+	}
+	if downloadResponse.Header().Get("Access-Control-Allow-Origin") != "https://web.telegram.org" {
+		t.Fatal("calendar response is missing Telegram Web download CORS header")
+	}
+	if events := strings.Count(downloadResponse.Body.String(), "BEGIN:VEVENT\r\n"); events != 42 {
+		t.Fatalf("calendar event count = %d, want 42", events)
+	}
+}
+
+func TestCalendarTokensRejectTamperingAndExpiry(t *testing.T) {
+	now := time.Date(2026, time.July, 17, 12, 0, 0, 0, time.UTC)
+	token, err := signCalendarToken("secret", calendarTokenPayload{
+		ChatID: 42, Days: 30, ExpiresAt: now.Add(calendarTokenLifetime).Unix(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if payload, err := verifyCalendarToken("secret", token, now); err != nil || payload.ChatID != 42 || payload.Days != 30 {
+		t.Fatalf("valid token failed: payload=%+v err=%v", payload, err)
+	}
+	if _, err := verifyCalendarToken("secret", token+"x", now); err == nil {
+		t.Fatal("tampered token was accepted")
+	}
+	if _, err := verifyCalendarToken("secret", token, now.Add(calendarTokenLifetime)); err == nil {
+		t.Fatal("expired token was accepted")
 	}
 }
 

--- a/global/internal/miniapp/static/app.css
+++ b/global/internal/miniapp/static/app.css
@@ -131,6 +131,87 @@ button { -webkit-tap-highlight-color: transparent; }
 .panel-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 10px; }
 .panel-heading h2 { margin: 3px 0 0; font-size: 19px; letter-spacing: -.02em; }
 
+.tools-panel { padding-bottom: 18px; }
+.tool-grid { display: grid; gap: 12px; }
+.tool-card {
+  position: relative;
+  min-width: 0;
+  padding: 17px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 20px;
+  background: color-mix(in srgb, var(--surface-alt) 58%, var(--surface));
+}
+.tool-card::before {
+  position: absolute;
+  width: 130px;
+  height: 130px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--accent) 9%, transparent);
+  content: "";
+  inset: -70px -55px auto auto;
+  pointer-events: none;
+}
+[dir="rtl"] .tool-card::before { right: auto; left: -55px; }
+.tool-heading { position: relative; z-index: 1; display: flex; align-items: flex-start; gap: 10px; }
+.tool-heading h3 { margin: 1px 0 4px; font-size: 16px; letter-spacing: -.015em; }
+.tool-heading p { margin: 0; color: var(--app-muted); font-size: 11px; line-height: 1.45; }
+.tool-icon { display: grid; place-items: center; width: 34px; height: 34px; flex: 0 0 34px; border-radius: 11px; background: var(--surface); font-size: 17px; box-shadow: 0 5px 15px rgba(25, 57, 45, .07); }
+
+.qibla-compass {
+  position: relative;
+  width: 190px;
+  height: 190px;
+  margin: 19px auto 13px;
+  border: 1px solid color-mix(in srgb, var(--accent) 25%, var(--line));
+  border-radius: 50%;
+  background:
+    radial-gradient(circle, transparent 0 31%, color-mix(in srgb, var(--accent) 9%, transparent) 32% 33%, transparent 34%),
+    repeating-conic-gradient(from -1deg, color-mix(in srgb, var(--app-muted) 34%, transparent) 0deg 1deg, transparent 1deg 15deg),
+    radial-gradient(circle, var(--surface) 0 67%, color-mix(in srgb, var(--accent) 8%, var(--surface-alt)) 68%);
+  box-shadow: inset 0 0 0 10px color-mix(in srgb, var(--surface) 82%, transparent), 0 12px 30px rgba(25, 57, 45, .08);
+}
+.cardinal { position: absolute; z-index: 2; color: var(--app-muted); font-size: 10px; font-weight: 850; }
+.cardinal-north { top: 10px; left: 50%; color: var(--accent); transform: translateX(-50%); }
+.cardinal-east { top: 50%; right: 11px; transform: translateY(-50%); }
+.cardinal-south { bottom: 9px; left: 50%; transform: translateX(-50%); }
+.cardinal-west { top: 50%; left: 11px; transform: translateY(-50%); }
+.qibla-needle {
+  position: absolute;
+  z-index: 1;
+  top: 20px;
+  right: 20px;
+  bottom: 20px;
+  left: 20px;
+  transform: rotate(var(--qibla-rotation, 0deg));
+  transition: transform .28s ease-out;
+}
+.needle-arrow { position: absolute; top: -3px; left: 50%; color: #bf8b25; font-size: 23px; line-height: 1; transform: translateX(-50%); filter: drop-shadow(0 2px 3px rgba(100, 71, 13, .25)); }
+.needle-kaaba { position: absolute; top: 20px; left: 50%; font-size: 18px; transform: translateX(-50%); }
+.qibla-needle::after { position: absolute; top: 43px; bottom: 50%; left: calc(50% - 1px); width: 2px; border-radius: 2px; background: linear-gradient(#c49330, color-mix(in srgb, var(--accent) 45%, transparent)); content: ""; }
+.compass-center { position: absolute; z-index: 3; top: 50%; left: 50%; width: 14px; height: 14px; border: 4px solid var(--surface); border-radius: 50%; background: var(--accent); box-shadow: 0 2px 8px rgba(0,0,0,.18); transform: translate(-50%, -50%); }
+.tool-value { margin: 0; font-size: 18px; font-weight: 850; text-align: center; }
+.tool-note { margin: 5px 0 13px; color: var(--app-muted); font-size: 11px; line-height: 1.4; text-align: center; }
+
+.calendar-card { display: flex; flex-direction: column; }
+.calendar-illustration {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 126px;
+  height: 112px;
+  margin: 24px auto 25px;
+  border: 1px solid var(--line);
+  border-radius: 19px;
+  color: var(--app-text);
+  background: var(--surface);
+  box-shadow: 0 14px 28px rgba(25, 57, 45, .09);
+}
+.calendar-illustration::before { position: absolute; top: 0; right: 0; left: 0; height: 29px; border-radius: 18px 18px 0 0; background: var(--accent); content: ""; }
+.calendar-illustration span { position: absolute; z-index: 1; top: 4px; left: 13px; color: #fff8d6; font: 700 22px/1 Georgia, serif; }
+.calendar-illustration strong { margin-top: 24px; font-size: 38px; letter-spacing: -.05em; }
+.calendar-actions { display: grid; gap: 9px; margin-top: auto; }
+
 .toggle-row { position: relative; display: flex; align-items: center; justify-content: space-between; gap: 16px; min-height: 68px; border-bottom: 1px solid var(--line); cursor: pointer; }
 .toggle-row:last-child { border-bottom: 0; }
 .toggle-row strong, .toggle-row small { display: block; }
@@ -170,6 +251,9 @@ select:focus, input[type="number"]:focus { border-color: var(--accent); box-shad
 
 .primary-button { width: 100%; min-height: 50px; padding: 0 18px; border: 0; border-radius: 16px; color: var(--accent-text); background: var(--accent); font-weight: 800; cursor: pointer; box-shadow: 0 10px 24px color-mix(in srgb, var(--accent) 24%, transparent); }
 .primary-button:disabled { opacity: .55; cursor: wait; }
+.primary-button.compact { min-height: 44px; border-radius: 14px; box-shadow: none; font-size: 13px; }
+.secondary-button { width: 100%; min-height: 44px; padding: 0 14px; border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--line)); border-radius: 14px; color: var(--accent); background: color-mix(in srgb, var(--accent) 7%, var(--surface)); font-size: 13px; font-weight: 800; cursor: pointer; }
+.secondary-button:disabled { opacity: .55; cursor: wait; }
 .text-button { padding: 8px 0; border: 0; color: var(--accent); background: transparent; font-size: 12px; font-weight: 750; cursor: pointer; }
 
 .save-bar {
@@ -187,6 +271,7 @@ select:focus, input[type="number"]:focus { border-color: var(--accent); box-shad
 @media (min-width: 560px) {
   .app-shell { padding-inline: 24px; }
   .form-grid { grid-template-columns: 1fr 1fr; }
+  .tool-grid { grid-template-columns: 1fr 1fr; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/global/internal/miniapp/static/app.js
+++ b/global/internal/miniapp/static/app.js
@@ -7,6 +7,7 @@
   let activeDay = "today";
   let toastTimer = null;
   let dirty = false;
+  let compassStarted = false;
 
   const launchCopy = {
     en: { open: "Open this page from the bot inside Telegram.", expired: "Your Telegram session expired. Close this window and reopen the app from the bot menu.", failed: "The app could not load. Please try again.", retry: "Try again" },
@@ -107,6 +108,14 @@
     setText("adjustments-label", labels.adjustments);
     setText("save-preferences", labels.save);
     setText("calculation-note", labels.calculated_locally);
+    setText("tools-title", labels.tools);
+    setText("qibla-title", labels.qibla_title);
+    setText("qibla-help", labels.qibla_help);
+    setText("start-compass", labels.compass_start);
+    setText("calendar-title", labels.calendar_title);
+    setText("calendar-help", labels.calendar_help);
+    setText("export-week", labels.export_week);
+    setText("export-month", labels.export_month);
   }
 
   function fillSelect(id, options, selected) {
@@ -174,6 +183,29 @@
     });
   }
 
+  function formatLabel(template, values) {
+    return Object.entries(values).reduce(
+      (result, [key, value]) => result.replaceAll(`{${key}}`, String(value)),
+      template || "",
+    );
+  }
+
+  function renderTools() {
+    if (!state.qibla) return;
+    const bearing = Number(state.qibla.bearing_degrees);
+    const number = new Intl.NumberFormat(state.locale, { maximumFractionDigits: 1 });
+    byId("qibla-needle").style.setProperty("--qibla-rotation", `${bearing}deg`);
+    setText("qibla-bearing", formatLabel(state.labels.qibla_bearing, { bearing: number.format(bearing) }));
+    setText("qibla-distance", formatLabel(state.labels.qibla_distance, {
+      distance: new Intl.NumberFormat(state.locale).format(state.qibla.distance_kilometres),
+    }));
+    byId("qibla-compass").setAttribute("aria-label", byId("qibla-bearing").textContent);
+    compassStarted = false;
+    byId("start-compass").disabled = false;
+    setText("start-compass", state.labels.compass_start);
+    byId("compass-status").classList.add("hidden");
+  }
+
   function renderReminders() {
     byId("prayer-reminders").checked = state.reminders.prayer;
     fillSelect("pre-prayer-minutes", state.options.pre_reminders, state.reminders.pre_prayer_minutes);
@@ -201,6 +233,7 @@
     locationGate.classList.add("hidden");
     dashboard.classList.remove("hidden");
     renderSchedule();
+    renderTools();
     renderReminders();
     renderSettings();
     setDirty(false);
@@ -321,6 +354,84 @@
     }
   }
 
+  function showCompassUnavailable() {
+    const sensor = telegram && telegram.DeviceOrientation;
+    if (sensor && sensor.isStarted) sensor.stop();
+    compassStarted = false;
+    setText("compass-status", state.labels.compass_unavailable);
+    byId("compass-status").classList.remove("hidden");
+    byId("start-compass").disabled = false;
+    setText("start-compass", state.labels.compass_start);
+  }
+
+  function updateCompassOrientation() {
+    const sensor = telegram && telegram.DeviceOrientation;
+    if (!state || !state.qibla || !sensor || !sensor.isStarted) return;
+    if (!sensor.absolute || !Number.isFinite(sensor.alpha)) {
+      showCompassUnavailable();
+      return;
+    }
+    // Telegram exposes the standard positive Z-axis rotation. Convert it to
+    // the clockwise compass heading used by bearings from magnetic north.
+    const alpha = ((sensor.alpha * 180 / Math.PI) % 360 + 360) % 360;
+    const heading = (360 - alpha) % 360;
+    const rotation = Number(state.qibla.bearing_degrees) - heading;
+    byId("qibla-needle").style.setProperty("--qibla-rotation", `${rotation}deg`);
+    if (!compassStarted) {
+      compassStarted = true;
+      setText("start-compass", state.labels.compass_active);
+      setText("compass-status", state.labels.compass_active);
+      byId("compass-status").classList.remove("hidden");
+      byId("start-compass").disabled = true;
+      if (telegram.HapticFeedback) telegram.HapticFeedback.notificationOccurred("success");
+    }
+  }
+
+  function startCompass() {
+    const sensor = telegram && telegram.DeviceOrientation;
+    if (!sensor || !telegram.isVersionAtLeast("8.0")) {
+      showCompassUnavailable();
+      return;
+    }
+    byId("start-compass").disabled = true;
+    sensor.start({ refresh_rate: 100, need_absolute: true }, (started) => {
+      if (!started) showCompassUnavailable();
+    });
+  }
+
+  function fallbackDownload(url, filename) {
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    link.rel = "noopener";
+    document.body.append(link);
+    link.click();
+    link.remove();
+    showToast(state.labels.export_ready);
+  }
+
+  async function exportCalendar(days, button) {
+    button.disabled = true;
+    const previousText = button.textContent;
+    button.textContent = state.labels.export_preparing;
+    try {
+      const download = await request("/api/miniapp/calendar-link", "POST", { days });
+      const fileURL = new URL(download.path, window.location.origin).href;
+      if (telegram && telegram.downloadFile && telegram.isVersionAtLeast("8.0") && fileURL.startsWith("https://")) {
+        telegram.downloadFile({ url: fileURL, file_name: download.filename }, (accepted) => {
+          if (accepted) showToast(state.labels.export_ready);
+        });
+      } else {
+        fallbackDownload(fileURL, download.filename);
+      }
+    } catch (_) {
+      showToast(state.labels.temporary_failure, true);
+    } finally {
+      button.disabled = false;
+      button.textContent = previousText;
+    }
+  }
+
   function showLaunchError(kind) {
     const copy = launchCopy[launchLanguage()] || launchCopy.en;
     loading.classList.add("hidden");
@@ -361,6 +472,9 @@
   byId("tomorrow-tab").addEventListener("click", () => selectDay("tomorrow"));
   byId("location-primary").addEventListener("click", (event) => updateLocation(event.currentTarget));
   byId("location-secondary").addEventListener("click", (event) => updateLocation(event.currentTarget));
+  byId("start-compass").addEventListener("click", startCompass);
+  byId("export-week").addEventListener("click", (event) => exportCalendar(7, event.currentTarget));
+  byId("export-month").addEventListener("click", (event) => exportCalendar(30, event.currentTarget));
   byId("save-preferences").addEventListener("click", savePreferences);
   byId("retry-app").addEventListener("click", bootstrapApp);
   ["prayer-reminders", "pre-prayer-minutes", "fasting-reminders", "kahf-reminders", "language", "method", "madhab", "highlat", "hijri-adjustment"]
@@ -370,6 +484,14 @@
   window.addEventListener("pageshow", (event) => {
     if (event.persisted) bootstrapApp();
   });
+  window.addEventListener("pagehide", () => {
+    const sensor = telegram && telegram.DeviceOrientation;
+    if (sensor && sensor.isStarted) sensor.stop();
+  });
+  if (telegram && telegram.onEvent) {
+    telegram.onEvent("deviceOrientationChanged", updateCompassOrientation);
+    telegram.onEvent("deviceOrientationFailed", showCompassUnavailable);
+  }
 
   bootstrapApp();
 })();

--- a/global/internal/miniapp/static/index.html
+++ b/global/internal/miniapp/static/index.html
@@ -58,6 +58,59 @@
         </article>
       </section>
 
+      <section class="panel tools-panel">
+        <div class="panel-heading">
+          <h2 id="tools-title">Tools</h2>
+        </div>
+
+        <div class="tool-grid">
+          <article class="tool-card qibla-card">
+            <div class="tool-heading">
+              <span class="tool-icon" aria-hidden="true">🕋</span>
+              <div>
+                <h3 id="qibla-title">Qibla direction</h3>
+                <p id="qibla-help">The arrow points from north toward the Kaaba.</p>
+              </div>
+            </div>
+
+            <div id="qibla-compass" class="qibla-compass" role="img" aria-labelledby="qibla-bearing">
+              <span class="cardinal cardinal-north">N</span>
+              <span class="cardinal cardinal-east">E</span>
+              <span class="cardinal cardinal-south">S</span>
+              <span class="cardinal cardinal-west">W</span>
+              <div id="qibla-needle" class="qibla-needle" aria-hidden="true">
+                <span class="needle-arrow">▲</span>
+                <span class="needle-kaaba">🕋</span>
+              </div>
+              <span class="compass-center" aria-hidden="true"></span>
+            </div>
+
+            <p id="qibla-bearing" class="tool-value"></p>
+            <p id="qibla-distance" class="tool-note"></p>
+            <button id="start-compass" class="secondary-button" type="button">Use live compass</button>
+            <p id="compass-status" class="tool-note hidden" role="status"></p>
+          </article>
+
+          <article class="tool-card calendar-card">
+            <div class="tool-heading">
+              <span class="tool-icon" aria-hidden="true">📅</span>
+              <div>
+                <h3 id="calendar-title">Prayer calendar</h3>
+                <p id="calendar-help">Export prayer times to your calendar.</p>
+              </div>
+            </div>
+            <div class="calendar-illustration" aria-hidden="true">
+              <span>☾</span>
+              <strong id="calendar-day">30</strong>
+            </div>
+            <div class="calendar-actions">
+              <button id="export-week" class="secondary-button" type="button" data-days="7">Export 7 days</button>
+              <button id="export-month" class="primary-button compact" type="button" data-days="30">Export 30 days</button>
+            </div>
+          </article>
+        </div>
+      </section>
+
       <section class="panel">
         <div class="panel-heading">
           <h2 id="reminders-title">Reminders</h2>

--- a/global/internal/qibla/qibla.go
+++ b/global/internal/qibla/qibla.go
@@ -1,0 +1,46 @@
+package qibla
+
+import (
+	"fmt"
+	"math"
+)
+
+const (
+	kaabaLatitude  = 21.4225
+	kaabaLongitude = 39.8262
+	earthRadiusKM  = 6371.0088
+)
+
+type Result struct {
+	BearingDegrees     float64
+	DistanceKilometres float64
+}
+
+// Calculate returns the initial great-circle bearing from the supplied
+// coordinates to the Kaaba and the corresponding surface distance.
+func Calculate(latitude, longitude float64) (Result, error) {
+	if latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180 {
+		return Result{}, fmt.Errorf("invalid coordinates")
+	}
+
+	latitudeRadians := degreesToRadians(latitude)
+	kaabaLatitudeRadians := degreesToRadians(kaabaLatitude)
+	longitudeDelta := degreesToRadians(kaabaLongitude - longitude)
+
+	y := math.Sin(longitudeDelta) * math.Cos(kaabaLatitudeRadians)
+	x := math.Cos(latitudeRadians)*math.Sin(kaabaLatitudeRadians) -
+		math.Sin(latitudeRadians)*math.Cos(kaabaLatitudeRadians)*math.Cos(longitudeDelta)
+	bearing := math.Mod(radiansToDegrees(math.Atan2(y, x))+360, 360)
+
+	latitudeDelta := kaabaLatitudeRadians - latitudeRadians
+	haversine := math.Sin(latitudeDelta/2)*math.Sin(latitudeDelta/2) +
+		math.Cos(latitudeRadians)*math.Cos(kaabaLatitudeRadians)*
+			math.Sin(longitudeDelta/2)*math.Sin(longitudeDelta/2)
+	haversine = math.Max(0, math.Min(1, haversine))
+	distance := 2 * earthRadiusKM * math.Asin(math.Sqrt(haversine))
+
+	return Result{BearingDegrees: bearing, DistanceKilometres: distance}, nil
+}
+
+func degreesToRadians(value float64) float64 { return value * math.Pi / 180 }
+func radiansToDegrees(value float64) float64 { return value * 180 / math.Pi }

--- a/global/internal/qibla/qibla_test.go
+++ b/global/internal/qibla/qibla_test.go
@@ -1,0 +1,42 @@
+package qibla
+
+import (
+	"math"
+	"testing"
+)
+
+func TestCalculateKnownBearings(t *testing.T) {
+	tests := []struct {
+		name                string
+		latitude, longitude float64
+		wantBearing         float64
+		wantDistance        float64
+	}{
+		{name: "Cairo", latitude: 30.0444, longitude: 31.2357, wantBearing: 136.1, wantDistance: 1287},
+		{name: "London", latitude: 51.5074, longitude: -0.1278, wantBearing: 118.9, wantDistance: 4794},
+		{name: "New York", latitude: 40.7128, longitude: -74.0060, wantBearing: 58.5, wantDistance: 10307},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := Calculate(test.latitude, test.longitude)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if math.Abs(result.BearingDegrees-test.wantBearing) > 0.6 {
+				t.Fatalf("bearing = %.2f, want approximately %.2f", result.BearingDegrees, test.wantBearing)
+			}
+			if math.Abs(result.DistanceKilometres-test.wantDistance) > 15 {
+				t.Fatalf("distance = %.2f, want approximately %.2f", result.DistanceKilometres, test.wantDistance)
+			}
+		})
+	}
+}
+
+func TestCalculateRejectsInvalidCoordinates(t *testing.T) {
+	if _, err := Calculate(91, 0); err == nil {
+		t.Fatal("expected invalid latitude to fail")
+	}
+	if _, err := Calculate(0, -181); err == nil {
+		t.Fatal("expected invalid longitude to fail")
+	}
+}


### PR DESCRIPTION
## What changed

- adds a localized Qibla tool to the Telegram Mini App
  - calculates the initial great-circle bearing and distance to the Kaaba from the saved profile coordinates
  - supports Telegram's absolute device-orientation API for a live compass, with a numeric/static fallback
- adds localized 7-day and 30-day prayer-calendar exports
  - generates portable iCalendar (`.ics`) files for the six daily prayer/sunrise events
  - uses short-lived encrypted and authenticated download links
  - keeps Telegram IDs out of exported event UIDs and URLs
  - supports Telegram's native file-download flow and a browser fallback
- adds unit/integration coverage and architecture documentation

## Operational impact

- no database migration or schema change
- no Terraform or workflow change
- no new Cloud Run service, secret, external API, or recurring job
- calculations reuse the existing saved profile and prayer-time engine

## Validation

- `go test ./...`
- `go test -race ./internal/...`
- `go vet ./...`
- `node --check internal/miniapp/static/app.js`
- `terraform -chdir=infra/gcp fmt -check -recursive`
- `git diff --check`
- Mini App visually inspected at mobile width
