### PR TITLE
[codex] Fix Supabase pooler statement errors

### DIFF
--- a/global/internal/store/postgres.go
+++ b/global/internal/store/postgres.go
@@ -36,7 +36,11 @@ func Open(ctx context.Context, databaseURL, databaseSchema string) (*Store, erro
 	if err := database.ValidateSchema(databaseSchema); err != nil {
 		return nil, fmt.Errorf("validate postgres schema: %w", err)
 	}
-	pool, err := pgxpool.New(ctx, databaseURL)
+	poolConfig, err := runtimePoolConfig(databaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse postgres config: %w", err)
+	}
+	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
 	if err != nil {
 		return nil, fmt.Errorf("open postgres: %w", err)
 	}
@@ -45,6 +49,20 @@ func Open(ctx context.Context, databaseURL, databaseSchema string) (*Store, erro
 		return nil, fmt.Errorf("ping postgres: %w", err)
 	}
 	return &Store{pool: &schemaPool{pool: pool, schema: databaseSchema}}, nil
+}
+
+func runtimePoolConfig(databaseURL string) (*pgxpool.Config, error) {
+	config, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		return nil, err
+	}
+	// Supabase's transaction pooler can execute consecutive queries on
+	// different PostgreSQL connections. Named prepared statements are scoped
+	// to one connection, so pgx's default statement cache produces 42P05
+	// ("already exists") and 26000 ("does not exist") errors through the
+	// pooler. Exec mode uses the extended protocol without named statements.
+	config.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeExec
+	return config, nil
 }
 
 func (p *schemaPool) Close() { p.pool.Close() }

--- a/global/internal/store/postgres_test.go
+++ b/global/internal/store/postgres_test.go
@@ -3,8 +3,26 @@ package store
 import (
 	"testing"
 
+	"github.com/jackc/pgx/v5"
+
 	"github.com/escalopa/prayer-bot/global/internal/database"
 )
+
+func TestRuntimePoolConfigDisablesNamedPreparedStatements(t *testing.T) {
+	config, err := runtimePoolConfig(
+		"postgres://user:password@localhost:5432/database?default_query_exec_mode=cache_statement",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.ConnConfig.DefaultQueryExecMode != pgx.QueryExecModeExec {
+		t.Fatalf(
+			"default query execution mode = %s, want %s",
+			config.ConnConfig.DefaultQueryExecMode,
+			pgx.QueryExecModeExec,
+		)
+	}
+}
 
 func TestQualifySQLUsesIsolatedSchema(t *testing.T) {
 	query := qualifySQL("SELECT * FROM global_bot.chats", database.TestingSchema)


### PR DESCRIPTION
## What changed

- Parse the shared pgx pool configuration before opening runtime connections.
- Force `pgx.QueryExecModeExec` for webhook, dispatcher, and sender database access.
- Add regression coverage proving an unsafe `default_query_exec_mode=cache_statement` URL option cannot re-enable named prepared statements.

## Root cause

The global services connect through the Supabase transaction pooler. pgx's default cached-statement mode creates named prepared statements scoped to an individual PostgreSQL connection, while consecutive pooled transactions may execute on different connections. This produced both `SQLSTATE 42P05` (`prepared statement ... already exists`) and `SQLSTATE 26000` (`prepared statement ... does not exist`). Calendar feed requests, Mini App requests, and Telegram update processing were all affected.

`QueryExecModeExec` keeps the extended protocol but executes without named prepared statements, making runtime queries compatible with transaction pooling.

## Impact

This is a shared runtime fix with no schema, secret, Terraform, or legacy city-bot changes. Deploying the global bot updates all three global Cloud Run services through their common image.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `node --check internal/miniapp/static/app.js`
- `GLOBAL_DB_SCHEMA=global_bot_testing goose -dir migrations validate`
- `terraform -chdir=infra/gcp fmt -check -recursive`
- `terraform -chdir=infra/gcp validate`
- `git diff --check`
