### PR TITLE
[codex] Add rolling Google Calendar subscriptions

### DIFF
--- a/global/README.md
+++ b/global/README.md
@@ -25,7 +25,7 @@ in the same pull request.
 - Configurable pre-prayer reminders at 5, 10, 15, 20, 30, 45, or 60 minutes before each obligatory prayer, followed by the normal prayer-time notification.
 - Category-aware notification cleanup: a new prayer notice replaces the preceding prayer/pre-prayer message, weekly categories are independent, and every reminder expires within Telegram's deletion window.
 - A Qibla tool that calculates the initial great-circle bearing and distance to the Kaaba from the saved rounded coordinates, with optional live compass orientation on supported Telegram clients.
-- Localized 7-day and 30-day prayer-calendar exports in standard `.ics` format for Apple Calendar, Google Calendar, Outlook, and other compatible clients.
+- A revocable private Google Calendar subscription that serves a localized rolling 30-day prayer feed and automatically reflects the saved location and calculation settings when Google refreshes it.
 - An embedded welcome illustration sent on `/start` and a generated bot avatar installed during profile synchronization.
 - A localized feedback and bug-report flow that accepts text or screenshots in a private chat and delivers them directly to the configured owner with the sender's disclosed Telegram identity.
 - An owner-only `/admin` dashboard with aggregate user activity, onboarding, language, calculation-method, reminder-adoption, queue, and delivery-health metrics.
@@ -52,7 +52,7 @@ Feedback arrives in the owner's private bot chat as a metadata message followed 
 
 The three services use one immutable image and select `/webhook`, `/dispatch`, or `/send` as the command. The webhook binary embeds the Mini App and serves it at `/app/`, so the feature does not add another Cloud Run service, container image, database, migration, or secret.
 
-Calendar downloads use a short-lived, encrypted and authenticated URL created only after the Mini App session has been authenticated. The link expires after five minutes and exposes neither the Telegram user ID nor the bot token. Qibla calculations and calendar generation use the existing saved profile and prayer engine, so neither feature adds an external API call or recurring job.
+Calendar subscriptions use a random private bearer URL created only after the Mini App session has been authenticated. The URL exposes neither the Telegram user ID nor the bot token and can be revoked from the Mini App. Each fetch calculates today and the following 29 local days, so no daily cron or stored calendar events are required. Google controls when subscribed calendars refresh, so updates are not guaranteed to appear exactly at local midnight. Qibla calculations and calendar generation use the existing saved profile and prayer engine, so neither feature adds an external API call from the bot or a recurring job.
 
 ## Testing and production secrets
 

--- a/global/docs/architecture.md
+++ b/global/docs/architecture.md
@@ -26,7 +26,15 @@ The backend never trusts a Telegram user ID sent in JSON. Every Mini App API req
 
 The Qibla tool derives a great-circle bearing from the rounded coordinates already present in the profile and sends only the resulting bearing and distance to the browser. Supported Telegram clients can rotate the displayed needle with absolute device-orientation data; unsupported clients retain the numeric bearing and static compass.
 
-Calendar export first creates a five-minute encrypted and authenticated download token from an authenticated Mini App request. The opaque token exposes neither the Telegram identity nor the bot token. The resulting same-origin URL generates a localized 7-day or 30-day iCalendar file on demand. Events are emitted as UTC instants for broad calendar-client compatibility, while the source timezone and calculation method remain in the calendar metadata. No exported event UID contains a Telegram user or chat ID.
+Calendar connection first creates or reuses a random private subscription URL
+from an authenticated Mini App request. Google Calendar fetches that URL without
+Telegram authentication, so possession of the URL is the access credential. The
+feed calculates a localized rolling 30-day window on every fetch, emits event
+instants in UTC for compatibility, and uses stable opaque UIDs so settings
+changes update events instead of duplicating them. The URL and event UIDs expose
+neither the Telegram user ID nor bot token. Users can revoke the URL from the
+Mini App. Google controls its subscription refresh schedule, so midnight
+rollover is eventually consistent rather than immediate.
 
 ## Data ownership
 

--- a/global/docs/code-map.md
+++ b/global/docs/code-map.md
@@ -29,7 +29,7 @@ with the container command, so the three Cloud Run services use the same build.
 | `internal/location` | Google Time Zone and reverse-geocoding integration | Google HTTP APIs |
 | `internal/reminders` | Recurrence planning, due dispatch, Cloud Tasks enqueueing, Telegram delivery, and cleanup categories | `domain`, `store`, `prayertime`, Telegram and GCP clients |
 | `internal/telegram` | Bot commands, callbacks, keyboards, update routing, feedback, and owner dashboard | `store`, `location`, `prayertime`, `reminders`, `i18n` |
-| `internal/miniapp` | Embedded web UI, signed init-data authentication, settings APIs, Qibla/bootstrap data, and calendar downloads | `store`, `location`, `prayertime`, `reminders`, `qibla`, `calendarfile`, `i18n` |
+| `internal/miniapp` | Embedded web UI, signed init-data authentication, settings APIs, Qibla/bootstrap data, and private calendar subscriptions | `store`, `location`, `prayertime`, `reminders`, `qibla`, `calendarfile`, `i18n` |
 | `internal/i18n` | All supported locales, messages, buttons, prayer names, method names, and dates | `domain` |
 | `internal/qibla` | Great-circle bearing and distance to the Kaaba | Standard library only |
 | `internal/calendarfile` | Localized RFC 5545 prayer-calendar generation | `domain`, `i18n`, `prayertime` |

--- a/global/docs/data-model.md
+++ b/global/docs/data-model.md
@@ -19,6 +19,7 @@ erDiagram
     reminder_schedules ||--o{ notification_deliveries : attempts
     reminder_schedules ||--o{ task_outbox : queues
     chats ||--o{ notification_message_slots : owns
+    chats ||--o| calendar_subscriptions : publishes
 
     chats {
         bigint telegram_chat_id PK
@@ -78,6 +79,12 @@ erDiagram
         text category PK
         bigint telegram_message_id
     }
+    calendar_subscriptions {
+        bigint chat_id PK
+        text feed_token UK
+        text uid_namespace UK
+        boolean enabled
+    }
 ```
 
 `processed_updates` is independent from this graph. Its primary key is the
@@ -136,6 +143,15 @@ category:
 
 Before-prayer and at-prayer messages deliberately share `prayer`.
 
+### `calendar_subscriptions`
+
+Stores one optional rolling calendar feed per private chat. `feed_token` is a
+random 256-bit bearer credential used by Google Calendar when it fetches the
+feed. `uid_namespace` is a stable random value used in event UIDs so a prayer
+keeps the same identity when its calculated time changes. Disabling the row
+immediately rejects future feed fetches; reconnecting issues a new feed token
+but keeps the UID namespace stable.
+
 ## Retention
 
 | Data | Retention behavior |
@@ -144,6 +160,7 @@ Before-prayer and at-prayer messages deliberately share `prayer`.
 | Sent, failed, or stale notification deliveries | Deleted after 30 days |
 | Telegram notification messages | Scheduled for deletion after 36 hours |
 | Profiles and reminder configuration | Kept until `/delete_me` or chat deletion |
+| Calendar subscription | Kept until `/delete_me`; its feed token can be disabled or replaced |
 | Feedback content | Never stored in PostgreSQL |
 
 Retention runs in bounded batches from the authenticated maintenance Scheduler

--- a/global/docs/operations.md
+++ b/global/docs/operations.md
@@ -71,7 +71,7 @@ The welcome illustration is embedded in the webhook binary and sent with the loc
 
 Set `GLOBAL_DB_SCHEMA` to `global_bot_testing` or `global_bot_production`, then run Goose with `-table="${GLOBAL_DB_SCHEMA}.goose_db_version"`. Never run global migrations with the legacy default migration table. The initial down migration drops only the selected global schema, but production rollback should normally use a forward corrective migration rather than dropping user data.
 
-Migration `00002` adds the per-chat Hijri correction and the two weekly reminder kinds. Migration `00003` adds notification message slots and scheduled deletion tasks for pre-prayer/category cleanup. The normal global deployment runs migrations before the new webhook and sender revisions are applied.
+Migration `00002` adds the per-chat Hijri correction and the two weekly reminder kinds. Migration `00003` adds notification message slots and scheduled deletion tasks for pre-prayer/category cleanup. Migration `00004` adds revocable private rolling-calendar subscriptions. The normal global deployment runs migrations before the new webhook and sender revisions are applied.
 
 Telegram only deletes messages younger than 48 hours. The sender schedules every reminder for cleanup after 36 hours, while a new message in the same category also triggers immediate best-effort deletion of its predecessor. If direct deletion fails transiently, the durable cleanup task retries through the existing Cloud Tasks queue.
 
@@ -80,6 +80,29 @@ Telegram only deletes messages younger than 48 hours. The sender schedules every
 Existing profiles and prayer calculations continue working if Google Maps is unavailable. Only new location setup or a location change fails, and Telegram retries the webhook after a server error. No Maps API is called for `/today`, `/tomorrow`, `/next`, or reminder delivery.
 
 The same behavior applies to the Mini App: loading an existing schedule and saving calculation/reminder settings do not call Maps. Only an explicit location update calls the Time Zone and Geocoding APIs.
+
+## Calendar subscriptions
+
+The private `.ics` URL is a bearer credential. Do not add it to application
+logs, support tickets, screenshots, or public documentation, and restrict
+access to platform request logs that may contain requested URLs. A user who
+accidentally shares it should press **Disconnect calendar** and reconnect; this
+disables the old token and issues a new one.
+
+The feed contains today and the following 29 days at the time of each request.
+It does not need Cloud Scheduler or a background sync job. Google Calendar
+chooses when to refetch URL subscriptions and can lag behind local midnight or a
+settings change. The feed advertises a 12-hour refresh interval, but that value
+is only a hint.
+
+If Google does not show events:
+
+1. Confirm the feed URL returns HTTP 200 and `Content-Type: text/calendar`.
+2. Confirm the body has no UTF-8 byte-order mark and uses CRLF line endings.
+3. Check that the subscription is still enabled.
+4. Add it from Google Calendar on a computer with **Other calendars → From
+   URL** using the Mini App's copy-link fallback.
+5. Allow for Google's refresh cache before recreating the subscription.
 
 ## Feedback delivery
 

--- a/global/docs/request-flows.md
+++ b/global/docs/request-flows.md
@@ -49,7 +49,7 @@ Location writes are the only normal user flow that calls Google APIs.
 7. The response calculates schedules locally with the saved rounded profile.
 
 If Google is unavailable, existing profiles, schedules, commands, reminders,
-Qibla direction, and calendar exports continue working. Only location writes
+Qibla direction, and calendar subscriptions continue working. Only location writes
 fail.
 
 ## Mini App session and API
@@ -98,17 +98,25 @@ returns only bearing and distance to the Mini App. On supported clients,
 Telegram's absolute device-orientation API rotates the needle; otherwise the
 numeric bearing remains available.
 
-Calendar export has two requests:
+Calendar connection separates authenticated management from anonymous feed
+fetching:
 
-1. An authenticated Mini App request asks for 7 or 30 days.
-2. The backend returns a same-origin URL containing a five-minute encrypted and
-   authenticated token.
-3. Telegram's native downloader, or an anchor fallback, downloads the `.ics`
-   file.
-4. The server loads the current profile, calculates each day on demand, and
-   emits localized events as UTC instants.
+1. An authenticated Mini App request creates or reuses a random private feed
+   token and stable UID namespace.
+2. The Mini App opens Google Calendar with the HTTPS feed URL. A copy-link
+   button supports Google's desktop **Other calendars → From URL** flow.
+3. Google fetches the `.ics` URL without Telegram authentication.
+4. The server validates the random token, loads the current profile, and
+   calculates today plus the following 29 local days.
+5. Stable event UIDs let Google update changed prayer times without creating a
+   second copy of the same prayer and date.
+6. Disconnecting the calendar disables the token. Future feed requests return
+   HTTP 401.
 
-The URL and event UIDs expose neither the Telegram user ID nor bot token.
+The feed always rolls forward when fetched and includes refresh hints, but
+Google decides when it refreshes subscribed calendars. The URL is a bearer
+credential and must remain private. It and the event UIDs expose neither the
+Telegram user ID nor bot token.
 
 ## Feedback
 

--- a/global/docs/runtime-and-deployment.md
+++ b/global/docs/runtime-and-deployment.md
@@ -32,6 +32,12 @@ All services scale to zero. A first request can therefore include Cloud Run cold
 start latency. No minimum instances are configured intentionally to control
 cost.
 
+The Google Calendar integration is a private `.ics` subscription served by the
+webhook service. It adds no Google OAuth client, Calendar API credential,
+Scheduler job, or separate runtime. Google fetches the URL on its own schedule;
+each request calculates the current rolling 30-day window from the user's saved
+profile.
+
 ## Secrets
 
 Runtime services read environment-specific Secret Manager values:

--- a/global/internal/calendarfile/calendar.go
+++ b/global/internal/calendarfile/calendar.go
@@ -3,8 +3,6 @@ package calendarfile
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"strings"
 	"time"
@@ -34,9 +32,13 @@ func Generate(
 	start time.Time,
 	days int,
 	createdAt time.Time,
+	uidNamespace string,
 ) ([]byte, error) {
 	if days < 1 || days > 31 {
 		return nil, fmt.Errorf("calendar range must be between 1 and 31 days")
+	}
+	if !validUIDNamespace(uidNamespace) {
+		return nil, fmt.Errorf("invalid calendar UID namespace")
 	}
 	location, err := time.LoadLocation(profile.Timezone)
 	if err != nil {
@@ -52,6 +54,8 @@ func Generate(
 	writeLine(&calendar, "METHOD:PUBLISH")
 	writeLine(&calendar, "X-WR-CALNAME:"+escapeText(locale.BotName))
 	writeLine(&calendar, "X-WR-TIMEZONE:"+escapeText(profile.Timezone))
+	writeLine(&calendar, "X-PUBLISHED-TTL:PT12H")
+	writeLine(&calendar, "REFRESH-INTERVAL;VALUE=DURATION:PT12H")
 
 	for day := 0; day < days; day++ {
 		schedule, err := calculator.Day(ctx, start.AddDate(0, 0, day), profile)
@@ -63,15 +67,11 @@ func Generate(
 			if !ok {
 				continue
 			}
-			writeEvent(&calendar, profile, locale, prayer, at, createdAt)
+			writeEvent(&calendar, profile, locale, prayer, at, createdAt, uidNamespace)
 		}
 	}
 	writeLine(&calendar, "END:VCALENDAR")
 	return calendar.Bytes(), nil
-}
-
-func Filename(start time.Time, days int) string {
-	return fmt.Sprintf("prayer-times-%s-%d-days.ics", start.Format("2006-01-02"), days)
 }
 
 func writeEvent(
@@ -81,13 +81,18 @@ func writeEvent(
 	prayer domain.Prayer,
 	at time.Time,
 	createdAt time.Time,
+	uidNamespace string,
 ) {
-	uidSource := fmt.Sprintf("%s|%.3f|%.3f|%s|%s", profile.Timezone, profile.Latitude, profile.Longitude, prayer, at.UTC().Format(time.RFC3339))
-	digest := sha256.Sum256([]byte(uidSource))
 	description := fmt.Sprintf("%s · %s · %s", locale.BotName, locale.Method(profile.Method), profile.Timezone)
+	uid := fmt.Sprintf(
+		"%s-%s-%s@global-prayer-bot",
+		uidNamespace,
+		at.In(mustLocation(profile.Timezone)).Format("20060102"),
+		prayer,
+	)
 
 	writeLine(calendar, "BEGIN:VEVENT")
-	writeLine(calendar, "UID:"+hex.EncodeToString(digest[:12])+"@global-prayer-bot")
+	writeLine(calendar, "UID:"+uid)
 	writeLine(calendar, "DTSTAMP:"+createdAt.UTC().Format("20060102T150405Z"))
 	writeLine(calendar, "DTSTART:"+at.UTC().Format("20060102T150405Z"))
 	writeLine(calendar, "DTEND:"+at.Add(eventDuration).UTC().Format("20060102T150405Z"))
@@ -95,6 +100,26 @@ func writeEvent(
 	writeLine(calendar, "DESCRIPTION:"+escapeText(description))
 	writeLine(calendar, "CATEGORIES:Prayer Times")
 	writeLine(calendar, "END:VEVENT")
+}
+
+func validUIDNamespace(value string) bool {
+	if len(value) != 32 {
+		return false
+	}
+	for _, character := range value {
+		if (character < '0' || character > '9') && (character < 'a' || character > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func mustLocation(name string) *time.Location {
+	location, err := time.LoadLocation(name)
+	if err != nil {
+		return time.UTC
+	}
+	return location
 }
 
 func escapeText(value string) string {

--- a/global/internal/calendarfile/calendar_test.go
+++ b/global/internal/calendarfile/calendar_test.go
@@ -32,7 +32,10 @@ func TestGenerateCreatesPortableLocalizedCalendar(t *testing.T) {
 		HighLatitudeRule: domain.HighLatitudeAngleBased,
 	}
 	start := time.Date(2026, time.July, 17, 12, 0, 0, 0, time.UTC)
-	data, err := Generate(context.Background(), fakeCalculator{}, profile, i18n.Resolve("ar"), start, 2, start)
+	data, err := Generate(
+		context.Background(), fakeCalculator{}, profile, i18n.Resolve("ar"),
+		start, 2, start, "0123456789abcdef0123456789abcdef",
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,6 +49,12 @@ func TestGenerateCreatesPortableLocalizedCalendar(t *testing.T) {
 	if !strings.Contains(content, "SUMMARY:الفجر\r\n") || !strings.Contains(content, "DTSTART:20260717T010000Z\r\n") {
 		t.Fatalf("calendar is missing localized prayer or UTC timestamp:\n%s", content)
 	}
+	if !strings.Contains(content, "UID:0123456789abcdef0123456789abcdef-20260717-fajr@global-prayer-bot\r\n") {
+		t.Fatalf("calendar is missing its stable subscription UID:\n%s", content)
+	}
+	if !strings.Contains(content, "REFRESH-INTERVAL;VALUE=DURATION:PT12H\r\n") {
+		t.Fatalf("calendar is missing its refresh hint:\n%s", content)
+	}
 	if strings.Contains(content, "42@") {
 		t.Fatal("calendar must not expose a Telegram chat ID")
 	}
@@ -53,8 +62,17 @@ func TestGenerateCreatesPortableLocalizedCalendar(t *testing.T) {
 
 func TestGenerateValidatesRange(t *testing.T) {
 	profile := domain.PrayerProfile{Timezone: "UTC"}
-	if _, err := Generate(context.Background(), fakeCalculator{}, profile, i18n.Resolve("en"), time.Now(), 32, time.Now()); err == nil {
-		t.Fatal("expected oversized calendar export to fail")
+	if _, err := Generate(
+		context.Background(), fakeCalculator{}, profile, i18n.Resolve("en"),
+		time.Now(), 32, time.Now(), "0123456789abcdef0123456789abcdef",
+	); err == nil {
+		t.Fatal("expected oversized calendar range to fail")
+	}
+	if _, err := Generate(
+		context.Background(), fakeCalculator{}, profile, i18n.Resolve("en"),
+		time.Now(), 30, time.Now(), "invalid",
+	); err == nil {
+		t.Fatal("expected invalid UID namespace to fail")
 	}
 }
 

--- a/global/internal/domain/domain.go
+++ b/global/internal/domain/domain.go
@@ -213,3 +213,10 @@ type MessageDeletionTask struct {
 	ChatID      int64  `json:"chat_id"`
 	MessageID   int64  `json:"message_id"`
 }
+
+type CalendarSubscription struct {
+	ChatID       int64
+	FeedToken    string
+	UIDNamespace string
+	Enabled      bool
+}

--- a/global/internal/miniapp/calendar.go
+++ b/global/internal/miniapp/calendar.go
@@ -1,12 +1,9 @@
 package miniapp
 
 import (
-	"crypto/aes"
-	"crypto/cipher"
 	"crypto/rand"
 	"crypto/sha256"
-	"encoding/base64"
-	"encoding/json"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -18,150 +15,115 @@ import (
 	"github.com/escalopa/prayer-bot/global/internal/store"
 )
 
-const calendarTokenLifetime = 5 * time.Minute
+const rollingCalendarDays = 30
 
-type calendarLinkRequest struct {
-	Days int `json:"days"`
+type calendarSubscriptionResponse struct {
+	Enabled bool   `json:"enabled"`
+	Path    string `json:"path,omitempty"`
 }
 
-type calendarLinkResponse struct {
-	Path     string `json:"path"`
-	Filename string `json:"filename"`
-}
-
-type calendarTokenPayload struct {
-	ChatID    int64 `json:"chat_id"`
-	Days      int   `json:"days"`
-	ExpiresAt int64 `json:"expires_at"`
-}
-
-func (h *Handler) calendarLink(w http.ResponseWriter, r *http.Request, identity Identity) error {
-	var request calendarLinkRequest
-	if err := decodeJSON(w, r, &request); err != nil || !validCalendarDays(request.Days) {
-		return badRequest("invalid_calendar_range")
-	}
-	profile, err := h.store.Profile(r.Context(), identity.UserID)
-	if store.IsNotFound(err) {
+func (h *Handler) createCalendarSubscription(w http.ResponseWriter, r *http.Request, identity Identity) error {
+	if _, err := h.store.Profile(r.Context(), identity.UserID); store.IsNotFound(err) {
 		return conflict("location_required")
-	}
-	if err != nil {
+	} else if err != nil {
 		return fmt.Errorf("load profile: %w", err)
 	}
-	location, err := time.LoadLocation(profile.Timezone)
+	feedToken, uidNamespace, err := newCalendarCredentials()
 	if err != nil {
-		return fmt.Errorf("load profile timezone: %w", err)
+		return fmt.Errorf("create calendar credentials: %w", err)
 	}
-	token, err := signCalendarToken(h.botToken, calendarTokenPayload{
-		ChatID: identity.UserID, Days: request.Days,
-		ExpiresAt: h.now().Add(calendarTokenLifetime).Unix(),
-	})
+	subscription, err := h.store.EnableCalendarSubscription(
+		r.Context(), identity.UserID, feedToken, uidNamespace,
+	)
 	if err != nil {
-		return fmt.Errorf("sign calendar token: %w", err)
+		return fmt.Errorf("enable calendar subscription: %w", err)
 	}
-	return writeJSON(w, calendarLinkResponse{
-		Path:     "/api/miniapp/calendar.ics?token=" + url.QueryEscape(token),
-		Filename: calendarfile.Filename(h.now().In(location), request.Days),
+	return writeJSON(w, calendarSubscriptionResponse{
+		Enabled: true,
+		Path:    "/api/miniapp/calendar.ics?token=" + url.QueryEscape(subscription.FeedToken),
 	})
+}
+
+func (h *Handler) disableCalendarSubscription(w http.ResponseWriter, r *http.Request, identity Identity) error {
+	if err := h.store.DisableCalendarSubscription(r.Context(), identity.UserID); err != nil {
+		return fmt.Errorf("disable calendar subscription: %w", err)
+	}
+	return writeJSON(w, calendarSubscriptionResponse{Enabled: false})
 }
 
 func (h *Handler) calendarDownload(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Cache-Control", "private, no-store")
+	w.Header().Set("Cache-Control", "private, max-age=300")
+	w.Header().Set("Referrer-Policy", "no-referrer")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
-	payload, err := verifyCalendarToken(h.botToken, r.URL.Query().Get("token"), h.now())
-	if err != nil {
-		http.Error(w, "invalid or expired calendar link", http.StatusUnauthorized)
+	subscription, err := h.store.CalendarSubscriptionByToken(r.Context(), r.URL.Query().Get("token"))
+	if err != nil || !subscription.Enabled {
+		if err != nil && !store.IsNotFound(err) {
+			h.logger.Error("Calendar subscription lookup failed", "error", err)
+		}
+		http.Error(w, "invalid calendar subscription", http.StatusUnauthorized)
 		return
 	}
-	chat, err := h.store.Chat(r.Context(), payload.ChatID)
+	chat, err := h.store.Chat(r.Context(), subscription.ChatID)
 	if err != nil {
 		if !store.IsNotFound(err) {
-			h.logger.Error("Calendar export chat lookup failed", "error", err)
+			h.logger.Error("Calendar feed chat lookup failed", "error", err)
 		}
 		http.NotFound(w, r)
 		return
 	}
-	profile, err := h.store.Profile(r.Context(), payload.ChatID)
+	profile, err := h.store.Profile(r.Context(), subscription.ChatID)
 	if err != nil {
 		if !store.IsNotFound(err) {
-			h.logger.Error("Calendar export profile lookup failed", "error", err)
+			h.logger.Error("Calendar feed profile lookup failed", "error", err)
 		}
 		http.NotFound(w, r)
 		return
 	}
 	location, err := time.LoadLocation(profile.Timezone)
 	if err != nil {
-		h.logger.Error("Calendar export timezone lookup failed", "timezone", profile.Timezone, "error", err)
+		h.logger.Error("Calendar feed timezone lookup failed", "timezone", profile.Timezone, "error", err)
 		http.Error(w, "calendar generation failed", http.StatusInternalServerError)
 		return
 	}
 	start := h.now().In(location)
+	createdAt := time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, location)
 	data, err := calendarfile.Generate(
-		r.Context(), h.calculator, profile, i18n.Resolve(chat.LanguageCode), start, payload.Days, h.now(),
+		r.Context(),
+		h.calculator,
+		profile,
+		i18n.Resolve(chat.LanguageCode),
+		start,
+		rollingCalendarDays,
+		createdAt,
+		subscription.UIDNamespace,
 	)
 	if err != nil {
-		h.logger.Error("Calendar export generation failed", "days", payload.Days, "error", err)
+		h.logger.Error("Calendar feed generation failed", "error", err)
 		http.Error(w, "calendar generation failed", http.StatusInternalServerError)
 		return
 	}
-	filename := calendarfile.Filename(start, payload.Days)
+	digest := sha256.Sum256(data)
+	etag := `"` + hex.EncodeToString(digest[:]) + `"`
+	w.Header().Set("ETag", etag)
+	if r.Header.Get("If-None-Match") == etag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
 	w.Header().Set("Content-Type", "text/calendar; charset=utf-8")
-	w.Header().Set("Content-Disposition", `attachment; filename="`+filename+`"`)
-	w.Header().Set("Access-Control-Allow-Origin", "https://web.telegram.org")
+	w.Header().Set("Content-Disposition", `inline; filename="prayer-times.ics"`)
 	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(data)
 }
 
-func signCalendarToken(secret string, payload calendarTokenPayload) (string, error) {
-	data, err := json.Marshal(payload)
-	if err != nil {
-		return "", err
+func newCalendarCredentials() (string, string, error) {
+	feedToken := make([]byte, 32)
+	if _, err := rand.Read(feedToken); err != nil {
+		return "", "", err
 	}
-	aead, err := calendarTokenCipher(secret)
-	if err != nil {
-		return "", err
+	uidNamespace := make([]byte, 16)
+	if _, err := rand.Read(uidNamespace); err != nil {
+		return "", "", err
 	}
-	nonce := make([]byte, aead.NonceSize())
-	if _, err := rand.Read(nonce); err != nil {
-		return "", err
-	}
-	sealed := aead.Seal(nonce, nonce, data, []byte("global-prayer-calendar-v1"))
-	return base64.RawURLEncoding.EncodeToString(sealed), nil
+	return hex.EncodeToString(feedToken), hex.EncodeToString(uidNamespace), nil
 }
-
-func verifyCalendarToken(secret, token string, now time.Time) (calendarTokenPayload, error) {
-	sealed, err := base64.RawURLEncoding.DecodeString(token)
-	if err != nil {
-		return calendarTokenPayload{}, fmt.Errorf("decode token")
-	}
-	aead, err := calendarTokenCipher(secret)
-	if err != nil || len(sealed) <= aead.NonceSize() {
-		return calendarTokenPayload{}, fmt.Errorf("malformed token")
-	}
-	nonce, ciphertext := sealed[:aead.NonceSize()], sealed[aead.NonceSize():]
-	data, err := aead.Open(nil, nonce, ciphertext, []byte("global-prayer-calendar-v1"))
-	if err != nil {
-		return calendarTokenPayload{}, fmt.Errorf("invalid token")
-	}
-	var payload calendarTokenPayload
-	if err := json.Unmarshal(data, &payload); err != nil {
-		return calendarTokenPayload{}, fmt.Errorf("decode payload")
-	}
-	expiresAt := time.Unix(payload.ExpiresAt, 0)
-	if payload.ChatID <= 0 || !validCalendarDays(payload.Days) || !expiresAt.After(now) ||
-		expiresAt.After(now.Add(2*calendarTokenLifetime)) {
-		return calendarTokenPayload{}, fmt.Errorf("invalid payload")
-	}
-	return payload, nil
-}
-
-func calendarTokenCipher(secret string) (cipher.AEAD, error) {
-	key := sha256.Sum256([]byte("global-prayer-calendar-key-v1\x00" + secret))
-	block, err := aes.NewCipher(key[:])
-	if err != nil {
-		return nil, err
-	}
-	return cipher.NewGCM(block)
-}
-
-func validCalendarDays(days int) bool { return days == 7 || days == 30 }

--- a/global/internal/miniapp/handler.go
+++ b/global/internal/miniapp/handler.go
@@ -38,6 +38,10 @@ type Storage interface {
 	DisableRules(context.Context, int64) error
 	ConfigurePrayerRules(context.Context, int64, bool, int) error
 	SetWeeklyRule(context.Context, int64, domain.ReminderKind, bool) error
+	CalendarSubscription(context.Context, int64) (domain.CalendarSubscription, error)
+	CalendarSubscriptionByToken(context.Context, string) (domain.CalendarSubscription, error)
+	EnableCalendarSubscription(context.Context, int64, string, string) (domain.CalendarSubscription, error)
+	DisableCalendarSubscription(context.Context, int64) error
 }
 
 type ReminderPlanner interface {
@@ -79,7 +83,8 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("PUT /api/miniapp/preferences", h.api(h.updatePreferences))
 	mux.HandleFunc("PUT /api/miniapp/settings", h.api(h.updateSettings))
 	mux.HandleFunc("PUT /api/miniapp/reminders", h.api(h.updateReminders))
-	mux.HandleFunc("POST /api/miniapp/calendar-link", h.api(h.calendarLink))
+	mux.HandleFunc("POST /api/miniapp/calendar-subscription", h.api(h.createCalendarSubscription))
+	mux.HandleFunc("DELETE /api/miniapp/calendar-subscription", h.api(h.disableCalendarSubscription))
 	mux.HandleFunc("GET /api/miniapp/calendar.ics", h.calendarDownload)
 }
 
@@ -369,17 +374,18 @@ func (h *Handler) applyReminders(ctx context.Context, chatID int64, request remi
 }
 
 type bootstrapResponse struct {
-	User          userResponse      `json:"user"`
-	Locale        string            `json:"locale"`
-	NeedsLocation bool              `json:"needs_location"`
-	LocationName  string            `json:"location_name,omitempty"`
-	Profile       *profileResponse  `json:"profile,omitempty"`
-	Today         *scheduleResponse `json:"today,omitempty"`
-	Tomorrow      *scheduleResponse `json:"tomorrow,omitempty"`
-	Qibla         *qiblaResponse    `json:"qibla,omitempty"`
-	Reminders     reminderResponse  `json:"reminders"`
-	Options       optionsResponse   `json:"options"`
-	Labels        map[string]string `json:"labels"`
+	User          userResponse                 `json:"user"`
+	Locale        string                       `json:"locale"`
+	NeedsLocation bool                         `json:"needs_location"`
+	LocationName  string                       `json:"location_name,omitempty"`
+	Profile       *profileResponse             `json:"profile,omitempty"`
+	Today         *scheduleResponse            `json:"today,omitempty"`
+	Tomorrow      *scheduleResponse            `json:"tomorrow,omitempty"`
+	Qibla         *qiblaResponse               `json:"qibla,omitempty"`
+	Calendar      calendarSubscriptionResponse `json:"calendar"`
+	Reminders     reminderResponse             `json:"reminders"`
+	Options       optionsResponse              `json:"options"`
+	Labels        map[string]string            `json:"labels"`
 }
 
 type userResponse struct {
@@ -459,6 +465,12 @@ func (h *Handler) build(ctx context.Context, identity Identity) (bootstrapRespon
 	}
 	if err != nil {
 		return bootstrapResponse{}, fmt.Errorf("load profile: %w", err)
+	}
+	subscription, err := h.store.CalendarSubscription(ctx, identity.UserID)
+	if err == nil {
+		response.Calendar.Enabled = subscription.Enabled
+	} else if !store.IsNotFound(err) {
+		return bootstrapResponse{}, fmt.Errorf("load calendar subscription: %w", err)
 	}
 	response.Profile = &profileResponse{
 		Timezone: profile.Timezone, Method: profile.Method, Madhab: profile.Madhab,
@@ -670,8 +682,10 @@ func labels(locale i18n.Locale) map[string]string {
 		"compass_start": copy.CompassStart, "compass_active": copy.CompassActive,
 		"compass_unavailable": copy.CompassUnavailable,
 		"calendar_title":      copy.CalendarTitle, "calendar_help": copy.CalendarHelp,
-		"export_week": copy.ExportWeek, "export_month": copy.ExportMonth,
-		"export_preparing": copy.ExportPreparing, "export_ready": copy.ExportReady,
+		"calendar_connect": copy.CalendarConnect, "calendar_copy": copy.CalendarCopy,
+		"calendar_disconnect": copy.CalendarDisconnect, "calendar_opening": copy.CalendarOpening,
+		"calendar_copied": copy.CalendarCopied, "calendar_disconnected": copy.CalendarDisconnected,
+		"calendar_private": copy.CalendarPrivate,
 	}
 }
 
@@ -682,7 +696,9 @@ type miniAppCopy struct {
 	Tools, QiblaTitle, QiblaHelp, QiblaBearing            string
 	QiblaDistance, CompassStart, CompassActive            string
 	CompassUnavailable, CalendarTitle, CalendarHelp       string
-	ExportWeek, ExportMonth, ExportPreparing, ExportReady string
+	CalendarConnect, CalendarCopy, CalendarDisconnect     string
+	CalendarOpening, CalendarCopied, CalendarDisconnected string
+	CalendarPrivate                                       string
 }
 
 var miniCopy = map[string]miniAppCopy{
@@ -696,8 +712,11 @@ var miniCopy = map[string]miniAppCopy{
 		QiblaBearing: "{bearing}° from north", QiblaDistance: "Approximately {distance} km to the Kaaba",
 		CompassStart: "Use live compass", CompassActive: "Live compass active",
 		CompassUnavailable: "An absolute compass is unavailable on this device. Use the bearing above.",
-		CalendarTitle:      "Prayer calendar", CalendarHelp: "Export prayer times to Apple, Google, Outlook, or another calendar.",
-		ExportWeek: "Export 7 days", ExportMonth: "Export 30 days", ExportPreparing: "Preparing calendar…", ExportReady: "Calendar ready",
+		CalendarTitle:      "Prayer calendar", CalendarHelp: "Connect a rolling 30-day prayer calendar that updates automatically.",
+		CalendarConnect: "Connect Google Calendar", CalendarCopy: "Copy private link", CalendarDisconnect: "Disconnect calendar",
+		CalendarOpening: "Opening Google Calendar…", CalendarCopied: "Private calendar link copied",
+		CalendarDisconnected: "Calendar feed disconnected",
+		CalendarPrivate:      "Keep the link private. Google controls when subscribed calendars refresh.",
 	},
 	"ar": {
 		Save: "حفظ التغييرات", Saved: "تم الحفظ", Loading: "جارٍ تحميل مواقيت الصلاة…",
@@ -709,8 +728,11 @@ var miniCopy = map[string]miniAppCopy{
 		QiblaBearing: "{bearing}° من الشمال", QiblaDistance: "حوالي {distance} كم إلى الكعبة",
 		CompassStart: "استخدام البوصلة المباشرة", CompassActive: "البوصلة المباشرة مفعّلة",
 		CompassUnavailable: "البوصلة المطلقة غير متاحة على هذا الجهاز. استخدم الزاوية الموضحة أعلاه.",
-		CalendarTitle:      "تقويم الصلاة", CalendarHelp: "صدّر مواقيت الصلاة إلى تقويم Apple أو Google أو Outlook أو أي تقويم آخر.",
-		ExportWeek: "تصدير 7 أيام", ExportMonth: "تصدير 30 يومًا", ExportPreparing: "جارٍ إعداد التقويم…", ExportReady: "التقويم جاهز",
+		CalendarTitle:      "تقويم الصلاة", CalendarHelp: "اربط تقويمًا متجددًا لمواقيت الصلاة خلال 30 يومًا.",
+		CalendarConnect: "الربط مع تقويم Google", CalendarCopy: "نسخ الرابط الخاص", CalendarDisconnect: "قطع اتصال التقويم",
+		CalendarOpening: "جارٍ فتح تقويم Google…", CalendarCopied: "تم نسخ رابط التقويم الخاص",
+		CalendarDisconnected: "تم قطع اتصال التقويم",
+		CalendarPrivate:      "احتفظ بالرابط سريًا. يحدد Google وقت تحديث التقويمات المشتركة.",
 	},
 	"es": {
 		Save: "Guardar cambios", Saved: "Guardado", Loading: "Cargando horarios de oración…",
@@ -722,8 +744,11 @@ var miniCopy = map[string]miniAppCopy{
 		QiblaBearing: "{bearing}° desde el norte", QiblaDistance: "Aproximadamente {distance} km hasta la Kaaba",
 		CompassStart: "Usar brújula en vivo", CompassActive: "Brújula en vivo activa",
 		CompassUnavailable: "Este dispositivo no ofrece una brújula absoluta. Usa el ángulo indicado arriba.",
-		CalendarTitle:      "Calendario de oración", CalendarHelp: "Exporta los horarios a Apple, Google, Outlook u otro calendario.",
-		ExportWeek: "Exportar 7 días", ExportMonth: "Exportar 30 días", ExportPreparing: "Preparando calendario…", ExportReady: "Calendario listo",
+		CalendarTitle:      "Calendario de oración", CalendarHelp: "Conecta un calendario móvil de 30 días que se actualiza automáticamente.",
+		CalendarConnect: "Conectar Google Calendar", CalendarCopy: "Copiar enlace privado", CalendarDisconnect: "Desconectar calendario",
+		CalendarOpening: "Abriendo Google Calendar…", CalendarCopied: "Enlace privado copiado",
+		CalendarDisconnected: "Calendario desconectado",
+		CalendarPrivate:      "Mantén el enlace privado. Google decide cuándo actualizar los calendarios suscritos.",
 	},
 	"fr": {
 		Save: "Enregistrer", Saved: "Enregistré", Loading: "Chargement des horaires de prière…",
@@ -735,8 +760,11 @@ var miniCopy = map[string]miniAppCopy{
 		QiblaBearing: "{bearing}° depuis le nord", QiblaDistance: "Environ {distance} km jusqu’à la Kaaba",
 		CompassStart: "Utiliser la boussole", CompassActive: "Boussole active",
 		CompassUnavailable: "La boussole absolue n’est pas disponible sur cet appareil. Utilisez l’angle ci-dessus.",
-		CalendarTitle:      "Calendrier des prières", CalendarHelp: "Exportez les horaires vers Apple, Google, Outlook ou un autre calendrier.",
-		ExportWeek: "Exporter 7 jours", ExportMonth: "Exporter 30 jours", ExportPreparing: "Préparation du calendrier…", ExportReady: "Calendrier prêt",
+		CalendarTitle:      "Calendrier des prières", CalendarHelp: "Connectez un calendrier glissant de 30 jours mis à jour automatiquement.",
+		CalendarConnect: "Connecter Google Agenda", CalendarCopy: "Copier le lien privé", CalendarDisconnect: "Déconnecter le calendrier",
+		CalendarOpening: "Ouverture de Google Agenda…", CalendarCopied: "Lien privé copié",
+		CalendarDisconnected: "Calendrier déconnecté",
+		CalendarPrivate:      "Gardez ce lien privé. Google décide quand actualiser les calendriers abonnés.",
 	},
 	"ru": {
 		Save: "Сохранить", Saved: "Сохранено", Loading: "Загружаем время намаза…",
@@ -748,8 +776,11 @@ var miniCopy = map[string]miniAppCopy{
 		QiblaBearing: "{bearing}° от севера", QiblaDistance: "Примерно {distance} км до Каабы",
 		CompassStart: "Включить компас", CompassActive: "Компас включён",
 		CompassUnavailable: "Абсолютный компас недоступен на этом устройстве. Используйте угол выше.",
-		CalendarTitle:      "Календарь намаза", CalendarHelp: "Экспортируйте время намаза в Apple, Google, Outlook или другой календарь.",
-		ExportWeek: "Экспорт на 7 дней", ExportMonth: "Экспорт на 30 дней", ExportPreparing: "Готовим календарь…", ExportReady: "Календарь готов",
+		CalendarTitle:      "Календарь намаза", CalendarHelp: "Подключите автоматически обновляемый календарь намаза на 30 дней.",
+		CalendarConnect: "Подключить Google Календарь", CalendarCopy: "Копировать закрытую ссылку", CalendarDisconnect: "Отключить календарь",
+		CalendarOpening: "Открываем Google Календарь…", CalendarCopied: "Закрытая ссылка скопирована",
+		CalendarDisconnected: "Календарь отключён",
+		CalendarPrivate:      "Не передавайте ссылку другим. Частоту обновления подписки определяет Google.",
 	},
 	"tr": {
 		Save: "Değişiklikleri kaydet", Saved: "Kaydedildi", Loading: "Namaz vakitleri yükleniyor…",
@@ -761,8 +792,11 @@ var miniCopy = map[string]miniAppCopy{
 		QiblaBearing: "Kuzeyden {bearing}°", QiblaDistance: "Kâbe’ye yaklaşık {distance} km",
 		CompassStart: "Canlı pusulayı kullan", CompassActive: "Canlı pusula etkin",
 		CompassUnavailable: "Bu cihazda mutlak pusula kullanılamıyor. Yukarıdaki açıyı kullanın.",
-		CalendarTitle:      "Namaz takvimi", CalendarHelp: "Namaz vakitlerini Apple, Google, Outlook veya başka bir takvime aktarın.",
-		ExportWeek: "7 günü aktar", ExportMonth: "30 günü aktar", ExportPreparing: "Takvim hazırlanıyor…", ExportReady: "Takvim hazır",
+		CalendarTitle:      "Namaz takvimi", CalendarHelp: "Otomatik güncellenen 30 günlük namaz takvimini bağlayın.",
+		CalendarConnect: "Google Takvim’e bağlan", CalendarCopy: "Özel bağlantıyı kopyala", CalendarDisconnect: "Takvim bağlantısını kes",
+		CalendarOpening: "Google Takvim açılıyor…", CalendarCopied: "Özel takvim bağlantısı kopyalandı",
+		CalendarDisconnected: "Takvim bağlantısı kesildi",
+		CalendarPrivate:      "Bağlantıyı gizli tutun. Abone takvimlerin yenilenme zamanını Google belirler.",
 	},
 	"uz": {
 		Save: "O‘zgarishlarni saqlash", Saved: "Saqlandi", Loading: "Namoz vaqtlari yuklanmoqda…",
@@ -774,8 +808,11 @@ var miniCopy = map[string]miniAppCopy{
 		QiblaBearing: "Shimoldan {bearing}°", QiblaDistance: "Ka’bagacha taxminan {distance} km",
 		CompassStart: "Jonli kompasni yoqish", CompassActive: "Jonli kompas faol",
 		CompassUnavailable: "Bu qurilmada mutlaq kompas mavjud emas. Yuqoridagi burchakdan foydalaning.",
-		CalendarTitle:      "Namoz taqvimi", CalendarHelp: "Namoz vaqtlarini Apple, Google, Outlook yoki boshqa taqvimga eksport qiling.",
-		ExportWeek: "7 kunni eksport qilish", ExportMonth: "30 kunni eksport qilish", ExportPreparing: "Taqvim tayyorlanmoqda…", ExportReady: "Taqvim tayyor",
+		CalendarTitle:      "Namoz taqvimi", CalendarHelp: "Avtomatik yangilanadigan 30 kunlik namoz taqvimini ulang.",
+		CalendarConnect: "Google Taqvimga ulash", CalendarCopy: "Maxfiy havolani nusxalash", CalendarDisconnect: "Taqvimni uzish",
+		CalendarOpening: "Google Taqvim ochilmoqda…", CalendarCopied: "Maxfiy taqvim havolasi nusxalandi",
+		CalendarDisconnected: "Taqvim uzildi",
+		CalendarPrivate:      "Havolani maxfiy saqlang. Obuna taqvimini qachon yangilashni Google belgilaydi.",
 	},
 	"tt": {
 		Save: "Үзгәрешләрне саклау", Saved: "Сакланды", Loading: "Намаз вакытлары йөкләнә…",
@@ -787,7 +824,10 @@ var miniCopy = map[string]miniAppCopy{
 		QiblaBearing: "Төньяктан {bearing}°", QiblaDistance: "Кәгъбәгә якынча {distance} км",
 		CompassStart: "Тере компасны кабызу", CompassActive: "Тере компас эшли",
 		CompassUnavailable: "Бу җайланмада абсолют компас юк. Өстәге почмакны кулланыгыз.",
-		CalendarTitle:      "Намаз календаре", CalendarHelp: "Намаз вакытларын Apple, Google, Outlook яки башка календарьга чыгарыгыз.",
-		ExportWeek: "7 көнне чыгару", ExportMonth: "30 көнне чыгару", ExportPreparing: "Календарь әзерләнә…", ExportReady: "Календарь әзер",
+		CalendarTitle:      "Намаз календаре", CalendarHelp: "Автоматик яңартыла торган 30 көнлек намаз календарен тоташтырыгыз.",
+		CalendarConnect: "Google Календарьга тоташтыру", CalendarCopy: "Яшерен сылтаманы күчерү", CalendarDisconnect: "Календарьны өзү",
+		CalendarOpening: "Google Календарь ачыла…", CalendarCopied: "Яшерен календарь сылтамасы күчерелде",
+		CalendarDisconnected: "Календарь өзелде",
+		CalendarPrivate:      "Сылтаманы яшерен саклагыз. Яңарту вакытын Google билгели.",
 	},
 }

--- a/global/internal/miniapp/handler_test.go
+++ b/global/internal/miniapp/handler_test.go
@@ -42,9 +42,10 @@ func TestStaticMiniAppIsEmbeddedWithSecurityHeaders(t *testing.T) {
 	if !strings.Contains(string(script), "tgWebAppData") || !strings.Contains(string(script), "/api/miniapp/preferences") {
 		t.Fatal("Mini App script is missing resilient Telegram launch data or unified preference saving")
 	}
-	if !strings.Contains(html, "qibla-compass") || !strings.Contains(html, "export-month") ||
-		!strings.Contains(string(script), "DeviceOrientation") || !strings.Contains(string(script), "downloadFile") {
-		t.Fatal("Mini App is missing Qibla compass or native calendar export support")
+	if !strings.Contains(html, "qibla-compass") || !strings.Contains(html, "connect-calendar") ||
+		!strings.Contains(string(script), "DeviceOrientation") ||
+		!strings.Contains(string(script), "/api/miniapp/calendar-subscription") {
+		t.Fatal("Mini App is missing Qibla compass or rolling calendar subscription support")
 	}
 	if !strings.Contains(response.Header().Get("Content-Security-Policy"), "telegram.org") {
 		t.Fatal("Mini App response is missing its CSP")
@@ -164,7 +165,7 @@ func TestLocationUpdatePreservesCalculationSettingsAndRoundsCoordinates(t *testi
 	}
 }
 
-func TestCalendarExportUsesShortLivedSignedDownload(t *testing.T) {
+func TestCalendarSubscriptionProducesRollingThirtyDayFeed(t *testing.T) {
 	now := time.Date(2026, time.July, 17, 12, 0, 0, 0, time.UTC)
 	storage := newFakeStorage()
 	storage.chats[42] = domain.Chat{TelegramChatID: 42, Type: "private", LanguageCode: "en"}
@@ -178,7 +179,7 @@ func TestCalendarExportUsesShortLivedSignedDownload(t *testing.T) {
 	mux := http.NewServeMux()
 	handler.Register(mux)
 
-	linkRequest := httptest.NewRequest(http.MethodPost, "/api/miniapp/calendar-link", strings.NewReader(`{"days":7}`))
+	linkRequest := httptest.NewRequest(http.MethodPost, "/api/miniapp/calendar-subscription", nil)
 	linkRequest.Header.Set("X-Telegram-Init-Data", signedInitData(t, "test-token", now, initDataUser{
 		ID: 42, FirstName: "Amina", LanguageCode: "en",
 	}))
@@ -187,13 +188,16 @@ func TestCalendarExportUsesShortLivedSignedDownload(t *testing.T) {
 	if linkResponse.Code != http.StatusOK {
 		t.Fatalf("link status = %d, body = %s", linkResponse.Code, linkResponse.Body.String())
 	}
-	var link calendarLinkResponse
+	var link calendarSubscriptionResponse
 	if err := json.Unmarshal(linkResponse.Body.Bytes(), &link); err != nil {
 		t.Fatal(err)
 	}
-	if !strings.HasPrefix(link.Path, "/api/miniapp/calendar.ics?token=") ||
-		link.Filename != "prayer-times-2026-07-17-7-days.ics" {
+	if !link.Enabled || !strings.HasPrefix(link.Path, "/api/miniapp/calendar.ics?token=") {
 		t.Fatalf("unexpected calendar link: %+v", link)
+	}
+	subscription := storage.subscriptions[42]
+	if !subscription.Enabled || len(subscription.FeedToken) != 64 || len(subscription.UIDNamespace) != 32 {
+		t.Fatalf("unexpected stored subscription: %+v", subscription)
 	}
 
 	downloadRequest := httptest.NewRequest(http.MethodGet, link.Path, nil)
@@ -205,33 +209,125 @@ func TestCalendarExportUsesShortLivedSignedDownload(t *testing.T) {
 	if contentType := downloadResponse.Header().Get("Content-Type"); !strings.HasPrefix(contentType, "text/calendar") {
 		t.Fatalf("content type = %q", contentType)
 	}
-	if disposition := downloadResponse.Header().Get("Content-Disposition"); !strings.Contains(disposition, link.Filename) {
+	if disposition := downloadResponse.Header().Get("Content-Disposition"); disposition != `inline; filename="prayer-times.ics"` {
 		t.Fatalf("content disposition = %q", disposition)
 	}
-	if downloadResponse.Header().Get("Access-Control-Allow-Origin") != "https://web.telegram.org" {
-		t.Fatal("calendar response is missing Telegram Web download CORS header")
+	if !strings.Contains(downloadResponse.Body.String(), "REFRESH-INTERVAL;VALUE=DURATION:PT12H") {
+		t.Fatal("calendar response is missing its refresh hint")
 	}
-	if events := strings.Count(downloadResponse.Body.String(), "BEGIN:VEVENT\r\n"); events != 42 {
-		t.Fatalf("calendar event count = %d, want 42", events)
+	if events := strings.Count(downloadResponse.Body.String(), "BEGIN:VEVENT\r\n"); events != 180 {
+		t.Fatalf("calendar event count = %d, want 180", events)
+	}
+	if !strings.Contains(downloadResponse.Body.String(), subscription.UIDNamespace+"-20260717-fajr@global-prayer-bot") {
+		t.Fatal("calendar response is missing its stable event UID")
+	}
+	etag := downloadResponse.Header().Get("ETag")
+	if etag == "" {
+		t.Fatal("calendar response is missing its ETag")
+	}
+	cachedRequest := httptest.NewRequest(http.MethodGet, link.Path, nil)
+	cachedRequest.Header.Set("If-None-Match", etag)
+	cachedResponse := httptest.NewRecorder()
+	mux.ServeHTTP(cachedResponse, cachedRequest)
+	if cachedResponse.Code != http.StatusNotModified {
+		t.Fatalf("cached status = %d, want 304", cachedResponse.Code)
+	}
+	tamperedResponse := httptest.NewRecorder()
+	mux.ServeHTTP(tamperedResponse, httptest.NewRequest(http.MethodGet, link.Path+"0", nil))
+	if tamperedResponse.Code != http.StatusUnauthorized {
+		t.Fatalf("tampered calendar status = %d, want 401", tamperedResponse.Code)
+	}
+
+	now = now.AddDate(0, 0, 1)
+	rolledRequest := httptest.NewRequest(http.MethodGet, link.Path, nil)
+	rolledResponse := httptest.NewRecorder()
+	mux.ServeHTTP(rolledResponse, rolledRequest)
+	if rolledResponse.Code != http.StatusOK {
+		t.Fatalf("rolled feed status = %d, body = %s", rolledResponse.Code, rolledResponse.Body.String())
+	}
+	if strings.Contains(rolledResponse.Body.String(), subscription.UIDNamespace+"-20260717-fajr@global-prayer-bot") ||
+		!strings.Contains(rolledResponse.Body.String(), subscription.UIDNamespace+"-20260718-fajr@global-prayer-bot") {
+		t.Fatal("calendar feed did not roll forward by one local day")
 	}
 }
 
-func TestCalendarTokensRejectTamperingAndExpiry(t *testing.T) {
+func TestCalendarSubscriptionCanBeRevoked(t *testing.T) {
 	now := time.Date(2026, time.July, 17, 12, 0, 0, 0, time.UTC)
-	token, err := signCalendarToken("secret", calendarTokenPayload{
-		ChatID: 42, Days: 30, ExpiresAt: now.Add(calendarTokenLifetime).Unix(),
+	storage := newFakeStorage()
+	storage.chats[42] = domain.Chat{TelegramChatID: 42, Type: "private", LanguageCode: "en"}
+	storage.profiles[42] = domain.PrayerProfile{
+		ChatID: 42, Latitude: 30.044, Longitude: 31.236, Timezone: "Africa/Cairo",
+		Method: domain.MethodEgyptian, Madhab: domain.MadhabShafii,
+		HighLatitudeRule: domain.HighLatitudeAngleBased,
+	}
+	handler := NewHandler("test-token", storage, nil, prayertime.New(), nil, nil)
+	handler.now = func() time.Time { return now }
+	mux := http.NewServeMux()
+	handler.Register(mux)
+	initData := signedInitData(t, "test-token", now, initDataUser{
+		ID: 42, FirstName: "Amina", LanguageCode: "en",
 	})
+
+	createRequest := httptest.NewRequest(http.MethodPost, "/api/miniapp/calendar-subscription", nil)
+	createRequest.Header.Set("X-Telegram-Init-Data", initData)
+	createResponse := httptest.NewRecorder()
+	mux.ServeHTTP(createResponse, createRequest)
+	var created calendarSubscriptionResponse
+	if err := json.Unmarshal(createResponse.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+
+	deleteRequest := httptest.NewRequest(http.MethodDelete, "/api/miniapp/calendar-subscription", nil)
+	deleteRequest.Header.Set("X-Telegram-Init-Data", initData)
+	deleteResponse := httptest.NewRecorder()
+	mux.ServeHTTP(deleteResponse, deleteRequest)
+	if deleteResponse.Code != http.StatusOK || storage.subscriptions[42].Enabled {
+		t.Fatalf("calendar subscription was not disabled: %d %+v", deleteResponse.Code, storage.subscriptions[42])
+	}
+
+	downloadResponse := httptest.NewRecorder()
+	mux.ServeHTTP(downloadResponse, httptest.NewRequest(http.MethodGet, created.Path, nil))
+	if downloadResponse.Code != http.StatusUnauthorized {
+		t.Fatalf("revoked calendar status = %d, want 401", downloadResponse.Code)
+	}
+
+	previous := storage.subscriptions[42]
+	reconnectRequest := httptest.NewRequest(http.MethodPost, "/api/miniapp/calendar-subscription", nil)
+	reconnectRequest.Header.Set("X-Telegram-Init-Data", initData)
+	reconnectResponse := httptest.NewRecorder()
+	mux.ServeHTTP(reconnectResponse, reconnectRequest)
+	var reconnected calendarSubscriptionResponse
+	if err := json.Unmarshal(reconnectResponse.Body.Bytes(), &reconnected); err != nil {
+		t.Fatal(err)
+	}
+	current := storage.subscriptions[42]
+	if reconnected.Path == created.Path || current.FeedToken == previous.FeedToken {
+		t.Fatal("reconnecting did not replace the revoked private feed token")
+	}
+	if current.UIDNamespace != previous.UIDNamespace {
+		t.Fatal("reconnecting changed the stable event UID namespace")
+	}
+	newFeedResponse := httptest.NewRecorder()
+	mux.ServeHTTP(newFeedResponse, httptest.NewRequest(http.MethodGet, reconnected.Path, nil))
+	if newFeedResponse.Code != http.StatusOK {
+		t.Fatalf("reconnected calendar status = %d, want 200", newFeedResponse.Code)
+	}
+}
+
+func TestCalendarCredentialsAreOpaqueAndIndependent(t *testing.T) {
+	firstToken, firstNamespace, err := newCalendarCredentials()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if payload, err := verifyCalendarToken("secret", token, now); err != nil || payload.ChatID != 42 || payload.Days != 30 {
-		t.Fatalf("valid token failed: payload=%+v err=%v", payload, err)
+	secondToken, secondNamespace, err := newCalendarCredentials()
+	if err != nil {
+		t.Fatal(err)
 	}
-	if _, err := verifyCalendarToken("secret", token+"x", now); err == nil {
-		t.Fatal("tampered token was accepted")
+	if len(firstToken) != 64 || len(firstNamespace) != 32 {
+		t.Fatalf("unexpected credential sizes: token=%d namespace=%d", len(firstToken), len(firstNamespace))
 	}
-	if _, err := verifyCalendarToken("secret", token, now.Add(calendarTokenLifetime)); err == nil {
-		t.Fatal("expired token was accepted")
+	if firstToken == secondToken || firstNamespace == secondNamespace {
+		t.Fatal("calendar credentials were unexpectedly reused")
 	}
 }
 
@@ -304,15 +400,17 @@ func TestValidateRemindersRejectsUnsupportedLeadTime(t *testing.T) {
 }
 
 type fakeStorage struct {
-	chats    map[int64]domain.Chat
-	profiles map[int64]domain.PrayerProfile
-	rules    map[int64][]domain.ReminderRule
+	chats         map[int64]domain.Chat
+	profiles      map[int64]domain.PrayerProfile
+	rules         map[int64][]domain.ReminderRule
+	subscriptions map[int64]domain.CalendarSubscription
 }
 
 func newFakeStorage() *fakeStorage {
 	return &fakeStorage{
 		chats: make(map[int64]domain.Chat), profiles: make(map[int64]domain.PrayerProfile),
-		rules: make(map[int64][]domain.ReminderRule),
+		rules:         make(map[int64][]domain.ReminderRule),
+		subscriptions: make(map[int64]domain.CalendarSubscription),
 	}
 }
 
@@ -403,6 +501,54 @@ func (s *fakeStorage) SetWeeklyRule(_ context.Context, chatID int64, kind domain
 		}
 	}
 	s.rules[chatID] = append(s.rules[chatID], domain.ReminderRule{ChatID: chatID, Kind: kind, Enabled: enabled})
+	return nil
+}
+
+func (s *fakeStorage) CalendarSubscription(_ context.Context, chatID int64) (domain.CalendarSubscription, error) {
+	subscription, ok := s.subscriptions[chatID]
+	if !ok {
+		return domain.CalendarSubscription{}, pgx.ErrNoRows
+	}
+	return subscription, nil
+}
+
+func (s *fakeStorage) CalendarSubscriptionByToken(
+	_ context.Context,
+	feedToken string,
+) (domain.CalendarSubscription, error) {
+	for _, subscription := range s.subscriptions {
+		if subscription.FeedToken == feedToken {
+			return subscription, nil
+		}
+	}
+	return domain.CalendarSubscription{}, pgx.ErrNoRows
+}
+
+func (s *fakeStorage) EnableCalendarSubscription(
+	_ context.Context,
+	chatID int64,
+	feedToken string,
+	uidNamespace string,
+) (domain.CalendarSubscription, error) {
+	subscription, ok := s.subscriptions[chatID]
+	if !ok {
+		subscription = domain.CalendarSubscription{
+			ChatID: chatID, FeedToken: feedToken, UIDNamespace: uidNamespace,
+		}
+	} else if !subscription.Enabled {
+		subscription.FeedToken = feedToken
+	}
+	subscription.Enabled = true
+	s.subscriptions[chatID] = subscription
+	return subscription, nil
+}
+
+func (s *fakeStorage) DisableCalendarSubscription(_ context.Context, chatID int64) error {
+	subscription, ok := s.subscriptions[chatID]
+	if ok && subscription.Enabled {
+		subscription.Enabled = false
+		s.subscriptions[chatID] = subscription
+	}
 	return nil
 }
 

--- a/global/internal/miniapp/static/app.css
+++ b/global/internal/miniapp/static/app.css
@@ -211,6 +211,8 @@ button { -webkit-tap-highlight-color: transparent; }
 .calendar-illustration span { position: absolute; z-index: 1; top: 4px; left: 13px; color: #fff8d6; font: 700 22px/1 Georgia, serif; }
 .calendar-illustration strong { margin-top: 24px; font-size: 38px; letter-spacing: -.05em; }
 .calendar-actions { display: grid; gap: 9px; margin-top: auto; }
+.calendar-private { margin: -7px 0 15px; }
+.calendar-disconnect { justify-self: center; color: #a84040; }
 
 .toggle-row { position: relative; display: flex; align-items: center; justify-content: space-between; gap: 16px; min-height: 68px; border-bottom: 1px solid var(--line); cursor: pointer; }
 .toggle-row:last-child { border-bottom: 0; }

--- a/global/internal/miniapp/static/app.js
+++ b/global/internal/miniapp/static/app.js
@@ -8,6 +8,7 @@
   let toastTimer = null;
   let dirty = false;
   let compassStarted = false;
+  let calendarFeedURL = "";
 
   const launchCopy = {
     en: { open: "Open this page from the bot inside Telegram.", expired: "Your Telegram session expired. Close this window and reopen the app from the bot menu.", failed: "The app could not load. Please try again.", retry: "Try again" },
@@ -114,8 +115,10 @@
     setText("start-compass", labels.compass_start);
     setText("calendar-title", labels.calendar_title);
     setText("calendar-help", labels.calendar_help);
-    setText("export-week", labels.export_week);
-    setText("export-month", labels.export_month);
+    setText("calendar-private", labels.calendar_private);
+    setText("connect-calendar", labels.calendar_connect);
+    setText("copy-calendar-link", labels.calendar_copy);
+    setText("disconnect-calendar", labels.calendar_disconnect);
   }
 
   function fillSelect(id, options, selected) {
@@ -204,6 +207,16 @@
     byId("start-compass").disabled = false;
     setText("start-compass", state.labels.compass_start);
     byId("compass-status").classList.add("hidden");
+    renderCalendarSubscription();
+  }
+
+  function renderCalendarSubscription() {
+    const enabled = Boolean(state.calendar && state.calendar.enabled);
+    byId("disconnect-calendar").classList.toggle("hidden", !enabled);
+    byId("calendar-status").classList.add("hidden");
+    setText("connect-calendar", state.labels.calendar_connect);
+    setText("copy-calendar-link", state.labels.calendar_copy);
+    setText("disconnect-calendar", state.labels.calendar_disconnect);
   }
 
   function renderReminders() {
@@ -399,36 +412,80 @@
     });
   }
 
-  function fallbackDownload(url, filename) {
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = filename;
-    link.rel = "noopener";
-    document.body.append(link);
-    link.click();
-    link.remove();
-    showToast(state.labels.export_ready);
+  function setCalendarButtonsDisabled(value) {
+    ["connect-calendar", "copy-calendar-link", "disconnect-calendar"].forEach((id) => {
+      byId(id).disabled = value;
+    });
   }
 
-  async function exportCalendar(days, button) {
-    button.disabled = true;
-    const previousText = button.textContent;
-    button.textContent = state.labels.export_preparing;
+  async function ensureCalendarSubscription() {
+    const subscription = await request("/api/miniapp/calendar-subscription", "POST");
+    state.calendar = subscription;
+    calendarFeedURL = new URL(subscription.path, window.location.origin).href;
+    renderCalendarSubscription();
+    return calendarFeedURL;
+  }
+
+  async function connectGoogleCalendar() {
+    setCalendarButtonsDisabled(true);
+    setText("calendar-status", state.labels.calendar_opening);
+    byId("calendar-status").classList.remove("hidden");
     try {
-      const download = await request("/api/miniapp/calendar-link", "POST", { days });
-      const fileURL = new URL(download.path, window.location.origin).href;
-      if (telegram && telegram.downloadFile && telegram.isVersionAtLeast("8.0") && fileURL.startsWith("https://")) {
-        telegram.downloadFile({ url: fileURL, file_name: download.filename }, (accepted) => {
-          if (accepted) showToast(state.labels.export_ready);
-        });
+      const feedURL = await ensureCalendarSubscription();
+      const googleURL = `https://calendar.google.com/calendar/render?cid=${encodeURIComponent(feedURL)}`;
+      if (telegram && telegram.openLink) {
+        telegram.openLink(googleURL);
       } else {
-        fallbackDownload(fileURL, download.filename);
+        window.open(googleURL, "_blank", "noopener");
       }
+      showToast(state.labels.calendar_opening);
     } catch (_) {
       showToast(state.labels.temporary_failure, true);
     } finally {
-      button.disabled = false;
-      button.textContent = previousText;
+      setCalendarButtonsDisabled(false);
+    }
+  }
+
+  function copyText(value) {
+    if (navigator.clipboard && window.isSecureContext) {
+      return navigator.clipboard.writeText(value);
+    }
+    const input = document.createElement("textarea");
+    input.value = value;
+    input.setAttribute("readonly", "");
+    input.style.position = "fixed";
+    input.style.opacity = "0";
+    document.body.append(input);
+    input.select();
+    const copied = document.execCommand("copy");
+    input.remove();
+    return copied ? Promise.resolve() : Promise.reject(new Error("copy_failed"));
+  }
+
+  async function copyCalendarLink() {
+    setCalendarButtonsDisabled(true);
+    try {
+      const feedURL = calendarFeedURL || await ensureCalendarSubscription();
+      await copyText(feedURL);
+      showToast(state.labels.calendar_copied);
+    } catch (_) {
+      showToast(state.labels.temporary_failure, true);
+    } finally {
+      setCalendarButtonsDisabled(false);
+    }
+  }
+
+  async function disconnectCalendar() {
+    setCalendarButtonsDisabled(true);
+    try {
+      state.calendar = await request("/api/miniapp/calendar-subscription", "DELETE");
+      calendarFeedURL = "";
+      renderCalendarSubscription();
+      showToast(state.labels.calendar_disconnected);
+    } catch (_) {
+      showToast(state.labels.temporary_failure, true);
+    } finally {
+      setCalendarButtonsDisabled(false);
     }
   }
 
@@ -473,8 +530,9 @@
   byId("location-primary").addEventListener("click", (event) => updateLocation(event.currentTarget));
   byId("location-secondary").addEventListener("click", (event) => updateLocation(event.currentTarget));
   byId("start-compass").addEventListener("click", startCompass);
-  byId("export-week").addEventListener("click", (event) => exportCalendar(7, event.currentTarget));
-  byId("export-month").addEventListener("click", (event) => exportCalendar(30, event.currentTarget));
+  byId("connect-calendar").addEventListener("click", connectGoogleCalendar);
+  byId("copy-calendar-link").addEventListener("click", copyCalendarLink);
+  byId("disconnect-calendar").addEventListener("click", disconnectCalendar);
   byId("save-preferences").addEventListener("click", savePreferences);
   byId("retry-app").addEventListener("click", bootstrapApp);
   ["prayer-reminders", "pre-prayer-minutes", "fasting-reminders", "kahf-reminders", "language", "method", "madhab", "highlat", "hijri-adjustment"]

--- a/global/internal/miniapp/static/index.html
+++ b/global/internal/miniapp/static/index.html
@@ -96,17 +96,20 @@
               <span class="tool-icon" aria-hidden="true">📅</span>
               <div>
                 <h3 id="calendar-title">Prayer calendar</h3>
-                <p id="calendar-help">Export prayer times to your calendar.</p>
+                <p id="calendar-help">Connect an automatically updated rolling 30-day calendar.</p>
               </div>
             </div>
             <div class="calendar-illustration" aria-hidden="true">
               <span>☾</span>
               <strong id="calendar-day">30</strong>
             </div>
+            <p id="calendar-private" class="tool-note calendar-private">Keep the private calendar link secret.</p>
             <div class="calendar-actions">
-              <button id="export-week" class="secondary-button" type="button" data-days="7">Export 7 days</button>
-              <button id="export-month" class="primary-button compact" type="button" data-days="30">Export 30 days</button>
+              <button id="connect-calendar" class="primary-button compact" type="button">Connect Google Calendar</button>
+              <button id="copy-calendar-link" class="secondary-button" type="button">Copy private link</button>
+              <button id="disconnect-calendar" class="text-button calendar-disconnect hidden" type="button">Disconnect calendar</button>
             </div>
+            <p id="calendar-status" class="tool-note hidden" role="status"></p>
           </article>
         </div>
       </section>

--- a/global/internal/store/postgres.go
+++ b/global/internal/store/postgres.go
@@ -702,6 +702,70 @@ func (s *Store) FailDelivery(ctx context.Context, deliveryKey string, cause erro
 	return err
 }
 
+func (s *Store) CalendarSubscription(ctx context.Context, chatID int64) (domain.CalendarSubscription, error) {
+	var subscription domain.CalendarSubscription
+	err := s.pool.QueryRow(ctx, `SELECT chat_id, feed_token, uid_namespace, enabled
+		FROM global_bot.calendar_subscriptions WHERE chat_id = $1`, chatID).Scan(
+		&subscription.ChatID,
+		&subscription.FeedToken,
+		&subscription.UIDNamespace,
+		&subscription.Enabled,
+	)
+	return subscription, err
+}
+
+func (s *Store) CalendarSubscriptionByToken(
+	ctx context.Context,
+	feedToken string,
+) (domain.CalendarSubscription, error) {
+	var subscription domain.CalendarSubscription
+	err := s.pool.QueryRow(ctx, `SELECT chat_id, feed_token, uid_namespace, enabled
+		FROM global_bot.calendar_subscriptions WHERE feed_token = $1`, feedToken).Scan(
+		&subscription.ChatID,
+		&subscription.FeedToken,
+		&subscription.UIDNamespace,
+		&subscription.Enabled,
+	)
+	return subscription, err
+}
+
+func (s *Store) EnableCalendarSubscription(
+	ctx context.Context,
+	chatID int64,
+	feedToken string,
+	uidNamespace string,
+) (domain.CalendarSubscription, error) {
+	var subscription domain.CalendarSubscription
+	err := s.pool.QueryRow(ctx, `
+		INSERT INTO global_bot.calendar_subscriptions AS current_subscription
+			(chat_id, feed_token, uid_namespace, enabled)
+		VALUES ($1, $2, $3, true)
+		ON CONFLICT (chat_id) DO UPDATE SET
+			feed_token = CASE
+				WHEN current_subscription.enabled
+				THEN current_subscription.feed_token
+				ELSE excluded.feed_token
+			END,
+			enabled = true,
+			updated_at = now()
+		RETURNING chat_id, feed_token, uid_namespace, enabled`,
+		chatID, feedToken, uidNamespace,
+	).Scan(
+		&subscription.ChatID,
+		&subscription.FeedToken,
+		&subscription.UIDNamespace,
+		&subscription.Enabled,
+	)
+	return subscription, err
+}
+
+func (s *Store) DisableCalendarSubscription(ctx context.Context, chatID int64) error {
+	_, err := s.pool.Exec(ctx, `UPDATE global_bot.calendar_subscriptions
+		SET enabled = false, updated_at = now()
+		WHERE chat_id = $1 AND enabled`, chatID)
+	return err
+}
+
 func errorText(err error) string {
 	if err == nil {
 		return ""

--- a/global/migrations/00004_calendar_subscriptions.sql
+++ b/global/migrations/00004_calendar_subscriptions.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- +goose ENVSUB ON
+CREATE TABLE ${GLOBAL_DB_SCHEMA}.calendar_subscriptions (
+    chat_id BIGINT PRIMARY KEY
+        REFERENCES ${GLOBAL_DB_SCHEMA}.chats(telegram_chat_id) ON DELETE CASCADE,
+    feed_token TEXT NOT NULL UNIQUE
+        CHECK (length(feed_token) = 64 AND feed_token !~ '[^0-9a-f]'),
+    uid_namespace TEXT NOT NULL UNIQUE
+        CHECK (length(uid_namespace) = 32 AND uid_namespace !~ '[^0-9a-f]'),
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- +goose Down
+DROP TABLE ${GLOBAL_DB_SCHEMA}.calendar_subscriptions;
+-- +goose ENVSUB OFF


### PR DESCRIPTION
## What changed

- Replaced one-time 7/30-day calendar downloads with a private, revocable Google Calendar subscription.
- Added a rolling feed containing today plus the following 29 local days, calculated on every fetch from the user's current location and prayer settings.
- Added stable opaque event UIDs, ETag support, and iCalendar refresh hints so updates replace existing prayer events instead of duplicating them.
- Added Mini App controls to connect Google Calendar, copy the private feed URL, and disconnect/revoke it in all supported languages.
- Added an isolated `calendar_subscriptions` table in the global-bot schema; no legacy city-bot tables are touched.
- Updated architecture, request-flow, data-model, deployment, and operations documentation.

## Why

A downloaded calendar becomes stale. A subscribed feed lets Google periodically retrieve a fresh 30-day prayer window while preserving the bot's current calculation method, madhab, high-latitude rule, adjustments, timezone, and language.

Google controls the refresh time for URL subscriptions, so rollover is eventually consistent and is not guaranteed exactly at local midnight. The bot needs no Calendar API OAuth credentials, daily cron, or additional Cloud Run service.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `node --check internal/miniapp/static/app.js`
- `GLOBAL_DB_SCHEMA=global_bot_testing goose -dir migrations validate`
- `terraform -chdir=infra/gcp fmt -check -recursive`
- `terraform -chdir=infra/gcp validate`
- `git diff --check`

Tests cover the 30-day/180-event feed, local-day rollover, stable UIDs, conditional GET, invalid tokens, revocation, reconnection, old-token invalidation, and credential randomness.
