### PR TITLE
[codex] Retry transient Telegram profile sync

### DIFF
--- a/.github/workflows/global-deploy.yaml
+++ b/.github/workflows/global-deploy.yaml
@@ -150,9 +150,13 @@ jobs:
           fi
 
           RETRY_AFTER="$(printf '%s\n' "$PROFILE_OUTPUT" | sed -n 's/^PROFILE_SYNC_SKIPPED_RETRY_AFTER=//p' | tail -n 1)"
+          TRANSIENT_SKIPPED="$(printf '%s\n' "$PROFILE_OUTPUT" | sed -n 's/^PROFILE_SYNC_SKIPPED_TRANSIENT=//p' | tail -n 1)"
           if [[ -n "$RETRY_AFTER" ]]; then
             echo "profile_status=rate limited; skipped (retry after ${RETRY_AFTER}s)" >> "$GITHUB_OUTPUT"
             echo "::warning::Telegram profile updates were rate limited and skipped. Redeploy after ${RETRY_AFTER} seconds."
+          elif [[ "$TRANSIENT_SKIPPED" == "1" ]]; then
+            echo "profile_status=temporary Telegram failure; skipped after retries" >> "$GITHUB_OUTPUT"
+            echo "::warning::Telegram profile synchronization remained temporarily unavailable after retries. Infrastructure deployment succeeded; redeploy later to retry profile synchronization."
           else
             echo "profile_status=synchronized" >> "$GITHUB_OUTPUT"
           fi

--- a/global/cmd/botprofile/main.go
+++ b/global/cmd/botprofile/main.go
@@ -39,6 +39,11 @@ func main() {
 			fmt.Fprintf(os.Stderr, "warning: Telegram profile sync rate limited; skipping profile updates and retrying on a future deployment: %v\n", err)
 			return
 		}
+		if profile.IsTransientFailure(err) {
+			fmt.Println("PROFILE_SYNC_SKIPPED_TRANSIENT=1")
+			fmt.Fprintf(os.Stderr, "warning: Telegram profile sync remained temporarily unavailable after retries; skipping profile updates and retrying on a future deployment: %v\n", err)
+			return
+		}
 		fatal(fmt.Errorf("sync bot profile failed: %w", err))
 	}
 	fmt.Println("PROFILE_SYNC_STATUS=synchronized")

--- a/global/docs/operations.md
+++ b/global/docs/operations.md
@@ -29,6 +29,7 @@ payload.
 | Old notification remains | Immediate Telegram deletion failed and its durable deletion task is retrying or expired past Telegram's limit | [Reminder delivery](reminder-delivery.md#cleanup-categories) |
 | Existing schedules work but location update fails | Google Time Zone or Geocoding failure | [Maps failure mode](#maps-failure-mode) |
 | Mini App says to open it in Telegram | Missing, expired, or invalid signed Telegram init data | [Request flows](request-flows.md#mini-app-session-and-api) |
+| Profile sync reports an empty or malformed Telegram response | The deploy command retries the idempotent sync three times, then skips only the cosmetic profile step | [Runtime and deployment](runtime-and-deployment.md#deployment-workflow) |
 
 For a duplicate reminder, reconstruct the sequence in this order:
 

--- a/global/internal/botprofile/sync.go
+++ b/global/internal/botprofile/sync.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"math/bits"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -34,9 +35,15 @@ var startDescriptions = map[string]string{
 	"tt": "Ботны ачу һәм төп менюны күрсәтү",
 }
 
-var profileSyncDelay = 50 * time.Millisecond
+var (
+	profileSyncDelay        = 50 * time.Millisecond
+	transientSyncRetryDelay = 250 * time.Millisecond
+)
 
-const profilePhotoHashTolerance = 16
+const (
+	profilePhotoHashTolerance = 16
+	transientSyncMaxAttempts  = 3
+)
 
 type profilePhotoAPIResponse struct {
 	OK          bool   `json:"ok"`
@@ -49,8 +56,16 @@ type profilePhotoAPIResponse struct {
 // Sync applies one stable Telegram-facing identity and removes old localized
 // profile variants. User-selected languages belong to chat data and must never
 // mutate global bot metadata. The avatar is uploaded only when the bot does not
-// yet have a profile photo.
+// yet have a profile photo. The complete operation is idempotent, so transient
+// Telegram response failures can safely restart it without repeating unchanged
+// writes.
 func Sync(ctx context.Context, client *botapi.Bot, token, miniAppURL string) error {
+	return retryTransientSync(ctx, func() error {
+		return syncOnce(ctx, client, token, miniAppURL)
+	})
+}
+
+func syncOnce(ctx context.Context, client *botapi.Bot, token, miniAppURL string) error {
 	if err := syncStableIdentity(ctx, client); err != nil {
 		return err
 	}
@@ -92,6 +107,63 @@ func Sync(ctx context.Context, client *botapi.Bot, token, miniAppURL string) err
 		}
 	}
 	return nil
+}
+
+type transientSyncError struct {
+	cause error
+}
+
+func (e *transientSyncError) Error() string {
+	return fmt.Sprintf("Telegram profile sync remained transiently unavailable after %d attempts: %v", transientSyncMaxAttempts, e.cause)
+}
+
+func (e *transientSyncError) Unwrap() error {
+	return e.cause
+}
+
+// IsTransientFailure reports that profile synchronization exhausted its
+// bounded retries on a temporary Telegram or network response. Deployments may
+// safely skip this cosmetic step and try it again on a future run.
+func IsTransientFailure(err error) bool {
+	var transient *transientSyncError
+	return errors.As(err, &transient)
+}
+
+func retryTransientSync(ctx context.Context, operation func() error) error {
+	var lastErr error
+	for attempt := 1; attempt <= transientSyncMaxAttempts; attempt++ {
+		lastErr = operation()
+		if lastErr == nil || !isTransientTelegramError(lastErr) {
+			return lastErr
+		}
+		if attempt == transientSyncMaxAttempts {
+			break
+		}
+		delay := transientSyncRetryDelay * time.Duration(1<<(attempt-1))
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return &transientSyncError{cause: lastErr}
+}
+
+func isTransientTelegramError(err error) bool {
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var syntaxError *json.SyntaxError
+	if errors.As(err, &syntaxError) {
+		return true
+	}
+	var networkError net.Error
+	return errors.As(err, &networkError)
 }
 
 // RateLimitRetryAfter reports Telegram's requested retry delay through wrapped

--- a/global/internal/botprofile/sync_test.go
+++ b/global/internal/botprofile/sync_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"image/jpeg"
 	"net/http"
@@ -150,6 +151,86 @@ func TestProfilePhotoRateLimitIsRecognized(t *testing.T) {
 	if !ok || retryAfter != 3600 {
 		t.Fatalf("RateLimitRetryAfter() = %d, %t", retryAfter, ok)
 	}
+}
+
+func TestTransientProfileSyncRetriesThenSucceeds(t *testing.T) {
+	originalDelay := transientSyncRetryDelay
+	transientSyncRetryDelay = 0
+	t.Cleanup(func() { transientSyncRetryDelay = originalDelay })
+
+	attempts := 0
+	err := retryTransientSync(context.Background(), func() error {
+		attempts++
+		if attempts < transientSyncMaxAttempts {
+			return emptyTelegramResponseError(t)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempts != transientSyncMaxAttempts {
+		t.Fatalf("profile sync attempts = %d, want %d", attempts, transientSyncMaxAttempts)
+	}
+}
+
+func TestTransientProfileSyncExhaustionIsSkippable(t *testing.T) {
+	originalDelay := transientSyncRetryDelay
+	transientSyncRetryDelay = 0
+	t.Cleanup(func() { transientSyncRetryDelay = originalDelay })
+
+	attempts := 0
+	err := retryTransientSync(context.Background(), func() error {
+		attempts++
+		return emptyTelegramResponseError(t)
+	})
+	if !IsTransientFailure(err) {
+		t.Fatalf("expected a skippable transient failure, got %v", err)
+	}
+	if attempts != transientSyncMaxAttempts {
+		t.Fatalf("profile sync attempts = %d, want %d", attempts, transientSyncMaxAttempts)
+	}
+}
+
+func TestPermanentProfileSyncFailureIsNotRetried(t *testing.T) {
+	permanent := errors.New("unauthorized")
+	attempts := 0
+	err := retryTransientSync(context.Background(), func() error {
+		attempts++
+		return permanent
+	})
+	if !errors.Is(err, permanent) || IsTransientFailure(err) {
+		t.Fatalf("expected permanent failure, got %v", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("permanent profile sync attempts = %d, want 1", attempts)
+	}
+}
+
+func TestRateLimitedProfileSyncIsNotRetried(t *testing.T) {
+	limited := &botapi.TooManyRequestsError{Message: "Too Many Requests", RetryAfter: 60}
+	attempts := 0
+	err := retryTransientSync(context.Background(), func() error {
+		attempts++
+		return limited
+	})
+	retryAfter, ok := RateLimitRetryAfter(err)
+	if !ok || retryAfter != 60 {
+		t.Fatalf("expected rate limit to be preserved, got %v", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("rate-limited profile sync attempts = %d, want 1", attempts)
+	}
+}
+
+func emptyTelegramResponseError(t *testing.T) error {
+	t.Helper()
+	var response any
+	err := json.Unmarshal(nil, &response)
+	if err == nil {
+		t.Fatal("empty Telegram response unexpectedly decoded")
+	}
+	return fmt.Errorf("decode Telegram response: %w", err)
 }
 
 func TestProfilePhotoComparisonAllowsJPEGRecompression(t *testing.T) {


### PR DESCRIPTION
## What changed

- Retry the complete idempotent Telegram profile synchronization up to three times with bounded exponential backoff when Telegram returns an empty/malformed JSON response, EOF, timeout, or network failure.
- Re-read profile state on every attempt so already-applied profile fields are not written again.
- Treat exhausted transient profile failures as a nonfatal skipped cosmetic step after infrastructure deployment has succeeded.
- Preserve immediate permanent failure for authentication and invalid-request errors.
- Preserve the existing dedicated rate-limit skip behavior.
- Report transient skips distinctly in the deployment summary and operations guide.

## Root cause

Deployment run `29664799342` successfully built the image, migrated PostgreSQL, applied Terraform, and configured the webhook. Telegram then returned an empty or truncated response to `getMyName`. The Telegram client wrapped the JSON decode failure, and the deployment command treated every non-rate-limit profile error as fatal even though profile synchronization is cosmetic and idempotent.

## Impact

A temporary Telegram profile API response can no longer mark an otherwise successful global deployment as failed. Permanent configuration and authentication problems still fail loudly.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `node --check internal/miniapp/static/app.js`
- `GLOBAL_DB_SCHEMA=global_bot_testing goose -dir migrations validate`
- `terraform -chdir=infra/gcp fmt -check -recursive`
- `terraform -chdir=infra/gcp validate`
- `git diff --check`

Regression tests cover transient recovery, exhausted transient classification, permanent failures, and rate-limit preservation.
