### PR TITLE
Add offline Mini App access and prayer cards

### DIFF
--- a/global/README.md
+++ b/global/README.md
@@ -17,7 +17,8 @@ in the same pull request.
 - Local calculation of prayer times with MWL, Egyptian, Umm al-Qura, Karachi, ISNA, Diyanet, Kemenag, MUIS, and JAKIM methods.
 - Shafii/Hanafi Asr selection, three high-latitude rules, and per-prayer minute adjustments.
 - A persistent two-column Telegram menu for today, tomorrow, the next prayer, location, settings, reminders, language, and help.
-- A Telegram Mini App, opened from the bot menu, for today/tomorrow schedules, location, calculation settings, Hijri correction, and all reminder toggles without typed commands.
+- A Telegram Mini App, opened from the bot menu or an optional Telegram home-screen shortcut, for today/tomorrow schedules, location, calculation settings, Hijri correction, and all reminder toggles without typed commands.
+- A privacy-safe, per-user 48-hour Mini App cache for instant startup and read-only access to saved schedules, Qibla data, and prayer-card sharing during temporary network failures.
 - Inline button pickers for calculation method, madhab, high-latitude rule, per-prayer adjustments, reminder state, and language. The equivalent typed commands remain available.
 - Localized messages, reply keyboards, prayer names, dates, Mini App, and reminder deliveries in English, Arabic, Spanish, French, Russian, Turkish, Uzbek, and Tatar. The public Telegram bot name and description remain stable for every user.
 - Gregorian and calculated Umm al-Qura Hijri dates on every daily schedule, with a per-chat moon-sighting correction from -2 to +2 days.
@@ -26,6 +27,7 @@ in the same pull request.
 - Category-aware notification cleanup: a new prayer notice replaces the preceding prayer/pre-prayer message, weekly categories are independent, and every reminder expires within Telegram's deletion window.
 - A Qibla tool that calculates the initial great-circle bearing and distance to the Kaaba from the saved rounded coordinates, with optional live compass orientation on supported Telegram clients.
 - A revocable private Google Calendar subscription that serves a localized rolling 30-day prayer feed and automatically reflects the saved location and calculation settings when Google refreshes it.
+- Localized 1080×1350 prayer cards generated entirely in the Mini App and shared through the device share sheet, with a gallery-download fallback.
 - An embedded welcome illustration sent on `/start` and a generated bot avatar installed during profile synchronization.
 - A localized feedback and bug-report flow that accepts text or screenshots in a private chat and delivers them directly to the configured owner with the sender's disclosed Telegram identity.
 - An owner-only `/admin` dashboard with aggregate user activity, onboarding, language, calculation-method, reminder-adoption, queue, and delivery-health metrics.
@@ -50,7 +52,7 @@ Feedback arrives in the owner's private bot chat as a metadata message followed 
 | `dispatch` | Cloud Scheduler service account only | Claim due indexed schedules and create Cloud Tasks |
 | `sender` | Cloud Tasks service account only | Idempotent Telegram delivery, category cleanup, and next-occurrence planning |
 
-The three services use one immutable image and select `/webhook`, `/dispatch`, or `/send` as the command. The webhook binary embeds the Mini App and serves it at `/app/`, so the feature does not add another Cloud Run service, container image, database, migration, or secret.
+The three services use one immutable image and select `/webhook`, `/dispatch`, or `/send` as the command. The webhook binary embeds the Mini App and serves it at `/app/`, so the feature does not add another Cloud Run service, container image, database, migration, or secret. Offline snapshots remain on the user's device, and prayer cards are rendered in the browser; neither feature adds server storage or scheduled work.
 
 Calendar subscriptions use a random private bearer URL created only after the Mini App session has been authenticated. The URL exposes neither the Telegram user ID nor the bot token and can be revoked from the Mini App. Each fetch calculates today and the following 29 local days, so no daily cron or stored calendar events are required. Google controls when subscribed calendars refresh, so updates are not guaranteed to appear exactly at local midnight. Qibla calculations and calendar generation use the existing saved profile and prayer engine, so neither feature adds an external API call from the bot or a recurring job.
 

--- a/global/docs/architecture.md
+++ b/global/docs/architecture.md
@@ -26,6 +26,26 @@ The backend never trusts a Telegram user ID sent in JSON. Every Mini App API req
 
 The Qibla tool derives a great-circle bearing from the rounded coordinates already present in the profile and sends only the resulting bearing and distance to the browser. Supported Telegram clients can rotate the displayed needle with absolute device-orientation data; unsupported clients retain the numeric bearing and static compass.
 
+After an authenticated bootstrap, the Mini App stores a rendering snapshot for
+at most 48 hours. Storage is namespaced by the signed Telegram user and uses
+Telegram Device Storage when the client supports it, with browser local storage
+as a compatibility fallback. A same-origin service worker caches the versioned
+HTML, CSS, JavaScript, and Telegram SDK application shell so a previously opened
+Mini App can start during a network interruption. The snapshot omits the numeric
+Telegram ID and never contains raw coordinates, the bot token, signed init data,
+or the private calendar feed URL. A cached launch is read-only until the
+same-origin API responds: schedules, Qibla, and prayer-card sharing remain
+available, while location, settings, reminders, and calendar mutations are
+disabled. A fresh bootstrap replaces the snapshot.
+
+Supported Telegram clients may add a Mini App shortcut to their home screen.
+This is a client-side entry point to the same signed Mini App and creates no new
+service or authentication path. Prayer cards are likewise generated entirely
+in the browser as localized PNG files from the selected today/tomorrow
+schedule. The native device share sheet is used when file sharing is supported;
+otherwise the image is downloaded for manual sharing. Cards are not uploaded or
+stored by the bot.
+
 Calendar connection first creates or reuses a random private subscription URL
 from an authenticated Mini App request. Google Calendar fetches that URL without
 Telegram authentication, so possession of the URL is the access credential. The

--- a/global/docs/request-flows.md
+++ b/global/docs/request-flows.md
@@ -76,6 +76,22 @@ snapshot only after the user presses **Save changes**. A successful response is
 a new complete bootstrap snapshot, allowing the UI to re-render immediately in
 the newly selected language.
 
+### Cached startup and offline behavior
+
+On a returning launch, the Mini App reads a device-local snapshot scoped to the
+Telegram user and renders it immediately while requesting a fresh bootstrap.
+Snapshots older than 48 hours or missing a complete today/tomorrow schedule are
+discarded. If refresh succeeds, the live response replaces the cache. If it
+fails temporarily, the cached schedule remains visible with an offline banner,
+but all server-side mutations stay disabled. An expired or invalid signed
+Telegram session still fails closed with the normal reopen-from-Telegram state;
+the cache never bypasses server authentication.
+
+The selected day's schedule can be rendered into a localized portrait PNG and
+sent to the platform share sheet without an API request. When file sharing is
+unavailable, the browser saves the PNG instead. No card contents leave the
+device through the bot backend.
+
 ## Prayer schedule display
 
 Both the conversational bot and Mini App use the same profile and

--- a/global/internal/miniapp/handler.go
+++ b/global/internal/miniapp/handler.go
@@ -686,6 +686,15 @@ func labels(locale i18n.Locale) map[string]string {
 		"calendar_disconnect": copy.CalendarDisconnect, "calendar_opening": copy.CalendarOpening,
 		"calendar_copied": copy.CalendarCopied, "calendar_disconnected": copy.CalendarDisconnected,
 		"calendar_private": copy.CalendarPrivate,
+		"offline_updating": copy.OfflineUpdating, "offline_updating_help": copy.OfflineUpdatingHelp,
+		"offline_title": copy.OfflineTitle, "offline_help": copy.OfflineHelp,
+		"home_title": copy.HomeTitle, "home_help": copy.HomeHelp,
+		"home_add": copy.HomeAdd, "home_added": copy.HomeAdded,
+		"share_title": copy.ShareTitle, "share_help": copy.ShareHelp,
+		"share_action": copy.ShareAction, "share_preparing": copy.SharePreparing,
+		"share_downloaded": copy.ShareDownloaded, "share_failed": copy.ShareFailed,
+		"share_card_heading": copy.ShareCardHeading, "share_card_footer": copy.ShareCardFooter,
+		"share_message": copy.ShareMessage,
 	}
 }
 
@@ -699,6 +708,12 @@ type miniAppCopy struct {
 	CalendarConnect, CalendarCopy, CalendarDisconnect     string
 	CalendarOpening, CalendarCopied, CalendarDisconnected string
 	CalendarPrivate                                       string
+	OfflineUpdating, OfflineUpdatingHelp                  string
+	OfflineTitle, OfflineHelp                             string
+	HomeTitle, HomeHelp, HomeAdd, HomeAdded               string
+	ShareTitle, ShareHelp, ShareAction, SharePreparing    string
+	ShareDownloaded, ShareFailed                          string
+	ShareCardHeading, ShareCardFooter, ShareMessage       string
 }
 
 var miniCopy = map[string]miniAppCopy{
@@ -717,6 +732,15 @@ var miniCopy = map[string]miniAppCopy{
 		CalendarOpening: "Opening Google Calendar…", CalendarCopied: "Private calendar link copied",
 		CalendarDisconnected: "Calendar feed disconnected",
 		CalendarPrivate:      "Keep the link private. Google controls when subscribed calendars refresh.",
+		OfflineUpdating:      "Updating prayer times…", OfflineUpdatingHelp: "Showing the saved schedule while the latest data loads.",
+		OfflineTitle: "Offline schedule", OfflineHelp: "Showing the schedule saved at {time}. Changes will be available after reconnecting.",
+		HomeTitle: "Quick access", HomeHelp: "Add prayer times to your Telegram home screen.",
+		HomeAdd: "Add to home screen", HomeAdded: "Added to home screen",
+		ShareTitle: "Share prayer card", ShareHelp: "Create a beautiful image with the selected day’s prayer times.",
+		ShareAction: "Create & share", SharePreparing: "Creating card…",
+		ShareDownloaded: "Card saved. Share it from your gallery.", ShareFailed: "The prayer card could not be created.",
+		ShareCardHeading: "Daily prayer times", ShareCardFooter: "Global Prayer Times",
+		ShareMessage: "Prayer times",
 	},
 	"ar": {
 		Save: "حفظ التغييرات", Saved: "تم الحفظ", Loading: "جارٍ تحميل مواقيت الصلاة…",
@@ -733,6 +757,15 @@ var miniCopy = map[string]miniAppCopy{
 		CalendarOpening: "جارٍ فتح تقويم Google…", CalendarCopied: "تم نسخ رابط التقويم الخاص",
 		CalendarDisconnected: "تم قطع اتصال التقويم",
 		CalendarPrivate:      "احتفظ بالرابط سريًا. يحدد Google وقت تحديث التقويمات المشتركة.",
+		OfflineUpdating:      "جارٍ تحديث المواقيت…", OfflineUpdatingHelp: "نعرض الجدول المحفوظ أثناء تحميل أحدث البيانات.",
+		OfflineTitle: "الجدول دون اتصال", OfflineHelp: "نعرض الجدول المحفوظ الساعة {time}. ستتوفر التغييرات بعد عودة الاتصال.",
+		HomeTitle: "وصول سريع", HomeHelp: "أضف مواقيت الصلاة إلى شاشة تيليجرام الرئيسية.",
+		HomeAdd: "إضافة إلى الشاشة الرئيسية", HomeAdded: "تمت الإضافة إلى الشاشة الرئيسية",
+		ShareTitle: "مشاركة بطاقة الصلاة", ShareHelp: "أنشئ صورة جميلة بمواقيت اليوم المحدد.",
+		ShareAction: "إنشاء ومشاركة", SharePreparing: "جارٍ إنشاء البطاقة…",
+		ShareDownloaded: "تم حفظ البطاقة. شاركها من معرض الصور.", ShareFailed: "تعذر إنشاء بطاقة الصلاة.",
+		ShareCardHeading: "مواقيت الصلاة اليومية", ShareCardFooter: "مواقيت الصلاة العالمية",
+		ShareMessage: "مواقيت الصلاة",
 	},
 	"es": {
 		Save: "Guardar cambios", Saved: "Guardado", Loading: "Cargando horarios de oración…",
@@ -749,6 +782,15 @@ var miniCopy = map[string]miniAppCopy{
 		CalendarOpening: "Abriendo Google Calendar…", CalendarCopied: "Enlace privado copiado",
 		CalendarDisconnected: "Calendario desconectado",
 		CalendarPrivate:      "Mantén el enlace privado. Google decide cuándo actualizar los calendarios suscritos.",
+		OfflineUpdating:      "Actualizando horarios…", OfflineUpdatingHelp: "Mostramos el horario guardado mientras se cargan los datos nuevos.",
+		OfflineTitle: "Horario sin conexión", OfflineHelp: "Mostrando el horario guardado a las {time}. Los cambios estarán disponibles al reconectar.",
+		HomeTitle: "Acceso rápido", HomeHelp: "Añade los horarios a la pantalla de inicio de Telegram.",
+		HomeAdd: "Añadir a inicio", HomeAdded: "Añadido a inicio",
+		ShareTitle: "Compartir tarjeta", ShareHelp: "Crea una imagen con los horarios del día seleccionado.",
+		ShareAction: "Crear y compartir", SharePreparing: "Creando tarjeta…",
+		ShareDownloaded: "Tarjeta guardada. Compártela desde tu galería.", ShareFailed: "No se pudo crear la tarjeta.",
+		ShareCardHeading: "Horarios diarios de oración", ShareCardFooter: "Horarios de oración globales",
+		ShareMessage: "Horarios de oración",
 	},
 	"fr": {
 		Save: "Enregistrer", Saved: "Enregistré", Loading: "Chargement des horaires de prière…",
@@ -765,6 +807,15 @@ var miniCopy = map[string]miniAppCopy{
 		CalendarOpening: "Ouverture de Google Agenda…", CalendarCopied: "Lien privé copié",
 		CalendarDisconnected: "Calendrier déconnecté",
 		CalendarPrivate:      "Gardez ce lien privé. Google décide quand actualiser les calendriers abonnés.",
+		OfflineUpdating:      "Actualisation des horaires…", OfflineUpdatingHelp: "L’horaire enregistré reste affiché pendant le chargement.",
+		OfflineTitle: "Horaire hors ligne", OfflineHelp: "Horaire enregistré à {time}. Les modifications seront disponibles après reconnexion.",
+		HomeTitle: "Accès rapide", HomeHelp: "Ajoutez les horaires à l’écran d’accueil Telegram.",
+		HomeAdd: "Ajouter à l’accueil", HomeAdded: "Ajouté à l’accueil",
+		ShareTitle: "Partager une carte", ShareHelp: "Créez une image avec les horaires du jour sélectionné.",
+		ShareAction: "Créer et partager", SharePreparing: "Création de la carte…",
+		ShareDownloaded: "Carte enregistrée. Partagez-la depuis votre galerie.", ShareFailed: "Impossible de créer la carte.",
+		ShareCardHeading: "Horaires de prière du jour", ShareCardFooter: "Horaires de prière mondiaux",
+		ShareMessage: "Horaires de prière",
 	},
 	"ru": {
 		Save: "Сохранить", Saved: "Сохранено", Loading: "Загружаем время намаза…",
@@ -781,6 +832,15 @@ var miniCopy = map[string]miniAppCopy{
 		CalendarOpening: "Открываем Google Календарь…", CalendarCopied: "Закрытая ссылка скопирована",
 		CalendarDisconnected: "Календарь отключён",
 		CalendarPrivate:      "Не передавайте ссылку другим. Частоту обновления подписки определяет Google.",
+		OfflineUpdating:      "Обновляем время намаза…", OfflineUpdatingHelp: "Пока новые данные загружаются, показываем сохранённое расписание.",
+		OfflineTitle: "Расписание офлайн", OfflineHelp: "Показано расписание, сохранённое в {time}. Изменения станут доступны после подключения.",
+		HomeTitle: "Быстрый доступ", HomeHelp: "Добавьте время намаза на главный экран Telegram.",
+		HomeAdd: "Добавить на главный экран", HomeAdded: "Добавлено на главный экран",
+		ShareTitle: "Поделиться карточкой", ShareHelp: "Создайте красивую карточку с расписанием выбранного дня.",
+		ShareAction: "Создать и поделиться", SharePreparing: "Создаём карточку…",
+		ShareDownloaded: "Карточка сохранена. Поделитесь ею из галереи.", ShareFailed: "Не удалось создать карточку.",
+		ShareCardHeading: "Время намаза на день", ShareCardFooter: "Global Prayer Times",
+		ShareMessage: "Время намаза",
 	},
 	"tr": {
 		Save: "Değişiklikleri kaydet", Saved: "Kaydedildi", Loading: "Namaz vakitleri yükleniyor…",
@@ -797,6 +857,15 @@ var miniCopy = map[string]miniAppCopy{
 		CalendarOpening: "Google Takvim açılıyor…", CalendarCopied: "Özel takvim bağlantısı kopyalandı",
 		CalendarDisconnected: "Takvim bağlantısı kesildi",
 		CalendarPrivate:      "Bağlantıyı gizli tutun. Abone takvimlerin yenilenme zamanını Google belirler.",
+		OfflineUpdating:      "Namaz vakitleri güncelleniyor…", OfflineUpdatingHelp: "Yeni veriler yüklenirken kayıtlı takvim gösteriliyor.",
+		OfflineTitle: "Çevrimdışı takvim", OfflineHelp: "{time} saatinde kaydedilen takvim gösteriliyor. Değişiklikler bağlantı gelince açılır.",
+		HomeTitle: "Hızlı erişim", HomeHelp: "Namaz vakitlerini Telegram ana ekranına ekleyin.",
+		HomeAdd: "Ana ekrana ekle", HomeAdded: "Ana ekrana eklendi",
+		ShareTitle: "Namaz kartını paylaş", ShareHelp: "Seçilen günün vakitleriyle güzel bir görsel oluşturun.",
+		ShareAction: "Oluştur ve paylaş", SharePreparing: "Kart oluşturuluyor…",
+		ShareDownloaded: "Kart kaydedildi. Galerinizden paylaşın.", ShareFailed: "Namaz kartı oluşturulamadı.",
+		ShareCardHeading: "Günlük namaz vakitleri", ShareCardFooter: "Global Namaz Vakitleri",
+		ShareMessage: "Namaz vakitleri",
 	},
 	"uz": {
 		Save: "O‘zgarishlarni saqlash", Saved: "Saqlandi", Loading: "Namoz vaqtlari yuklanmoqda…",
@@ -813,6 +882,15 @@ var miniCopy = map[string]miniAppCopy{
 		CalendarOpening: "Google Taqvim ochilmoqda…", CalendarCopied: "Maxfiy taqvim havolasi nusxalandi",
 		CalendarDisconnected: "Taqvim uzildi",
 		CalendarPrivate:      "Havolani maxfiy saqlang. Obuna taqvimini qachon yangilashni Google belgilaydi.",
+		OfflineUpdating:      "Namoz vaqtlari yangilanmoqda…", OfflineUpdatingHelp: "Yangi ma’lumot yuklanayotganda saqlangan jadval ko‘rsatiladi.",
+		OfflineTitle: "Oflayn jadval", OfflineHelp: "{time} da saqlangan jadval ko‘rsatilmoqda. O‘zgarishlar ulanish qaytgach ishlaydi.",
+		HomeTitle: "Tezkor kirish", HomeHelp: "Namoz vaqtlarini Telegram bosh ekraniga qo‘shing.",
+		HomeAdd: "Bosh ekranga qo‘shish", HomeAdded: "Bosh ekranga qo‘shildi",
+		ShareTitle: "Namoz kartasini ulashish", ShareHelp: "Tanlangan kun vaqtlari bilan chiroyli rasm yarating.",
+		ShareAction: "Yaratish va ulashish", SharePreparing: "Karta yaratilmoqda…",
+		ShareDownloaded: "Karta saqlandi. Uni galereyadan ulashing.", ShareFailed: "Namoz kartasini yaratib bo‘lmadi.",
+		ShareCardHeading: "Kunlik namoz vaqtlari", ShareCardFooter: "Global Namoz Vaqtlari",
+		ShareMessage: "Namoz vaqtlari",
 	},
 	"tt": {
 		Save: "Үзгәрешләрне саклау", Saved: "Сакланды", Loading: "Намаз вакытлары йөкләнә…",
@@ -829,5 +907,14 @@ var miniCopy = map[string]miniAppCopy{
 		CalendarOpening: "Google Календарь ачыла…", CalendarCopied: "Яшерен календарь сылтамасы күчерелде",
 		CalendarDisconnected: "Календарь өзелде",
 		CalendarPrivate:      "Сылтаманы яшерен саклагыз. Яңарту вакытын Google билгели.",
+		OfflineUpdating:      "Намаз вакытлары яңартыла…", OfflineUpdatingHelp: "Яңа мәгълүмат йөкләнгәндә сакланган җәдвәл күрсәтелә.",
+		OfflineTitle: "Офлайн җәдвәл", OfflineHelp: "{time} сәгатьтә сакланган җәдвәл күрсәтелә. Үзгәрешләр элемтә кайткач эшләячәк.",
+		HomeTitle: "Тиз керү", HomeHelp: "Намаз вакытларын Telegram төп экранына өстәгез.",
+		HomeAdd: "Төп экранга өстәү", HomeAdded: "Төп экранга өстәлде",
+		ShareTitle: "Намаз карточкасын бүлешү", ShareHelp: "Сайланган көн вакытлары белән матур рәсем ясагыз.",
+		ShareAction: "Ясау һәм бүлешү", SharePreparing: "Карточка ясала…",
+		ShareDownloaded: "Карточка сакланды. Галереядән бүлешегез.", ShareFailed: "Намаз карточкасын ясап булмады.",
+		ShareCardHeading: "Көнлек намаз вакытлары", ShareCardFooter: "Глобаль намаз вакытлары",
+		ShareMessage: "Намаз вакытлары",
 	},
 }

--- a/global/internal/miniapp/handler_test.go
+++ b/global/internal/miniapp/handler_test.go
@@ -47,8 +47,42 @@ func TestStaticMiniAppIsEmbeddedWithSecurityHeaders(t *testing.T) {
 		!strings.Contains(string(script), "/api/miniapp/calendar-subscription") {
 		t.Fatal("Mini App is missing Qibla compass or rolling calendar subscription support")
 	}
+	if !strings.Contains(html, "add-home-screen") || !strings.Contains(html, "share-prayer-card") ||
+		!strings.Contains(string(script), "DeviceStorage") ||
+		!strings.Contains(string(script), "addToHomeScreen") ||
+		!strings.Contains(string(script), "navigator.share") ||
+		!strings.Contains(string(script), "canvas.toDataURL") {
+		t.Fatal("Mini App is missing offline, home-screen, or prayer-card sharing support")
+	}
+	serviceWorker, err := embeddedStatic.ReadFile("static/sw.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(script), "serviceWorker.register") ||
+		!strings.Contains(string(serviceWorker), "global-prayer-miniapp-shell") ||
+		!strings.Contains(string(script), "delete snapshot.calendar.path") {
+		t.Fatal("Mini App is missing its safe offline application shell")
+	}
 	if !strings.Contains(response.Header().Get("Content-Security-Policy"), "telegram.org") {
 		t.Fatal("Mini App response is missing its CSP")
+	}
+}
+
+func TestOfflineAndSharingLabelsExistForEveryLocale(t *testing.T) {
+	keys := []string{
+		"offline_updating", "offline_updating_help", "offline_title", "offline_help",
+		"home_title", "home_help", "home_add", "home_added",
+		"share_title", "share_help", "share_action", "share_preparing",
+		"share_downloaded", "share_failed", "share_card_heading",
+		"share_card_footer", "share_message",
+	}
+	for _, locale := range i18n.Supported() {
+		localized := labels(locale)
+		for _, key := range keys {
+			if localized[key] == "" {
+				t.Errorf("locale %q has no %q label", locale.Code, key)
+			}
+		}
 	}
 }
 

--- a/global/internal/miniapp/static/app.css
+++ b/global/internal/miniapp/static/app.css
@@ -91,6 +91,26 @@ button { -webkit-tap-highlight-color: transparent; }
 }
 @keyframes spin { to { transform: rotate(360deg); } }
 
+.connection-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 11px;
+  margin-bottom: 12px;
+  padding: 13px 15px;
+  border: 1px solid color-mix(in srgb, #b48624 30%, var(--line));
+  border-radius: 17px;
+  color: var(--app-text);
+  background: color-mix(in srgb, #f2d887 18%, var(--surface));
+}
+.connection-banner.refreshing {
+  border-color: color-mix(in srgb, var(--accent) 25%, var(--line));
+  background: color-mix(in srgb, var(--accent) 7%, var(--surface));
+}
+.connection-icon { flex: 0 0 auto; color: #9a7424; font-size: 20px; line-height: 1.2; }
+.connection-banner.refreshing .connection-icon { color: var(--accent); }
+.connection-banner strong { display: block; margin-bottom: 3px; font-size: 13px; }
+.connection-banner p { margin: 0; color: var(--app-muted); font-size: 11px; line-height: 1.45; }
+
 .segmented {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -213,6 +233,55 @@ button { -webkit-tap-highlight-color: transparent; }
 .calendar-actions { display: grid; gap: 9px; margin-top: auto; }
 .calendar-private { margin: -7px 0 15px; }
 .calendar-disconnect { justify-self: center; color: #a84040; }
+
+.quick-access-card, .share-card { display: flex; flex-direction: column; }
+.quick-access-illustration {
+  display: grid;
+  place-items: center;
+  width: 94px;
+  height: 94px;
+  margin: 25px auto 23px;
+  border: 7px solid color-mix(in srgb, var(--app-text) 83%, transparent);
+  border-radius: 22px;
+  color: #fff8d6;
+  background: linear-gradient(145deg, #237f62, #0c4c3d);
+  box-shadow: 0 14px 28px rgba(25, 57, 45, .14);
+}
+.quick-access-illustration span { font: 700 49px/1 Georgia, serif; transform: rotate(-10deg); }
+.quick-access-card .secondary-button { margin-top: auto; }
+
+.share-card-preview {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  width: 154px;
+  height: 190px;
+  margin: 20px auto;
+  padding: 17px;
+  overflow: hidden;
+  border-radius: 21px;
+  color: #fffdf2;
+  background:
+    radial-gradient(circle at 84% 12%, rgba(226, 189, 91, .36), transparent 28%),
+    linear-gradient(155deg, #143e36, #071d28 75%);
+  box-shadow: 0 16px 34px rgba(8, 38, 32, .22);
+}
+.share-card-preview::after {
+  position: absolute;
+  right: -28px;
+  bottom: -30px;
+  width: 105px;
+  height: 105px;
+  border: 1px solid rgba(255, 255, 255, .12);
+  border-radius: 50%;
+  content: "";
+}
+.share-preview-moon { position: absolute; top: 12px; right: 16px; color: #f0cf72; font: 700 38px/1 Georgia, serif; }
+[dir="rtl"] .share-preview-moon { right: auto; left: 16px; }
+.share-card-preview strong { position: relative; z-index: 1; font-size: 13px; line-height: 1.3; }
+.share-card-preview > span:last-child { position: relative; z-index: 1; margin-top: 5px; color: #d9bd6e; font-size: 11px; font-weight: 750; }
+.share-card .primary-button { margin-top: auto; }
 
 .toggle-row { position: relative; display: flex; align-items: center; justify-content: space-between; gap: 16px; min-height: 68px; border-bottom: 1px solid var(--line); cursor: pointer; }
 .toggle-row:last-child { border-bottom: 0; }

--- a/global/internal/miniapp/static/app.js
+++ b/global/internal/miniapp/static/app.js
@@ -9,6 +9,10 @@
   let dirty = false;
   let compassStarted = false;
   let calendarFeedURL = "";
+  let offlineMode = false;
+  let homeScreenStatus = "unknown";
+  const offlineCacheVersion = 1;
+  const offlineCacheMaxAge = 48 * 60 * 60 * 1000;
 
   const launchCopy = {
     en: { open: "Open this page from the bot inside Telegram.", expired: "Your Telegram session expired. Close this window and reopen the app from the bot menu.", failed: "The app could not load. Please try again.", retry: "Try again" },
@@ -52,6 +56,14 @@
     }
   }
 
+  if ("serviceWorker" in navigator) {
+    window.addEventListener("load", () => {
+      navigator.serviceWorker.register("./sw.js", { scope: "./" }).catch(() => {
+        // Offline shell caching is an enhancement; live Mini App use continues.
+      });
+    });
+  }
+
   async function request(path, method = "POST", body) {
     const signedData = currentInitData();
     const response = await fetch(path, {
@@ -71,6 +83,84 @@
       throw error;
     }
     return data;
+  }
+
+  function telegramUserID() {
+    const user = telegram && telegram.initDataUnsafe && telegram.initDataUnsafe.user;
+    return user && Number.isSafeInteger(Number(user.id)) ? String(user.id) : "";
+  }
+
+  function offlineCacheKey() {
+    const userID = telegramUserID();
+    return userID ? `global-prayer-miniapp-v${offlineCacheVersion}-${userID}` : "";
+  }
+
+  function telegramVersionAtLeast(version) {
+    return Boolean(telegram && telegram.isVersionAtLeast && telegram.isVersionAtLeast(version));
+  }
+
+  function deviceStorageAvailable() {
+    return Boolean(telegramVersionAtLeast("9.0") && telegram.DeviceStorage);
+  }
+
+  function readStoredValue(key) {
+    if (!key) return Promise.resolve("");
+    if (deviceStorageAvailable()) {
+      return new Promise((resolve) => {
+        telegram.DeviceStorage.getItem(key, (error, value) => resolve(error ? "" : (value || "")));
+      });
+    }
+    try {
+      return Promise.resolve(window.localStorage.getItem(key) || "");
+    } catch (_) {
+      return Promise.resolve("");
+    }
+  }
+
+  function writeStoredValue(key, value) {
+    if (!key) return Promise.resolve();
+    if (deviceStorageAvailable()) {
+      return new Promise((resolve) => {
+        telegram.DeviceStorage.setItem(key, value, () => resolve());
+      });
+    }
+    try {
+      window.localStorage.setItem(key, value);
+    } catch (_) {
+      // A denied or full browser store must never prevent the live app loading.
+    }
+    return Promise.resolve();
+  }
+
+  function offlineSnapshot(next) {
+    if (!next || next.needs_location || !next.today || !next.tomorrow || !next.labels) return null;
+    const snapshot = JSON.parse(JSON.stringify(next));
+    // The cache key is already scoped to Telegram's signed user. The numeric
+    // account identifier is unnecessary for rendering and is not persisted.
+    if (snapshot.user) delete snapshot.user.id;
+    // The calendar path is a bearer credential and must remain memory-only.
+    if (snapshot.calendar) delete snapshot.calendar.path;
+    return snapshot;
+  }
+
+  async function cacheState(next) {
+    const snapshot = offlineSnapshot(next);
+    if (!snapshot) return;
+    await writeStoredValue(offlineCacheKey(), JSON.stringify({
+      saved_at: Date.now(),
+      state: snapshot,
+    }));
+  }
+
+  async function cachedState() {
+    try {
+      const stored = JSON.parse(await readStoredValue(offlineCacheKey()));
+      const age = Date.now() - Number(stored.saved_at);
+      if (!stored.state || age < 0 || age > offlineCacheMaxAge || !offlineSnapshot(stored.state)) return null;
+      return stored;
+    } catch (_) {
+      return null;
+    }
   }
 
   function setText(id, value) {
@@ -119,6 +209,12 @@
     setText("connect-calendar", labels.calendar_connect);
     setText("copy-calendar-link", labels.calendar_copy);
     setText("disconnect-calendar", labels.calendar_disconnect);
+    setText("home-screen-title", labels.home_title);
+    setText("home-screen-help", labels.home_help);
+    setText("add-home-screen", homeScreenStatus === "added" ? labels.home_added : labels.home_add);
+    setText("share-card-title", labels.share_title);
+    setText("share-card-help", labels.share_help);
+    setText("share-prayer-card", labels.share_action);
   }
 
   function fillSelect(id, options, selected) {
@@ -184,6 +280,9 @@
       item.append(emoji, name, time);
       grid.append(item);
     });
+    setText("share-preview-date", schedule.gregorian);
+    const nextPrayer = schedule.prayers.find((prayer) => prayer.time) || schedule.prayers[0];
+    setText("share-preview-time", nextPrayer ? `${nextPrayer.name} · ${nextPrayer.time}` : "");
   }
 
   function formatLabel(template, values) {
@@ -208,6 +307,7 @@
     setText("start-compass", state.labels.compass_start);
     byId("compass-status").classList.add("hidden");
     renderCalendarSubscription();
+    renderHomeScreen();
   }
 
   function renderCalendarSubscription() {
@@ -217,6 +317,37 @@
     setText("connect-calendar", state.labels.calendar_connect);
     setText("copy-calendar-link", state.labels.calendar_copy);
     setText("disconnect-calendar", state.labels.calendar_disconnect);
+  }
+
+  function updateHomeScreenStatus(status) {
+    homeScreenStatus = status || "unknown";
+    if (homeScreenStatus === "unsupported") {
+      byId("home-screen-card").classList.add("hidden");
+      return;
+    }
+    const button = byId("add-home-screen");
+    const statusElement = byId("home-screen-status");
+    const added = homeScreenStatus === "added";
+    button.disabled = added;
+    setText("add-home-screen", added ? state.labels.home_added : state.labels.home_add);
+    setText("home-screen-status", added ? state.labels.home_added : "");
+    statusElement.classList.toggle("hidden", !added);
+  }
+
+  function renderHomeScreen() {
+    const supported = telegramVersionAtLeast("8.0") &&
+      telegram && typeof telegram.addToHomeScreen === "function";
+    byId("home-screen-card").classList.toggle("hidden", !supported);
+    if (!supported) return;
+    updateHomeScreenStatus(homeScreenStatus);
+    if (typeof telegram.checkHomeScreenStatus === "function") {
+      telegram.checkHomeScreenStatus((status) => updateHomeScreenStatus(status));
+    }
+  }
+
+  function addToHomeScreen() {
+    if (!telegram || typeof telegram.addToHomeScreen !== "function") return;
+    telegram.addToHomeScreen();
   }
 
   function renderReminders() {
@@ -250,6 +381,34 @@
     renderReminders();
     renderSettings();
     setDirty(false);
+  }
+
+  function setOnlineControlsDisabled(value) {
+    offlineMode = value;
+    byId("location-primary").disabled = value;
+    byId("location-secondary").disabled = value;
+    setPreferencesDisabled(value);
+    setCalendarButtonsDisabled(value);
+  }
+
+  function showConnectionState(kind, savedAt) {
+    const banner = byId("connection-banner");
+    banner.classList.remove("hidden");
+    banner.classList.toggle("refreshing", kind === "refreshing");
+    if (kind === "refreshing") {
+      setText("connection-title", state.labels.offline_updating);
+      setText("connection-message", state.labels.offline_updating_help);
+      return;
+    }
+    const time = new Intl.DateTimeFormat(state.locale, {
+      hour: "2-digit", minute: "2-digit",
+    }).format(new Date(savedAt));
+    setText("connection-title", state.labels.offline_title);
+    setText("connection-message", formatLabel(state.labels.offline_help, { time }));
+  }
+
+  function hideConnectionState() {
+    byId("connection-banner").classList.add("hidden");
   }
 
   function setDirty(value) {
@@ -307,6 +466,9 @@
         longitude: location.longitude,
       });
       applyState(next);
+      setOnlineControlsDisabled(false);
+      hideConnectionState();
+      void cacheState(next);
       showToast(next.labels.saved);
       if (telegram && telegram.HapticFeedback) telegram.HapticFeedback.notificationOccurred("success");
     } catch (_) {
@@ -358,6 +520,9 @@
         reminders: collectReminders(),
       });
       applyState(next);
+      setOnlineControlsDisabled(false);
+      hideConnectionState();
+      void cacheState(next);
       showToast(next.labels.saved);
       if (telegram && telegram.HapticFeedback) telegram.HapticFeedback.notificationOccurred("success");
     } catch (_) {
@@ -423,6 +588,7 @@
     state.calendar = subscription;
     calendarFeedURL = new URL(subscription.path, window.location.origin).href;
     renderCalendarSubscription();
+    void cacheState(state);
     return calendarFeedURL;
   }
 
@@ -481,11 +647,173 @@
       state.calendar = await request("/api/miniapp/calendar-subscription", "DELETE");
       calendarFeedURL = "";
       renderCalendarSubscription();
+      void cacheState(state);
       showToast(state.labels.calendar_disconnected);
     } catch (_) {
       showToast(state.labels.temporary_failure, true);
     } finally {
       setCalendarButtonsDisabled(false);
+    }
+  }
+
+  function roundedRectangle(context, x, y, width, height, radius) {
+    const r = Math.min(radius, width / 2, height / 2);
+    context.beginPath();
+    context.moveTo(x + r, y);
+    context.arcTo(x + width, y, x + width, y + height, r);
+    context.arcTo(x + width, y + height, x, y + height, r);
+    context.arcTo(x, y + height, x, y, r);
+    context.arcTo(x, y, x + width, y, r);
+    context.closePath();
+  }
+
+  function fitCanvasText(context, text, maxWidth, initialSize, weight = 700) {
+    let size = initialSize;
+    do {
+      context.font = `${weight} ${size}px -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif`;
+      size -= 2;
+    } while (size > 24 && context.measureText(text).width > maxWidth);
+  }
+
+  function prayerCardCanvas() {
+    const schedule = state[activeDay];
+    const canvas = document.createElement("canvas");
+    canvas.width = 1080;
+    canvas.height = 1350;
+    const context = canvas.getContext("2d");
+    const rtl = state.locale === "ar";
+    const start = rtl ? 940 : 140;
+    const end = rtl ? 140 : 940;
+
+    const background = context.createLinearGradient(0, 0, 1080, 1350);
+    background.addColorStop(0, "#174d40");
+    background.addColorStop(.55, "#0b2d31");
+    background.addColorStop(1, "#061b29");
+    context.fillStyle = background;
+    context.fillRect(0, 0, 1080, 1350);
+
+    const glow = context.createRadialGradient(875, 130, 10, 875, 130, 360);
+    glow.addColorStop(0, "rgba(228,190,88,.34)");
+    glow.addColorStop(1, "rgba(228,190,88,0)");
+    context.fillStyle = glow;
+    context.fillRect(500, 0, 580, 560);
+
+    context.strokeStyle = "rgba(240,207,114,.18)";
+    context.lineWidth = 2;
+    context.beginPath();
+    context.arc(930, 170, 235, 0, Math.PI * 2);
+    context.stroke();
+    context.beginPath();
+    context.arc(930, 170, 176, 0, Math.PI * 2);
+    context.stroke();
+
+    context.direction = rtl ? "rtl" : "ltr";
+    context.textAlign = rtl ? "right" : "left";
+    context.textBaseline = "alphabetic";
+    context.fillStyle = "#f0cf72";
+    context.font = '700 76px Georgia, "Times New Roman", serif';
+    context.fillText("☾", start, 135);
+
+    context.fillStyle = "#fffdf2";
+    fitCanvasText(context, state.labels.share_card_heading, 780, 52, 800);
+    context.fillText(state.labels.share_card_heading, start, 220);
+
+    context.fillStyle = "rgba(255,253,242,.72)";
+    fitCanvasText(context, schedule.gregorian, 800, 35, 650);
+    context.fillText(schedule.gregorian, start, 278);
+    context.fillStyle = "#d9bd6e";
+    fitCanvasText(context, schedule.hijri, 800, 31, 650);
+    context.fillText(schedule.hijri, start, 326);
+
+    roundedRectangle(context, 90, 365, 900, 760, 38);
+    context.fillStyle = "rgba(255,255,255,.095)";
+    context.fill();
+    context.strokeStyle = "rgba(255,255,255,.12)";
+    context.stroke();
+
+    schedule.prayers.forEach((prayer, index) => {
+      const y = 455 + index * 108;
+      context.direction = rtl ? "rtl" : "ltr";
+      context.textAlign = rtl ? "right" : "left";
+      context.fillStyle = "#fffdf2";
+      fitCanvasText(context, prayer.name, 500, 36, 700);
+      context.fillText(prayer.name, start, y);
+
+      context.direction = "ltr";
+      context.textAlign = rtl ? "left" : "right";
+      context.fillStyle = "#f0cf72";
+      context.font = '800 42px -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif';
+      context.fillText(prayer.time, end, y);
+
+      if (index < schedule.prayers.length - 1) {
+        context.strokeStyle = "rgba(255,255,255,.09)";
+        context.beginPath();
+        context.moveTo(140, y + 42);
+        context.lineTo(940, y + 42);
+        context.stroke();
+      }
+    });
+
+    const method = state.options.methods.find((item) => item.value === state.profile.method);
+    const footer = `${schedule.timezone} · ${method ? method.label : state.profile.method}`;
+    context.direction = rtl ? "rtl" : "ltr";
+    context.textAlign = rtl ? "right" : "left";
+    context.fillStyle = "rgba(255,253,242,.62)";
+    fitCanvasText(context, footer, 800, 27, 600);
+    context.fillText(footer, start, 1196);
+    context.fillStyle = "#f0cf72";
+    context.font = '650 25px -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif';
+    context.fillText(state.labels.share_card_footer, start, 1250);
+
+    return canvas;
+  }
+
+  function canvasBlob(canvas) {
+    const dataURL = canvas.toDataURL("image/png", 1);
+    const [header, encoded] = dataURL.split(",");
+    const mediaType = (/^data:([^;]+)/.exec(header) || [])[1] || "image/png";
+    const binary = window.atob(encoded);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index);
+    return new Blob([bytes], { type: mediaType });
+  }
+
+  function downloadPrayerCard(blob, filename) {
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    document.body.append(link);
+    link.click();
+    link.remove();
+    window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
+
+  async function sharePrayerCard() {
+    const button = byId("share-prayer-card");
+    button.disabled = true;
+    setText("share-prayer-card", state.labels.share_preparing);
+    try {
+      // Keep generation synchronous until navigator.share is called so the
+      // browser preserves the button click's required transient activation.
+      const blob = canvasBlob(prayerCardCanvas());
+      const filename = `prayer-times-${activeDay}.png`;
+      const file = typeof File === "function" ? new File([blob], filename, { type: "image/png" }) : null;
+      if (file && navigator.share && navigator.canShare && navigator.canShare({ files: [file] })) {
+        await navigator.share({
+          title: state.labels.share_card_heading,
+          text: `${state.labels.share_message}\n${state[activeDay].gregorian}`,
+          files: [file],
+        });
+      } else {
+        downloadPrayerCard(blob, filename);
+        showToast(state.labels.share_downloaded);
+      }
+    } catch (error) {
+      if (!error || error.name !== "AbortError") showToast(state.labels.share_failed, true);
+    } finally {
+      button.disabled = false;
+      setText("share-prayer-card", state.labels.share_action);
     }
   }
 
@@ -506,11 +834,27 @@
       return;
     }
     standalone.classList.add("hidden");
-    loading.classList.remove("hidden");
+    const cached = await cachedState();
+    if (cached) {
+      applyState(cached.state);
+      setOnlineControlsDisabled(true);
+      showConnectionState("refreshing", cached.saved_at);
+    } else {
+      loading.classList.remove("hidden");
+    }
     try {
-      applyState(await request("/api/miniapp/bootstrap"));
+      const fresh = await request("/api/miniapp/bootstrap");
+      applyState(fresh);
+      setOnlineControlsDisabled(false);
+      hideConnectionState();
+      await cacheState(fresh);
     } catch (error) {
-      showLaunchError(error.status === 401 ? "expired" : "failed");
+      if (error.status === 401 || !cached) {
+        showLaunchError(error.status === 401 ? "expired" : "failed");
+        return;
+      }
+      setOnlineControlsDisabled(true);
+      showConnectionState("offline", cached.saved_at);
     }
   }
 
@@ -533,6 +877,8 @@
   byId("connect-calendar").addEventListener("click", connectGoogleCalendar);
   byId("copy-calendar-link").addEventListener("click", copyCalendarLink);
   byId("disconnect-calendar").addEventListener("click", disconnectCalendar);
+  byId("add-home-screen").addEventListener("click", addToHomeScreen);
+  byId("share-prayer-card").addEventListener("click", sharePrayerCard);
   byId("save-preferences").addEventListener("click", savePreferences);
   byId("retry-app").addEventListener("click", bootstrapApp);
   ["prayer-reminders", "pre-prayer-minutes", "fasting-reminders", "kahf-reminders", "language", "method", "madhab", "highlat", "hijri-adjustment"]
@@ -542,6 +888,9 @@
   window.addEventListener("pageshow", (event) => {
     if (event.persisted) bootstrapApp();
   });
+  window.addEventListener("online", () => {
+    if (offlineMode) bootstrapApp();
+  });
   window.addEventListener("pagehide", () => {
     const sensor = telegram && telegram.DeviceOrientation;
     if (sensor && sensor.isStarted) sensor.stop();
@@ -549,6 +898,8 @@
   if (telegram && telegram.onEvent) {
     telegram.onEvent("deviceOrientationChanged", updateCompassOrientation);
     telegram.onEvent("deviceOrientationFailed", showCompassUnavailable);
+    telegram.onEvent("homeScreenAdded", () => updateHomeScreenStatus("added"));
+    telegram.onEvent("homeScreenChecked", updateHomeScreenStatus);
   }
 
   bootstrapApp();

--- a/global/internal/miniapp/static/index.html
+++ b/global/internal/miniapp/static/index.html
@@ -39,6 +39,14 @@
     </section>
 
     <div id="dashboard" class="hidden">
+      <aside id="connection-banner" class="connection-banner hidden" role="status" aria-live="polite">
+        <span class="connection-icon" aria-hidden="true">☁</span>
+        <div>
+          <strong id="connection-title"></strong>
+          <p id="connection-message"></p>
+        </div>
+      </aside>
+
       <section class="schedule-section">
         <div class="segmented" role="tablist" aria-label="Prayer schedule date">
           <button id="today-tab" class="segment active" type="button" role="tab" aria-selected="true">Today</button>
@@ -110,6 +118,37 @@
               <button id="disconnect-calendar" class="text-button calendar-disconnect hidden" type="button">Disconnect calendar</button>
             </div>
             <p id="calendar-status" class="tool-note hidden" role="status"></p>
+          </article>
+
+          <article id="home-screen-card" class="tool-card quick-access-card hidden">
+            <div class="tool-heading">
+              <span class="tool-icon" aria-hidden="true">📲</span>
+              <div>
+                <h3 id="home-screen-title">Quick access</h3>
+                <p id="home-screen-help">Add prayer times to your Telegram home screen.</p>
+              </div>
+            </div>
+            <div class="quick-access-illustration" aria-hidden="true">
+              <span>☾</span>
+            </div>
+            <button id="add-home-screen" class="secondary-button" type="button">Add to home screen</button>
+            <p id="home-screen-status" class="tool-note hidden" role="status"></p>
+          </article>
+
+          <article class="tool-card share-card">
+            <div class="tool-heading">
+              <span class="tool-icon" aria-hidden="true">✨</span>
+              <div>
+                <h3 id="share-card-title">Share prayer card</h3>
+                <p id="share-card-help">Create a beautiful image with the selected day’s prayer times.</p>
+              </div>
+            </div>
+            <div class="share-card-preview" aria-hidden="true">
+              <span class="share-preview-moon">☾</span>
+              <strong id="share-preview-date"></strong>
+              <span id="share-preview-time"></span>
+            </div>
+            <button id="share-prayer-card" class="primary-button compact" type="button">Create &amp; share</button>
           </article>
         </div>
       </section>

--- a/global/internal/miniapp/static/sw.js
+++ b/global/internal/miniapp/static/sw.js
@@ -1,0 +1,54 @@
+"use strict";
+
+const cacheName = "global-prayer-miniapp-shell-v1";
+const shellAssets = [
+  "./",
+  "./app.css",
+  "./app.js",
+  "https://telegram.org/js/telegram-web-app.js?63",
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil((async () => {
+    const cache = await caches.open(cacheName);
+    await Promise.allSettled(shellAssets.map((asset) => cache.add(
+      asset.startsWith("https://") ? new Request(asset, { mode: "no-cors" }) : asset,
+    )));
+    await self.skipWaiting();
+  })());
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil((async () => {
+    const names = await caches.keys();
+    await Promise.all(names
+      .filter((name) => name.startsWith("global-prayer-miniapp-shell-") && name !== cacheName)
+      .map((name) => caches.delete(name)));
+    await self.clients.claim();
+  })());
+});
+
+self.addEventListener("fetch", (event) => {
+  if (event.request.method !== "GET") return;
+  const url = new URL(event.request.url);
+  const isAppShell = url.origin === self.location.origin && url.pathname.startsWith("/app/");
+  const isTelegramSDK = url.origin === "https://telegram.org" &&
+    url.pathname === "/js/telegram-web-app.js";
+  if (!isAppShell && !isTelegramSDK) return;
+
+  event.respondWith((async () => {
+    const cached = await caches.match(event.request, { ignoreSearch: isTelegramSDK });
+    const network = fetch(event.request).then(async (response) => {
+      if (response.ok || response.type === "opaque") {
+        const cache = await caches.open(cacheName);
+        await cache.put(event.request, response.clone());
+      }
+      return response;
+    });
+    if (cached) {
+      void network.catch(() => undefined);
+      return cached;
+    }
+    return network;
+  })());
+});


### PR DESCRIPTION
## Summary
- add Telegram home-screen shortcut support and a versioned service-worker application shell
- cache a privacy-safe 48-hour per-user bootstrap snapshot for instant and read-only offline schedules
- generate localized 1080x1350 prayer cards in the Mini App with native file sharing and a download fallback
- localize the new UI in all eight supported languages and document the data/security behavior

## Privacy and infrastructure
- strips the Telegram numeric ID and private calendar bearer path before device caching
- keeps offline mutations disabled until a signed live bootstrap succeeds
- uploads no prayer cards and adds no database table, cloud service, secret, scheduler, or recurring workload

## Validation
- go vet ./...
- go test -race ./...
- node --check internal/miniapp/static/app.js
- node --check internal/miniapp/static/sw.js
- git diff --check