### PR TITLE
Add Islamic occasions and opt-in reminders

### DIFF
--- a/global/README.md
+++ b/global/README.md
@@ -22,6 +22,9 @@ in the same pull request.
 - Inline button pickers for calculation method, madhab, high-latitude rule, per-prayer adjustments, reminder state, and language. The equivalent typed commands remain available.
 - Localized messages, reply keyboards, prayer names, dates, Mini App, and reminder deliveries in English, Arabic, Spanish, French, Russian, Turkish, Uzbek, and Tatar. The public Telegram bot name and description remain stable for every user.
 - Gregorian and calculated Umm al-Qura Hijri dates on every daily schedule, with a per-chat moon-sighting correction from -2 to +2 days.
+- The next three Islamic occasions in the Mini App and matching all-day events in the private rolling calendar, using the same corrected Hijri date.
+- A curated, localized occasion catalog covering major dates, voluntary fasting opportunities, and commonly observed dates, with cautious explanatory text and Quran/Hadith source links where available.
+- Three independent, opt-in occasion reminder groups delivered at 20:00 on the preceding local evening.
 - Opt-in weekly reminders for Monday/Thursday voluntary fasting (20:00 on the preceding evening) and reading Surah Al-Kahf on Friday (09:00), scheduled in the saved local timezone.
 - Configurable pre-prayer reminders at 5, 10, 15, 20, 30, 45, or 60 minutes before each obligatory prayer, followed by the normal prayer-time notification.
 - Category-aware notification cleanup: a new prayer notice replaces the preceding prayer/pre-prayer message, weekly categories are independent, and every reminder expires within Telegram's deletion window.
@@ -36,7 +39,7 @@ in the same pull request.
 
 The initial UI language follows the user's Telegram language when supported and otherwise falls back to English. A language selected inside the bot is persisted and is not overwritten by later Telegram updates.
 
-Hijri dates use the calculated Umm al-Qura calendar. Because official local moon-sighting dates can differ by a day or two, users can correct the displayed date under **Settings → Hijri date correction**. The correction is applied only to the Hijri display; it never shifts prayer calculations.
+Hijri dates use the calculated Umm al-Qura calendar. Because official local moon-sighting dates can differ by a day or two, users can correct the date under **Settings → Hijri date correction**. The correction shifts Hijri labels and Islamic occasion dates consistently; it never shifts prayer calculations.
 
 ## Owner dashboard and feedback
 
@@ -54,7 +57,7 @@ Feedback arrives in the owner's private bot chat as a metadata message followed 
 
 The three services use one immutable image and select `/webhook`, `/dispatch`, or `/send` as the command. The webhook binary embeds the Mini App and serves it at `/app/`, so the feature does not add another Cloud Run service, container image, database, migration, or secret. Offline snapshots remain on the user's device, and prayer cards are rendered in the browser; neither feature adds server storage or scheduled work.
 
-Calendar subscriptions use a random private bearer URL created only after the Mini App session has been authenticated. The URL exposes neither the Telegram user ID nor the bot token and can be revoked from the Mini App. Each fetch calculates today and the following 29 local days, so no daily cron or stored calendar events are required. Google controls when subscribed calendars refresh, so updates are not guaranteed to appear exactly at local midnight. Qibla calculations and calendar generation use the existing saved profile and prayer engine, so neither feature adds an external API call from the bot or a recurring job.
+Calendar subscriptions use a random private bearer URL created only after the Mini App session has been authenticated. The URL exposes neither the Telegram user ID nor the bot token and can be revoked from the Mini App. Each fetch calculates today and the following 29 local days, including prayer times and Islamic occasions, so no daily cron or stored calendar events are required. Google controls when subscribed calendars refresh, so updates are not guaranteed to appear exactly at local midnight. Qibla calculations and calendar generation use the existing saved profile and local calculation engines, so neither feature adds an external API call from the bot or a recurring job.
 
 ## Testing and production secrets
 

--- a/global/docs/architecture.md
+++ b/global/docs/architecture.md
@@ -56,6 +56,12 @@ neither the Telegram user ID nor bot token. Users can revoke the URL from the
 Mini App. Google controls its subscription refresh schedule, so midnight
 rollover is eventually consistent rather than immediate.
 
+The Mini App bootstrap also calculates the next three entries from the curated
+Islamic occasion catalog. These entries use the profile's Hijri correction,
+localize titles and recommendations, and expose HTTPS Quran/Hadith references
+from the catalog. Commonly observed dates are explicitly labelled and carry a
+moon-sighting and scholarly-practice disclaimer.
+
 ## Data ownership
 
 The legacy `public.chats` and `public.prayers` tables remain untouched. Global testing data is owned by `global_bot_testing`, production data is owned by `global_bot_production`, foreign keys cascade from each schema's `chats` table, and `/delete_me` deletes the chat root.
@@ -70,13 +76,13 @@ Every persisted profile records coordinates, IANA timezone, calculation method, 
 
 The current calculation engine is `github.com/hablullah/go-prayer`, hidden behind `prayertime.Calculator`. That boundary lets us replace or compare engines without changing handlers, storage, or reminders.
 
-Daily schedule headers use the calculated Umm al-Qura calendar from `github.com/hablullah/go-hijri`. The independently stored -2 to +2 day correction accounts for local moon-sighting differences and does not affect prayer-time calculations.
+Daily schedule headers use the calculated Umm al-Qura calendar from `github.com/hablullah/go-hijri`. The independently stored -2 to +2 day correction accounts for local moon-sighting differences. It is applied to displayed Hijri dates and occasion matching, but does not affect prayer-time calculations.
 
 ## Delivery behavior
 
 The dispatcher selects only due rows from the partial due-time index using `FOR UPDATE SKIP LOCKED`. It writes a durable outbox record in the same transaction and uses a deterministic Cloud Task name. The sender leases a delivery key before calling Telegram and records the next occurrence after a successful send. Prayer reminders, configurable pre-prayer notices, and opt-in weekly fasting/Al-Kahf reminders share this delivery path; all recurrence calculations use the profile's IANA timezone.
 
-The sender also maintains one active Telegram message slot per cleanup category. Before-prayer and at-prayer notifications share the `prayer` slot, so Asr's arrival replaces its pre-reminder, or the prior Dhuhr notification when no pre-reminder is enabled. Tomorrow, fasting, and Al-Kahf reminders have independent slots. Replaced messages are deleted immediately on a best-effort basis and through a durable Cloud Task fallback.
+The sender also maintains one active Telegram message slot per cleanup category. Before-prayer and at-prayer notifications share the `prayer` slot, so Asr's arrival replaces its pre-reminder, or the prior Dhuhr notification when no pre-reminder is enabled. Tomorrow, weekly fasting, Al-Kahf, and Islamic occasions have independent slots. All three occasion reminder groups share `islamic_occasion`, so a new occasion replaces the prior occasion notice. Replaced messages are deleted immediately on a best-effort basis and through a durable Cloud Task fallback.
 
 Telegram only permits message deletion for messages sent less than 48 hours ago. Every notification therefore receives a scheduled 36-hour cleanup task. This is especially important for weekly categories, whose next occurrence is too late to delete the previous Telegram message.
 

--- a/global/docs/code-map.md
+++ b/global/docs/code-map.md
@@ -26,13 +26,14 @@ with the container command, so the three Cloud Run services use the same build.
 | `internal/store` | All PostgreSQL queries and transaction boundaries | `domain`, pgx |
 | `internal/prayertime` | Prayer calculation interface and `go-prayer` adapter | `domain` |
 | `internal/hijri` | Umm al-Qura conversion and per-chat display correction | `go-hijri` |
+| `internal/occasions` | Curated Hijri occasion definitions, corrected Gregorian matching, category filtering, and recurrence lookup | `hijri` |
 | `internal/location` | Google Time Zone and reverse-geocoding integration | Google HTTP APIs |
 | `internal/reminders` | Recurrence planning, due dispatch, Cloud Tasks enqueueing, Telegram delivery, and cleanup categories | `domain`, `store`, `prayertime`, Telegram and GCP clients |
 | `internal/telegram` | Bot commands, callbacks, keyboards, update routing, feedback, and owner dashboard | `store`, `location`, `prayertime`, `reminders`, `i18n` |
 | `internal/miniapp` | Embedded web UI, signed init-data authentication, settings APIs, Qibla/bootstrap data, and private calendar subscriptions | `store`, `location`, `prayertime`, `reminders`, `qibla`, `calendarfile`, `i18n` |
 | `internal/i18n` | All supported locales, messages, buttons, prayer names, method names, and dates | `domain` |
 | `internal/qibla` | Great-circle bearing and distance to the Kaaba | Standard library only |
-| `internal/calendarfile` | Localized RFC 5545 prayer-calendar generation | `domain`, `i18n`, `prayertime` |
+| `internal/calendarfile` | Localized RFC 5545 prayer and Islamic-occasion calendar generation | `domain`, `i18n`, `prayertime`, `occasions` |
 | `internal/botprofile` | Read-before-write Telegram profile synchronization and rate-limit handling | Telegram Bot API |
 | `internal/assets` | Embedded bot avatar and welcome media | Go embed |
 | `internal/httpx` | Shared HTTP response helpers | Standard library only |
@@ -54,6 +55,7 @@ with the container command, so the three Cloud Run services use the same build.
 | Add a Mini App setting | `internal/miniapp`, `internal/store`, possibly migrations | [Request flows](request-flows.md), [Data model](data-model.md) |
 | Add a calculation method | `internal/domain`, `internal/prayertime`, `internal/i18n` | Public calculation methodology and [Architecture](architecture.md) |
 | Change reminder timing | `internal/reminders/planner.go`, `internal/store` | [Reminder delivery](reminder-delivery.md) |
+| Add or revise an Islamic occasion | `internal/occasions`, `internal/i18n/occasions.go` | [Request flows](request-flows.md), [Reminder delivery](reminder-delivery.md) |
 | Change retry or deletion behavior | `internal/reminders/sender.go`, `internal/store`, `infra/gcp` | [Reminder delivery](reminder-delivery.md), [Operations](operations.md) |
 | Add persistent state | `migrations`, `internal/store`, `internal/domain` | [Data model](data-model.md) |
 | Add a service or cloud dependency | `infra/gcp`, `internal/config`, relevant `cmd` | [Architecture](architecture.md), [Runtime and deployment](runtime-and-deployment.md) |

--- a/global/docs/data-model.md
+++ b/global/docs/data-model.md
@@ -110,7 +110,9 @@ profile change.
 
 Represents desired behavior, not a queued job. The unique key prevents duplicate
 rules with the same chat, kind, prayer, and offset. Weekly reminders use their
-own kinds and local times.
+own kinds and local times. Islamic occasions use `occasion_major`,
+`occasion_fasting`, and `occasion_observed`; all are opt-in and run at 20:00 on
+the preceding local evening.
 
 ### `reminder_schedules`
 
@@ -140,8 +142,10 @@ category:
 - `tomorrow`
 - `weekly_fasting`
 - `weekly_kahf`
+- `islamic_occasion`
 
-Before-prayer and at-prayer messages deliberately share `prayer`.
+Before-prayer and at-prayer messages deliberately share `prayer`. All three
+Islamic occasion rule kinds deliberately share `islamic_occasion`.
 
 ### `calendar_subscriptions`
 

--- a/global/docs/operations.md
+++ b/global/docs/operations.md
@@ -72,7 +72,7 @@ The welcome illustration is embedded in the webhook binary and sent with the loc
 
 Set `GLOBAL_DB_SCHEMA` to `global_bot_testing` or `global_bot_production`, then run Goose with `-table="${GLOBAL_DB_SCHEMA}.goose_db_version"`. Never run global migrations with the legacy default migration table. The initial down migration drops only the selected global schema, but production rollback should normally use a forward corrective migration rather than dropping user data.
 
-Migration `00002` adds the per-chat Hijri correction and the two weekly reminder kinds. Migration `00003` adds notification message slots and scheduled deletion tasks for pre-prayer/category cleanup. Migration `00004` adds revocable private rolling-calendar subscriptions. The normal global deployment runs migrations before the new webhook and sender revisions are applied.
+Migration `00002` adds the per-chat Hijri correction and the two weekly reminder kinds. Migration `00003` adds notification message slots and scheduled deletion tasks for pre-prayer/category cleanup. Migration `00004` adds revocable private rolling-calendar subscriptions. Migration `00005` adds the three opt-in Islamic occasion rule kinds and their shared notification cleanup category. The normal global deployment runs migrations before the new webhook and sender revisions are applied.
 
 Telegram only deletes messages younger than 48 hours. The sender schedules every reminder for cleanup after 36 hours, while a new message in the same category also triggers immediate best-effort deletion of its predecessor. If direct deletion fails transiently, the durable cleanup task retries through the existing Cloud Tasks queue.
 
@@ -90,7 +90,8 @@ access to platform request logs that may contain requested URLs. A user who
 accidentally shares it should press **Disconnect calendar** and reconnect; this
 disables the old token and issues a new one.
 
-The feed contains today and the following 29 days at the time of each request.
+The feed contains today's prayer times, the following 29 days, and Islamic
+occasions that fall within the same corrected local-date window.
 It does not need Cloud Scheduler or a background sync job. Google Calendar
 chooses when to refetch URL subscriptions and can lag behind local midnight or a
 settings change. The feed advertises a 12-hour refresh interval, but that value
@@ -101,9 +102,11 @@ If Google does not show events:
 1. Confirm the feed URL returns HTTP 200 and `Content-Type: text/calendar`.
 2. Confirm the body has no UTF-8 byte-order mark and uses CRLF line endings.
 3. Check that the subscription is still enabled.
-4. Add it from Google Calendar on a computer with **Other calendars → From
+4. Unfold RFC 5545 continuation lines before searching logs or test output for a
+   long occasion UID or source URL.
+5. Add it from Google Calendar on a computer with **Other calendars → From
    URL** using the Mini App's copy-link fallback.
-5. Allow for Google's refresh cache before recreating the subscription.
+6. Allow for Google's refresh cache before recreating the subscription.
 
 ## Feedback delivery
 

--- a/global/docs/reminder-delivery.md
+++ b/global/docs/reminder-delivery.md
@@ -63,9 +63,17 @@ same task twice returns `AlreadyExists` and is treated as success.
 | Tomorrow reminder | `tomorrow` | Replaces the prior tomorrow reminder |
 | Monday/Thursday fasting | `weekly_fasting` | Replaces only the prior fasting reminder |
 | Friday Al-Kahf | `weekly_kahf` | Replaces only the prior Al-Kahf reminder |
+| Major, fasting, or commonly observed Islamic occasion | `islamic_occasion` | Replaces the prior Islamic occasion reminder |
 
 Every message also expires after 36 hours because Telegram cannot delete bot
 messages once they are older than 48 hours.
+
+Islamic occasion recurrence is calculated, not stored as a list of Gregorian
+dates. The planner scans the curated Hijri catalog with the profile's -2 to +2
+day correction, selects the next event in the enabled category, and schedules
+20:00 on its preceding local evening. Major, fasting, and commonly observed
+categories are independent opt-ins, while their delivered messages share one
+cleanup slot to avoid accumulating occasion notices.
 
 ## Delivery guarantee
 

--- a/global/docs/request-flows.md
+++ b/global/docs/request-flows.md
@@ -104,8 +104,23 @@ Both the conversational bot and Mini App use the same profile and
 4. Format Gregorian and corrected Hijri dates.
 5. Localize prayer names and explanatory labels.
 
-The Hijri correction changes only the displayed Hijri date. It never changes
-the Gregorian date or prayer instants.
+The Hijri correction changes the displayed Hijri date and which Gregorian date
+matches an Islamic occasion. It never changes prayer instants.
+
+## Islamic occasions
+
+`internal/occasions` is the single catalog used by the Mini App, calendar, and
+reminder planner. Each definition contains a Hijri month/day, category, emoji,
+and optional HTTPS Quran/Hadith references; localized explanatory and
+recommended-action text lives in `internal/i18n`.
+
+The Mini App returns the next three occurrences after applying the profile's
+Hijri correction. The calendar adds matching all-day events within its rolling
+30-day window. Users can independently opt into major, fasting, and commonly
+observed reminder groups in either interface. The planner sends the next
+matching reminder at 20:00 on the preceding local evening. Commonly observed
+dates remain clearly labelled because exact dates, evidence, or community
+practice may differ.
 
 ## Qibla and calendar tools
 
@@ -129,7 +144,8 @@ fetching:
 6. Disconnecting the calendar disables the token. Future feed requests return
    HTTP 401.
 
-The feed always rolls forward when fetched and includes refresh hints, but
+The feed contains timed prayer events and corrected all-day Islamic occasion
+events. It always rolls forward when fetched and includes refresh hints, but
 Google decides when it refreshes subscribed calendars. The URL is a bearer
 credential and must remain private. It and the event UIDs expose neither the
 Telegram user ID nor bot token.

--- a/global/internal/calendarfile/calendar.go
+++ b/global/internal/calendarfile/calendar.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/escalopa/prayer-bot/global/internal/domain"
 	"github.com/escalopa/prayer-bot/global/internal/i18n"
+	"github.com/escalopa/prayer-bot/global/internal/occasions"
 	"github.com/escalopa/prayer-bot/global/internal/prayertime"
 )
 
@@ -70,8 +71,52 @@ func Generate(
 			writeEvent(&calendar, profile, locale, prayer, at, createdAt, uidNamespace)
 		}
 	}
+	upcoming, err := occasions.Between(start, days, profile.HijriAdjustment)
+	if err != nil {
+		return nil, fmt.Errorf("calculate Islamic occasions: %w", err)
+	}
+	for _, occurrence := range upcoming {
+		writeOccasionEvent(&calendar, locale, occurrence, createdAt, uidNamespace)
+	}
 	writeLine(&calendar, "END:VCALENDAR")
 	return calendar.Bytes(), nil
+}
+
+func writeOccasionEvent(
+	calendar *bytes.Buffer,
+	locale i18n.Locale,
+	occurrence occasions.Occurrence,
+	createdAt time.Time,
+	uidNamespace string,
+) {
+	copy := locale.Occasion(occurrence.Definition.ID)
+	date := occurrence.Date
+	uid := fmt.Sprintf(
+		"%s-%s-%s@global-prayer-bot",
+		uidNamespace,
+		date.Format("20060102"),
+		occurrence.Definition.ID,
+	)
+	description := copy.Summary + "\n\n" + copy.Action
+	if len(occurrence.Definition.Sources) > 0 {
+		description += "\n\n"
+		for index, source := range occurrence.Definition.Sources {
+			if index > 0 {
+				description += "\n"
+			}
+			description += source.Label + ": " + source.URL
+		}
+	}
+
+	writeLine(calendar, "BEGIN:VEVENT")
+	writeLine(calendar, "UID:"+uid)
+	writeLine(calendar, "DTSTAMP:"+createdAt.UTC().Format("20060102T150405Z"))
+	writeLine(calendar, "DTSTART;VALUE=DATE:"+date.Format("20060102"))
+	writeLine(calendar, "DTEND;VALUE=DATE:"+date.AddDate(0, 0, 1).Format("20060102"))
+	writeLine(calendar, "SUMMARY:"+escapeText(occurrence.Definition.Emoji+" "+copy.Title))
+	writeLine(calendar, "DESCRIPTION:"+escapeText(description))
+	writeLine(calendar, "CATEGORIES:Islamic Occasions")
+	writeLine(calendar, "END:VEVENT")
 }
 
 func writeEvent(

--- a/global/internal/calendarfile/calendar_test.go
+++ b/global/internal/calendarfile/calendar_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/escalopa/prayer-bot/global/internal/domain"
 	"github.com/escalopa/prayer-bot/global/internal/i18n"
+	"github.com/escalopa/prayer-bot/global/internal/occasions"
 )
 
 type fakeCalculator struct{}
@@ -73,6 +74,42 @@ func TestGenerateValidatesRange(t *testing.T) {
 		time.Now(), 30, time.Now(), "invalid",
 	); err == nil {
 		t.Fatal("expected invalid UID namespace to fail")
+	}
+}
+
+func TestGenerateIncludesLocalizedIslamicOccasionWithStableSource(t *testing.T) {
+	profile := domain.PrayerProfile{
+		Timezone: "UTC", HijriAdjustment: 1,
+		Method: domain.MethodMWL, Madhab: domain.MadhabShafii,
+		HighLatitudeRule: domain.HighLatitudeAngleBased,
+	}
+	occurrence, err := occasions.Next(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), 1, occasions.CategoryMajor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := Generate(
+		context.Background(), fakeCalculator{}, profile, i18n.Resolve("en"),
+		occurrence.Date, 1, occurrence.Date, "0123456789abcdef0123456789abcdef",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	unfolded := strings.ReplaceAll(content, "\r\n ", "")
+	expectedUID := "0123456789abcdef0123456789abcdef-" +
+		occurrence.Date.Format("20060102") + "-" + occurrence.Definition.ID + "@global-prayer-bot"
+	for _, expected := range []string{
+		"CATEGORIES:Islamic Occasions",
+		expectedUID,
+		"DTSTART;VALUE=DATE:" + occurrence.Date.Format("20060102"),
+	} {
+		if !strings.Contains(unfolded, expected) {
+			t.Errorf("calendar is missing %q:\n%s", expected, content)
+		}
+	}
+	if len(occurrence.Definition.Sources) > 0 &&
+		!strings.Contains(unfolded, occurrence.Definition.Sources[0].URL) {
+		t.Fatal("calendar occasion is missing its source URL")
 	}
 }
 

--- a/global/internal/domain/domain.go
+++ b/global/internal/domain/domain.go
@@ -154,15 +154,24 @@ func (s DaySchedule) At(prayer Prayer) (time.Time, bool) {
 type ReminderKind string
 
 const (
-	ReminderBefore        ReminderKind = "before"
-	ReminderAt            ReminderKind = "at"
-	ReminderTomorrow      ReminderKind = "tomorrow"
-	ReminderWeeklyFasting ReminderKind = "weekly_fasting"
-	ReminderWeeklyKahf    ReminderKind = "weekly_kahf"
+	ReminderBefore           ReminderKind = "before"
+	ReminderAt               ReminderKind = "at"
+	ReminderTomorrow         ReminderKind = "tomorrow"
+	ReminderWeeklyFasting    ReminderKind = "weekly_fasting"
+	ReminderWeeklyKahf       ReminderKind = "weekly_kahf"
+	ReminderOccasionMajor    ReminderKind = "occasion_major"
+	ReminderOccasionFasting  ReminderKind = "occasion_fasting"
+	ReminderOccasionObserved ReminderKind = "occasion_observed"
 )
 
 func (kind ReminderKind) Weekly() bool {
 	return kind == ReminderWeeklyFasting || kind == ReminderWeeklyKahf
+}
+
+func (kind ReminderKind) Occasion() bool {
+	return kind == ReminderOccasionMajor ||
+		kind == ReminderOccasionFasting ||
+		kind == ReminderOccasionObserved
 }
 
 type ReminderRule struct {

--- a/global/internal/i18n/occasions.go
+++ b/global/internal/i18n/occasions.go
@@ -1,0 +1,197 @@
+package i18n
+
+type OccasionCopy struct {
+	Title   string
+	Summary string
+	Action  string
+}
+
+func (l Locale) Occasion(id string) OccasionCopy {
+	if value, ok := occasionCopy[l.Code][id]; ok {
+		return value
+	}
+	return occasionCopy["en"][id]
+}
+
+func (l Locale) OccasionCategory(category string) string {
+	if value := occasionCategories[l.Code][category]; value != "" {
+		return value
+	}
+	return occasionCategories["en"][category]
+}
+
+func (l Locale) OccasionUI(key string) string {
+	if value := occasionUI[l.Code][key]; value != "" {
+		return value
+	}
+	return occasionUI["en"][key]
+}
+
+var occasionUI = map[string]map[string]string{
+	"en": {
+		"title": "Upcoming Islamic dates", "help": "Calculated from your corrected Hijri calendar.",
+		"disclaimer":  "Local moon sighting and scholarly practice may differ.",
+		"recommended": "Recommended", "sources": "Sources",
+		"major_reminders": "Major Islamic occasions", "fasting_reminders": "Special fasting days",
+		"observed_reminders": "Commonly observed dates", "schedule": "Evening before · 20:00",
+	},
+	"ar": {
+		"title": "المناسبات الإسلامية القادمة", "help": "محسوبة وفق تقويمك الهجري المصحح.",
+		"disclaimer":  "قد يختلف ثبوت الهلال والعمل الفقهي محليًا.",
+		"recommended": "المقترح", "sources": "المصادر",
+		"major_reminders": "المناسبات الإسلامية الكبرى", "fasting_reminders": "أيام الصيام الخاصة",
+		"observed_reminders": "المناسبات الشائعة", "schedule": "مساء اليوم السابق · 20:00",
+	},
+	"es": {
+		"title": "Próximas fechas islámicas", "help": "Calculadas con tu calendario hiyri corregido.",
+		"disclaimer":  "El avistamiento lunar y la práctica académica local pueden variar.",
+		"recommended": "Recomendado", "sources": "Fuentes",
+		"major_reminders": "Ocasiones islámicas principales", "fasting_reminders": "Días especiales de ayuno",
+		"observed_reminders": "Fechas habitualmente observadas", "schedule": "Víspera · 20:00",
+	},
+	"fr": {
+		"title": "Prochaines dates islamiques", "help": "Calculées selon votre calendrier hégirien corrigé.",
+		"disclaimer":  "L’observation lunaire et les pratiques savantes locales peuvent varier.",
+		"recommended": "Recommandé", "sources": "Sources",
+		"major_reminders": "Grandes occasions islamiques", "fasting_reminders": "Jours de jeûne particuliers",
+		"observed_reminders": "Dates couramment observées", "schedule": "La veille · 20:00",
+	},
+	"ru": {
+		"title": "Ближайшие исламские даты", "help": "Рассчитаны по вашему скорректированному календарю Хиджры.",
+		"disclaimer":  "Местное наблюдение луны и мнения учёных могут различаться.",
+		"recommended": "Рекомендуется", "sources": "Источники",
+		"major_reminders": "Важные исламские даты", "fasting_reminders": "Особые дни поста",
+		"observed_reminders": "Распространённые даты", "schedule": "Накануне · 20:00",
+	},
+	"tr": {
+		"title": "Yaklaşan İslami tarihler", "help": "Düzeltilmiş Hicri takviminize göre hesaplanır.",
+		"disclaimer":  "Yerel hilal gözlemi ve ilmî uygulamalar farklı olabilir.",
+		"recommended": "Önerilen", "sources": "Kaynaklar",
+		"major_reminders": "Önemli İslami günler", "fasting_reminders": "Özel oruç günleri",
+		"observed_reminders": "Yaygın anma tarihleri", "schedule": "Önceki akşam · 20:00",
+	},
+	"uz": {
+		"title": "Yaqin Islomiy sanalar", "help": "Tuzatilgan Hijriy taqvimingiz bo‘yicha hisoblanadi.",
+		"disclaimer":  "Mahalliy hilol kuzatuvi va ulamolar amaliyoti farq qilishi mumkin.",
+		"recommended": "Tavsiya", "sources": "Manbalar",
+		"major_reminders": "Muhim Islomiy sanalar", "fasting_reminders": "Maxsus ro‘za kunlari",
+		"observed_reminders": "Keng nishonlanadigan sanalar", "schedule": "Oldingi oqshom · 20:00",
+	},
+	"tt": {
+		"title": "Якын Ислам даталары", "help": "Төзәтелгән Һиҗри календарегыз буенча исәпләнә.",
+		"disclaimer":  "Җирле ай күренеше һәм галимнәр практикасы аерылырга мөмкин.",
+		"recommended": "Киңәш", "sources": "Чыганаклар",
+		"major_reminders": "Мөһим Ислам көннәре", "fasting_reminders": "Махсус ураза көннәре",
+		"observed_reminders": "Киң билгеләп үтелгән даталар", "schedule": "Алдагы кич · 20:00",
+	},
+}
+
+var occasionCategories = map[string]map[string]string{
+	"en": {"major": "Major occasion", "fasting": "Fasting opportunity", "observed": "Commonly observed"},
+	"ar": {"major": "مناسبة كبرى", "fasting": "فرصة للصيام", "observed": "مناسبة شائعة"},
+	"es": {"major": "Ocasión principal", "fasting": "Oportunidad de ayuno", "observed": "Conmemoración habitual"},
+	"fr": {"major": "Grande occasion", "fasting": "Jeûne recommandé", "observed": "Date couramment observée"},
+	"ru": {"major": "Важная дата", "fasting": "Возможность поста", "observed": "Распространённая дата"},
+	"tr": {"major": "Önemli gün", "fasting": "Oruç fırsatı", "observed": "Yaygın anma"},
+	"uz": {"major": "Muhim sana", "fasting": "Ro‘za imkoniyati", "observed": "Keng nishonlanadigan sana"},
+	"tt": {"major": "Мөһим көн", "fasting": "Ураза мөмкинлеге", "observed": "Киң билгеләп үтелә"},
+}
+
+var occasionCopy = map[string]map[string]OccasionCopy{
+	"en": {
+		"ashura":            {Title: "Day of Ashura", Summary: "The tenth of Muharram is a day of gratitude and remembrance.", Action: "Consider fasting Ashura and an adjacent day."},
+		"mawlid":            {Title: "Mawlid al-Nabi", Summary: "Commonly observed as the Prophet’s birth date; the exact historical date and observance differ among Muslims.", Action: "Send blessings and peace upon the Prophet ﷺ and study his character."},
+		"isra_miraj":        {Title: "Isra and Mi’raj", Summary: "A commonly observed date recalling the Night Journey and Ascension; its precise calendar date is not established.", Action: "Read the opening of Surah Al-Isra and reflect on the gift of prayer."},
+		"mid_shaban":        {Title: "Mid-Sha’ban", Summary: "A night commonly observed in some Muslim communities; practices and evidentiary assessments differ.", Action: "Use the night for general worship without treating a particular practice as obligatory."},
+		"ramadan_start":     {Title: "Beginning of Ramadan", Summary: "The month of fasting and Quran begins according to the calculated Hijri calendar.", Action: "Prepare your intention, worship plan, and local moon-sighting confirmation."},
+		"last_ten_nights":   {Title: "Last ten nights of Ramadan", Summary: "Laylat al-Qadr is sought in the odd nights of Ramadan’s final ten nights.", Action: "Increase prayer, Quran, charity, and the dua for pardon."},
+		"eid_fitr":          {Title: "Eid al-Fitr", Summary: "The celebration completing Ramadan and its prescribed fast.", Action: "Confirm the local date, give Zakat al-Fitr, and join the Eid prayer."},
+		"dhul_hijjah_start": {Title: "First ten days of Dhu al-Hijjah", Summary: "These are especially virtuous days for righteous deeds.", Action: "Increase dhikr, charity, prayer, and other good deeds."},
+		"arafah":            {Title: "Day of Arafah", Summary: "The ninth of Dhu al-Hijjah is the central day of Hajj and a recommended fast for non-pilgrims.", Action: "If you are not performing Hajj, consider fasting and making abundant dua."},
+		"eid_adha":          {Title: "Eid al-Adha", Summary: "The festival of sacrifice begins on the tenth of Dhu al-Hijjah.", Action: "Join the Eid prayer and follow your local guidance for udhiyah."},
+	},
+	"ar": {
+		"ashura":            {Title: "يوم عاشوراء", Summary: "العاشر من المحرم يوم شكر وذكر.", Action: "يُستحب صيام عاشوراء مع يوم قبله أو بعده."},
+		"mawlid":            {Title: "المولد النبوي", Summary: "يوافق تاريخًا شائعًا لمولد النبي ﷺ، مع اختلاف المسلمين في التاريخ الدقيق وطريقة إحيائه.", Action: "أكثر من الصلاة والسلام على النبي ﷺ وتعلّم من سيرته."},
+		"isra_miraj":        {Title: "الإسراء والمعراج", Summary: "تاريخ شائع لتذكر رحلة الإسراء والمعراج، أما تعيين الليلة بدقة فغير ثابت.", Action: "اقرأ بداية سورة الإسراء وتأمل في نعمة الصلاة."},
+		"mid_shaban":        {Title: "ليلة النصف من شعبان", Summary: "ليلة يحييها بعض المسلمين، مع اختلاف العلماء في الأعمال والأدلة الخاصة بها.", Action: "اغتنمها في العبادة العامة دون اعتقاد وجوب عمل مخصوص."},
+		"ramadan_start":     {Title: "بداية رمضان", Summary: "يبدأ شهر الصيام والقرآن وفق التاريخ الهجري المحسوب.", Action: "استعد بالنية وخطة العبادة وتحقق من ثبوت الهلال محليًا."},
+		"last_ten_nights":   {Title: "العشر الأواخر من رمضان", Summary: "تُتحرى ليلة القدر في الليالي الوترية من العشر الأواخر.", Action: "أكثر من الصلاة والقرآن والصدقة ودعاء العفو."},
+		"eid_fitr":          {Title: "عيد الفطر", Summary: "فرحة إتمام رمضان وصيامه المفروض.", Action: "تحقق من التاريخ المحلي وأدِّ زكاة الفطر وصلِّ العيد."},
+		"dhul_hijjah_start": {Title: "العشر الأوائل من ذي الحجة", Summary: "أيام فاضلة يُستحب فيها العمل الصالح.", Action: "أكثر من الذكر والصدقة والصلاة وسائر الخير."},
+		"arafah":            {Title: "يوم عرفة", Summary: "تاسع ذي الحجة وأعظم أيام الحج، ويُستحب صيامه لغير الحاج.", Action: "إن لم تكن حاجًا ففكر في الصيام وأكثر من الدعاء."},
+		"eid_adha":          {Title: "عيد الأضحى", Summary: "يبدأ عيد النحر في العاشر من ذي الحجة.", Action: "صلِّ العيد واتبع الإرشادات المحلية للأضحية."},
+	},
+	"es": {
+		"ashura":            {Title: "Día de Ashura", Summary: "El diez de Muharram es un día de gratitud y recuerdo.", Action: "Considera ayunar Ashura y un día adyacente."},
+		"mawlid":            {Title: "Mawlid al-Nabi", Summary: "Fecha comúnmente observada como nacimiento del Profeta; la fecha histórica y su celebración difieren.", Action: "Envía bendiciones al Profeta ﷺ y estudia su carácter."},
+		"isra_miraj":        {Title: "Isra y Mi’raj", Summary: "Fecha habitual para recordar el Viaje Nocturno; su fecha exacta no está establecida.", Action: "Lee el inicio de Al-Isra y reflexiona sobre la oración."},
+		"mid_shaban":        {Title: "Mitad de Sha’ban", Summary: "Noche observada en algunas comunidades; las prácticas y sus evidencias difieren.", Action: "Dedícala a la adoración general sin considerar obligatoria una práctica concreta."},
+		"ramadan_start":     {Title: "Comienzo de Ramadán", Summary: "Comienza el mes del ayuno y del Corán según el calendario calculado.", Action: "Prepara tu intención y confirma el avistamiento lunar local."},
+		"last_ten_nights":   {Title: "Últimas diez noches de Ramadán", Summary: "Laylat al-Qadr se busca en las noches impares de las últimas diez.", Action: "Aumenta la oración, el Corán, la caridad y la súplica por el perdón."},
+		"eid_fitr":          {Title: "Eid al-Fitr", Summary: "La celebración que completa Ramadán y su ayuno.", Action: "Confirma la fecha local, entrega Zakat al-Fitr y reza el Eid."},
+		"dhul_hijjah_start": {Title: "Primeros diez días de Dhu al-Hijjah", Summary: "Días especialmente virtuosos para las buenas obras.", Action: "Aumenta el dhikr, la caridad, la oración y el bien."},
+		"arafah":            {Title: "Día de Arafah", Summary: "El nueve de Dhu al-Hijjah es central en el Hajj y se recomienda ayunarlo a quien no peregrina.", Action: "Si no haces el Hajj, considera ayunar y hacer abundante dua."},
+		"eid_adha":          {Title: "Eid al-Adha", Summary: "La fiesta del sacrificio comienza el diez de Dhu al-Hijjah.", Action: "Reza el Eid y sigue la orientación local sobre la udhiyah."},
+	},
+	"fr": {
+		"ashura":            {Title: "Jour de Achoura", Summary: "Le dix Mouharram est un jour de gratitude et de rappel.", Action: "Envisagez de jeûner Achoura avec un jour adjacent."},
+		"mawlid":            {Title: "Mawlid an-Nabi", Summary: "Date souvent associée à la naissance du Prophète ; la date historique et sa commémoration divergent.", Action: "Priez sur le Prophète ﷺ et étudiez son comportement."},
+		"isra_miraj":        {Title: "Isra et Mi’raj", Summary: "Date courante rappelant le Voyage nocturne ; sa date exacte n’est pas établie.", Action: "Lisez le début d’Al-Isra et méditez sur le don de la prière."},
+		"mid_shaban":        {Title: "Mi-Chaabane", Summary: "Nuit observée dans certaines communautés ; les pratiques et les preuves divergent.", Action: "Consacrez-la au culte général sans rendre une pratique particulière obligatoire."},
+		"ramadan_start":     {Title: "Début du Ramadan", Summary: "Le mois du jeûne et du Coran commence selon le calendrier calculé.", Action: "Préparez votre intention et vérifiez l’observation lunaire locale."},
+		"last_ten_nights":   {Title: "Dix dernières nuits du Ramadan", Summary: "Laylat al-Qadr est recherchée durant les nuits impaires des dix dernières.", Action: "Multipliez prière, Coran, aumône et invocation du pardon."},
+		"eid_fitr":          {Title: "Aïd al-Fitr", Summary: "La fête qui conclut le Ramadan et son jeûne.", Action: "Confirmez la date locale, donnez Zakat al-Fitr et priez l’Aïd."},
+		"dhul_hijjah_start": {Title: "Dix premiers jours de Dhou al-Hijjah", Summary: "Des jours particulièrement vertueux pour les bonnes œuvres.", Action: "Multipliez dhikr, aumône, prière et bonnes actions."},
+		"arafah":            {Title: "Jour de Arafat", Summary: "Le neuf Dhou al-Hijjah est central au Hajj et son jeûne est recommandé aux non-pèlerins.", Action: "Si vous ne faites pas le Hajj, envisagez de jeûner et invoquez abondamment."},
+		"eid_adha":          {Title: "Aïd al-Adha", Summary: "La fête du sacrifice commence le dix Dhou al-Hijjah.", Action: "Priez l’Aïd et suivez les indications locales pour l’oudhiya."},
+	},
+	"ru": {
+		"ashura":            {Title: "День Ашура", Summary: "Десятый день Мухаррама — день благодарности и поминания.", Action: "Рассмотрите пост в Ашура и соседний день."},
+		"mawlid":            {Title: "Маулид ан-Наби", Summary: "Распространённая дата рождения Пророка; точная дата и форма её отмечания различаются.", Action: "Произносите салават Пророку ﷺ и изучайте его нрав."},
+		"isra_miraj":        {Title: "Исра и Мирадж", Summary: "Распространённая дата Ночного путешествия; её точное календарное определение не установлено.", Action: "Прочитайте начало суры «Аль-Исра» и размышляйте о даре молитвы."},
+		"mid_shaban":        {Title: "Середина Шаабана", Summary: "Ночь отмечается в некоторых общинах; практики и оценка доказательств различаются.", Action: "Посвятите время общему поклонению, не считая отдельную практику обязательной."},
+		"ramadan_start":     {Title: "Начало Рамадана", Summary: "Начинается месяц поста и Корана по расчётному календарю.", Action: "Подготовьте намерение и подтвердите местное наблюдение луны."},
+		"last_ten_nights":   {Title: "Последние десять ночей Рамадана", Summary: "Ляйлят аль-Кадр ищут в нечётные ночи последней декады.", Action: "Усильте молитву, чтение Корана, милостыню и дуа о прощении."},
+		"eid_fitr":          {Title: "Ид аль-Фитр", Summary: "Праздник завершения Рамадана и обязательного поста.", Action: "Уточните местную дату, выплатите закят аль-фитр и совершите праздничную молитву."},
+		"dhul_hijjah_start": {Title: "Первые десять дней Зуль-хиджи", Summary: "Особо благословенные дни для праведных дел.", Action: "Увеличьте зикр, милостыню, молитву и добрые дела."},
+		"arafah":            {Title: "День Арафа", Summary: "Девятый Зуль-хиджи — главный день хаджа; не паломникам рекомендуется пост.", Action: "Если вы не в хадже, рассмотрите пост и больше обращайтесь с дуа."},
+		"eid_adha":          {Title: "Ид аль-Адха", Summary: "Праздник жертвоприношения начинается десятого Зуль-хиджи.", Action: "Совершите праздничную молитву и следуйте местным правилам удхии."},
+	},
+	"tr": {
+		"ashura":            {Title: "Aşure Günü", Summary: "Muharrem’in onu şükür ve hatırlama günüdür.", Action: "Aşure günüyle birlikte önceki veya sonraki günü oruçlu geçirmeyi düşünün."},
+		"mawlid":            {Title: "Mevlid-i Nebi", Summary: "Peygamber’in doğumu olarak yaygın anılan tarihtir; kesin tarih ve anma şekli konusunda farklılık vardır.", Action: "Peygamber’e ﷺ salavat getirin ve ahlakını öğrenin."},
+		"isra_miraj":        {Title: "İsra ve Miraç", Summary: "Gece Yolculuğu’nun yaygın anma tarihidir; kesin takvim tarihi sabit değildir.", Action: "İsra Suresi’nin başını okuyun ve namaz nimetini düşünün."},
+		"mid_shaban":        {Title: "Şaban’ın Ortası", Summary: "Bazı topluluklarda ihya edilen bir gecedir; uygulamalar ve delil değerlendirmeleri farklıdır.", Action: "Belirli bir ameli zorunlu görmeden genel ibadetle değerlendirin."},
+		"ramadan_start":     {Title: "Ramazan’ın Başlangıcı", Summary: "Hesaplanan takvime göre oruç ve Kur’an ayı başlar.", Action: "Niyetinizi hazırlayın ve yerel hilal duyurusunu doğrulayın."},
+		"last_ten_nights":   {Title: "Ramazan’ın Son On Gecesi", Summary: "Kadir Gecesi son on gecenin tek gecelerinde aranır.", Action: "Namazı, Kur’an’ı, sadakayı ve af duasını artırın."},
+		"eid_fitr":          {Title: "Ramazan Bayramı", Summary: "Ramazan ve farz orucun tamamlanmasını kutlar.", Action: "Yerel tarihi doğrulayın, fitre verin ve bayram namazına katılın."},
+		"dhul_hijjah_start": {Title: "Zilhicce’nin İlk On Günü", Summary: "Salih ameller için özellikle faziletli günlerdir.", Action: "Zikri, sadakayı, namazı ve iyiliği artırın."},
+		"arafah":            {Title: "Arefe Günü", Summary: "Zilhicce’nin dokuzu haccın ana günüdür; hacda olmayanlara oruç tavsiye edilir.", Action: "Hacda değilseniz oruç tutmayı ve çokça dua etmeyi düşünün."},
+		"eid_adha":          {Title: "Kurban Bayramı", Summary: "Kurban bayramı Zilhicce’nin onunda başlar.", Action: "Bayram namazına katılın ve kurban için yerel rehberliği izleyin."},
+	},
+	"uz": {
+		"ashura":            {Title: "Ashuro kuni", Summary: "Muharramning o‘ninchi kuni shukr va eslash kunidir.", Action: "Ashuro va unga qo‘shni bir kunda ro‘za tutishni o‘ylab ko‘ring."},
+		"mawlid":            {Title: "Mavlid an-Nabiy", Summary: "Payg‘ambar tug‘ilgan kun sifatida keng tarqalgan sana; aniq tarix va nishonlash borasida farq bor.", Action: "Payg‘ambarimizga ﷺ salavot ayting va u zotning xulqini o‘rganing."},
+		"isra_miraj":        {Title: "Isro va Me’roj", Summary: "Tungi sayohatni eslash uchun keng tarqalgan sana; aniq kalendar kuni sobit emas.", Action: "Isro surasining boshini o‘qing va namoz ne’matini tafakkur qiling."},
+		"mid_shaban":        {Title: "Sha’bon o‘rtasi", Summary: "Ba’zi jamoalarda e’zozlanadigan tun; amallar va dalillar bahosi turlicha.", Action: "Muayyan amalni majburiy sanamasdan umumiy ibodat bilan o‘tkazing."},
+		"ramadan_start":     {Title: "Ramazon boshlanishi", Summary: "Hisoblangan taqvim bo‘yicha ro‘za va Qur’on oyi boshlanadi.", Action: "Niyat va ibodat rejangizni tayyorlab, mahalliy hilol xabarini tekshiring."},
+		"last_ten_nights":   {Title: "Ramazonning so‘nggi o‘n kechasi", Summary: "Qadr kechasi so‘nggi o‘n kechaning toq kechalarida izlanadi.", Action: "Namoz, Qur’on, sadaqa va afv duosini ko‘paytiring."},
+		"eid_fitr":          {Title: "Ramazon hayiti", Summary: "Ramazon va farz ro‘zaning tugash bayrami.", Action: "Mahalliy sanani tasdiqlang, fitr zakotini bering va hayit namoziga boring."},
+		"dhul_hijjah_start": {Title: "Zulhijjaning ilk o‘n kuni", Summary: "Yaxshi amallar uchun alohida fazilatli kunlar.", Action: "Zikr, sadaqa, namoz va ezgu ishlarni ko‘paytiring."},
+		"arafah":            {Title: "Arafa kuni", Summary: "Zulhijjaning to‘qqizinchi kuni hajning asosiy kuni; hojilarga bo‘lmaganlarga ro‘za tavsiya etiladi.", Action: "Hajda bo‘lmasangiz, ro‘za va ko‘p duo qilishni o‘ylab ko‘ring."},
+		"eid_adha":          {Title: "Qurbon hayiti", Summary: "Qurbon bayrami Zulhijjaning o‘ninchi kuni boshlanadi.", Action: "Hayit namoziga boring va qurbonlikda mahalliy ko‘rsatmaga amal qiling."},
+	},
+	"tt": {
+		"ashura":            {Title: "Гашура көне", Summary: "Мөхәррәмнең унынчы көне — шөкер һәм искә алу көне.", Action: "Гашура һәм аңа күрше бер көндә ураза тотуны уйлагыз."},
+		"mawlid":            {Title: "Мәүлид ән-Нәби", Summary: "Пәйгамбәрнең туган көне буларак киң билгеләнгән дата; төгәл тарих һәм үткәрү төрлечә.", Action: "Пәйгамбәргә ﷺ салават әйтегез һәм аның әхлагын өйрәнегез."},
+		"isra_miraj":        {Title: "Исра һәм Мигъраҗ", Summary: "Төнге сәяхәтне искә алу өчен киң дата; төгәл календарь көне нык билгеләнмәгән.", Action: "Исра сүрәсенең башын укыгыз һәм намаз нигъмәте турында уйланыгыз."},
+		"mid_shaban":        {Title: "Шәгъбан уртасы", Summary: "Кайбер җәмгыятьләрдә билгеләнә; гамәлләр һәм дәлилләргә бәя төрле.", Action: "Аерым гамәлне мәҗбүри санамыйча гомуми гыйбадәт кылыгыз."},
+		"ramadan_start":     {Title: "Рамазан башлануы", Summary: "Исәпләнгән календарь буенча ураза һәм Коръән ае башлана.", Action: "Ниятегезне әзерләгез һәм җирле ай күренү хәбәрен тикшерегез."},
+		"last_ten_nights":   {Title: "Рамазанның соңгы ун төне", Summary: "Кадер кичәсе соңгы ун төннең так кичләрендә эзләнә.", Action: "Намаз, Коръән, сәдака һәм гафу догасын арттырыгыз."},
+		"eid_fitr":          {Title: "Ураза бәйрәме", Summary: "Рамазан һәм фарыз уразаның тәмамлану бәйрәме.", Action: "Җирле датаны раслагыз, фитыр сәдакасын бирегез һәм бәйрәм намазына барыгыз."},
+		"dhul_hijjah_start": {Title: "Зөлхиҗҗәнең беренче ун көне", Summary: "Изге гамәлләр өчен аеруча фазыйләтле көннәр.", Action: "Зикер, сәдака, намаз һәм яхшылыкны арттырыгыз."},
+		"arafah":            {Title: "Гарәфә көне", Summary: "Зөлхиҗҗәнең тугызынчы көне — хаҗның төп көне; хаҗда булмаганнарга ураза киңәш ителә.", Action: "Хаҗда булмасагыз, ураза һәм күп дога кылуны уйлагыз."},
+		"eid_adha":          {Title: "Корбан бәйрәме", Summary: "Корбан бәйрәме Зөлхиҗҗәнең унынчы көнендә башлана.", Action: "Бәйрәм намазына барыгыз һәм корбанлыкта җирле күрсәтмәне үтәгез."},
+	},
+}

--- a/global/internal/i18n/occasions_test.go
+++ b/global/internal/i18n/occasions_test.go
@@ -1,0 +1,26 @@
+package i18n
+
+import (
+	"testing"
+
+	"github.com/escalopa/prayer-bot/global/internal/occasions"
+)
+
+func TestEveryOccasionIsLocalized(t *testing.T) {
+	for _, locale := range Supported() {
+		for _, definition := range occasions.Catalog() {
+			copy := locale.Occasion(definition.ID)
+			if copy.Title == "" || copy.Summary == "" || copy.Action == "" {
+				t.Errorf("%s is missing occasion copy for %s", locale.Code, definition.ID)
+			}
+			if locale.OccasionCategory(string(definition.Category)) == "" {
+				t.Errorf("%s is missing category %s", locale.Code, definition.Category)
+			}
+		}
+		for _, key := range []string{"title", "help", "disclaimer", "recommended", "sources", "major_reminders", "fasting_reminders", "observed_reminders", "schedule"} {
+			if locale.OccasionUI(key) == "" {
+				t.Errorf("%s is missing occasion UI key %s", locale.Code, key)
+			}
+		}
+	}
+}

--- a/global/internal/miniapp/handler.go
+++ b/global/internal/miniapp/handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/escalopa/prayer-bot/global/internal/hijri"
 	"github.com/escalopa/prayer-bot/global/internal/i18n"
 	"github.com/escalopa/prayer-bot/global/internal/location"
+	"github.com/escalopa/prayer-bot/global/internal/occasions"
 	"github.com/escalopa/prayer-bot/global/internal/prayertime"
 	"github.com/escalopa/prayer-bot/global/internal/qibla"
 	"github.com/escalopa/prayer-bot/global/internal/store"
@@ -38,6 +39,7 @@ type Storage interface {
 	DisableRules(context.Context, int64) error
 	ConfigurePrayerRules(context.Context, int64, bool, int) error
 	SetWeeklyRule(context.Context, int64, domain.ReminderKind, bool) error
+	SetOccasionRule(context.Context, int64, domain.ReminderKind, bool) error
 	CalendarSubscription(context.Context, int64) (domain.CalendarSubscription, error)
 	CalendarSubscriptionByToken(context.Context, string) (domain.CalendarSubscription, error)
 	EnableCalendarSubscription(context.Context, int64, string, string) (domain.CalendarSubscription, error)
@@ -233,6 +235,9 @@ type remindersRequest struct {
 	PrePrayerMinutes int   `json:"pre_prayer_minutes"`
 	Fasting          *bool `json:"fasting"`
 	Kahf             *bool `json:"kahf"`
+	OccasionMajor    *bool `json:"occasion_major"`
+	OccasionFasting  *bool `json:"occasion_fasting"`
+	OccasionObserved *bool `json:"occasion_observed"`
 }
 
 type preferencesRequest struct {
@@ -262,6 +267,7 @@ func validateSettings(request settingsRequest) (validatedSettings, error) {
 
 func validateReminders(request remindersRequest) error {
 	if request.Prayer == nil || request.Fasting == nil || request.Kahf == nil ||
+		request.OccasionMajor == nil || request.OccasionFasting == nil || request.OccasionObserved == nil ||
 		!domain.ValidPreReminderMinutes(request.PrePrayerMinutes) {
 		return badRequest("invalid_request")
 	}
@@ -330,7 +336,8 @@ func (h *Handler) updateReminders(w http.ResponseWriter, r *http.Request, identi
 	if err != nil {
 		return err
 	}
-	if changed && (desired.Prayer || desired.Fasting || desired.Kahf) {
+	if changed && (desired.Prayer || desired.Fasting || desired.Kahf ||
+		desired.OccasionMajor || desired.OccasionFasting || desired.OccasionObserved) {
 		if err := h.planner.RebuildChat(r.Context(), identity.UserID, h.now()); err != nil {
 			return fmt.Errorf("rebuild reminders: %w", err)
 		}
@@ -350,6 +357,8 @@ func (h *Handler) applyReminders(ctx context.Context, chatID int64, request remi
 	desired := reminderResponse{
 		Prayer: *request.Prayer, PrePrayerMinutes: request.PrePrayerMinutes,
 		Fasting: *request.Fasting, Kahf: *request.Kahf,
+		OccasionMajor: *request.OccasionMajor, OccasionFasting: *request.OccasionFasting,
+		OccasionObserved: *request.OccasionObserved,
 	}
 	if !desired.Prayer {
 		desired.PrePrayerMinutes = 0
@@ -370,6 +379,23 @@ func (h *Handler) applyReminders(ctx context.Context, chatID int64, request remi
 			return false, reminderResponse{}, fmt.Errorf("update Al-Kahf reminders: %w", err)
 		}
 	}
+	for _, change := range []struct {
+		current bool
+		desired bool
+		kind    domain.ReminderKind
+		name    string
+	}{
+		{current.OccasionMajor, desired.OccasionMajor, domain.ReminderOccasionMajor, "major occasion"},
+		{current.OccasionFasting, desired.OccasionFasting, domain.ReminderOccasionFasting, "occasion fasting"},
+		{current.OccasionObserved, desired.OccasionObserved, domain.ReminderOccasionObserved, "commonly observed occasion"},
+	} {
+		if change.current == change.desired {
+			continue
+		}
+		if err := h.store.SetOccasionRule(ctx, chatID, change.kind, change.desired); err != nil {
+			return false, reminderResponse{}, fmt.Errorf("update %s reminders: %w", change.name, err)
+		}
+	}
 	return current != desired, desired, nil
 }
 
@@ -383,6 +409,7 @@ type bootstrapResponse struct {
 	Tomorrow      *scheduleResponse            `json:"tomorrow,omitempty"`
 	Qibla         *qiblaResponse               `json:"qibla,omitempty"`
 	Calendar      calendarSubscriptionResponse `json:"calendar"`
+	Occasions     []occasionResponse           `json:"occasions,omitempty"`
 	Reminders     reminderResponse             `json:"reminders"`
 	Options       optionsResponse              `json:"options"`
 	Labels        map[string]string            `json:"labels"`
@@ -426,6 +453,27 @@ type reminderResponse struct {
 	PrePrayerMinutes int  `json:"pre_prayer_minutes"`
 	Fasting          bool `json:"fasting"`
 	Kahf             bool `json:"kahf"`
+	OccasionMajor    bool `json:"occasion_major"`
+	OccasionFasting  bool `json:"occasion_fasting"`
+	OccasionObserved bool `json:"occasion_observed"`
+}
+
+type occasionSourceResponse struct {
+	Label string `json:"label"`
+	URL   string `json:"url"`
+}
+
+type occasionResponse struct {
+	ID            string                   `json:"id"`
+	Emoji         string                   `json:"emoji"`
+	Category      string                   `json:"category"`
+	CategoryLabel string                   `json:"category_label"`
+	Title         string                   `json:"title"`
+	Summary       string                   `json:"summary"`
+	Action        string                   `json:"action"`
+	Gregorian     string                   `json:"gregorian"`
+	Hijri         string                   `json:"hijri"`
+	Sources       []occasionSourceResponse `json:"sources"`
 }
 
 type option struct {
@@ -499,6 +547,28 @@ func (h *Handler) build(ctx context.Context, identity Identity) (bootstrapRespon
 	formattedTomorrow := formatSchedule(tomorrow, profile, locale)
 	response.Today = &formattedToday
 	response.Tomorrow = &formattedTomorrow
+	upcoming, err := occasions.Between(now.In(today.Date.Location()), 400, profile.HijriAdjustment)
+	if err != nil {
+		return bootstrapResponse{}, fmt.Errorf("calculate upcoming Islamic occasions: %w", err)
+	}
+	for _, occurrence := range upcoming {
+		copy := locale.Occasion(occurrence.Definition.ID)
+		item := occasionResponse{
+			ID: occurrence.Definition.ID, Emoji: occurrence.Definition.Emoji,
+			Category:      string(occurrence.Definition.Category),
+			CategoryLabel: locale.OccasionCategory(string(occurrence.Definition.Category)),
+			Title:         copy.Title, Summary: copy.Summary, Action: copy.Action,
+			Gregorian: fmt.Sprintf("%d %s %d", occurrence.Date.Day(), locale.Month(int(occurrence.Date.Month())), occurrence.Date.Year()),
+			Hijri:     fmt.Sprintf("%d %s %d", occurrence.Hijri.Day, locale.HijriMonth(occurrence.Hijri.Month), occurrence.Hijri.Year),
+		}
+		for _, source := range occurrence.Definition.Sources {
+			item.Sources = append(item.Sources, occasionSourceResponse{Label: source.Label, URL: source.URL})
+		}
+		response.Occasions = append(response.Occasions, item)
+		if len(response.Occasions) == 3 {
+			break
+		}
+	}
 	return response, nil
 }
 
@@ -524,6 +594,12 @@ func (h *Handler) reminderState(ctx context.Context, chatID int64) (reminderResp
 			state.Fasting = true
 		case domain.ReminderWeeklyKahf:
 			state.Kahf = true
+		case domain.ReminderOccasionMajor:
+			state.OccasionMajor = true
+		case domain.ReminderOccasionFasting:
+			state.OccasionFasting = true
+		case domain.ReminderOccasionObserved:
+			state.OccasionObserved = true
 		case domain.ReminderAt:
 			state.Prayer = true
 		case domain.ReminderBefore:
@@ -672,7 +748,14 @@ func labels(locale i18n.Locale) map[string]string {
 		"pre_prayer_reminder": locale.Message("pre_prayer_reminder"),
 		"fasting_reminders":   locale.Button("fasting_reminders"), "kahf_reminders": locale.Button("kahf_reminders"),
 		"fasting_schedule": locale.Message("fasting_schedule"), "kahf_schedule": locale.Message("kahf_schedule"),
-		"save": copy.Save, "saved": copy.Saved, "loading": copy.Loading,
+		"occasions_title": locale.OccasionUI("title"), "occasions_help": locale.OccasionUI("help"),
+		"occasions_disclaimer": locale.OccasionUI("disclaimer"),
+		"occasion_recommended": locale.OccasionUI("recommended"), "occasion_sources": locale.OccasionUI("sources"),
+		"occasion_major_reminders":    locale.OccasionUI("major_reminders"),
+		"occasion_fasting_reminders":  locale.OccasionUI("fasting_reminders"),
+		"occasion_observed_reminders": locale.OccasionUI("observed_reminders"),
+		"occasion_schedule":           locale.OccasionUI("schedule"),
+		"save":                        copy.Save, "saved": copy.Saved, "loading": copy.Loading,
 		"location_help": copy.LocationHelp, "location_error": copy.LocationError,
 		"open_in_telegram": copy.OpenInTelegram, "temporary_failure": copy.TemporaryFailure,
 		"calculated_locally": copy.CalculatedLocally, "companion": copy.Companion,

--- a/global/internal/miniapp/handler_test.go
+++ b/global/internal/miniapp/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/escalopa/prayer-bot/global/internal/domain"
 	"github.com/escalopa/prayer-bot/global/internal/i18n"
 	"github.com/escalopa/prayer-bot/global/internal/location"
+	"github.com/escalopa/prayer-bot/global/internal/occasions"
 	"github.com/escalopa/prayer-bot/global/internal/prayertime"
 	"github.com/jackc/pgx/v5"
 )
@@ -53,6 +54,11 @@ func TestStaticMiniAppIsEmbeddedWithSecurityHeaders(t *testing.T) {
 		!strings.Contains(string(script), "navigator.share") ||
 		!strings.Contains(string(script), "canvas.toDataURL") {
 		t.Fatal("Mini App is missing offline, home-screen, or prayer-card sharing support")
+	}
+	if !strings.Contains(html, "occasion-list") ||
+		!strings.Contains(html, "occasion-observed-reminders") ||
+		!strings.Contains(string(script), "renderOccasions") {
+		t.Fatal("Mini App is missing Islamic occasion cards or opt-in reminder controls")
 	}
 	serviceWorker, err := embeddedStatic.ReadFile("static/sw.js")
 	if err != nil {
@@ -197,6 +203,9 @@ func TestLocationUpdatePreservesCalculationSettingsAndRoundsCoordinates(t *testi
 	if data.Qibla.BearingDegrees < 135 || data.Qibla.BearingDegrees > 137 || data.Qibla.DistanceKilometres < 1250 {
 		t.Fatalf("unexpected Qibla result: %+v", data.Qibla)
 	}
+	if len(data.Occasions) != 3 || data.Occasions[0].Title == "" || data.Occasions[0].Hijri == "" {
+		t.Fatalf("unexpected upcoming Islamic occasions: %+v", data.Occasions)
+	}
 }
 
 func TestCalendarSubscriptionProducesRollingThirtyDayFeed(t *testing.T) {
@@ -249,8 +258,20 @@ func TestCalendarSubscriptionProducesRollingThirtyDayFeed(t *testing.T) {
 	if !strings.Contains(downloadResponse.Body.String(), "REFRESH-INTERVAL;VALUE=DURATION:PT12H") {
 		t.Fatal("calendar response is missing its refresh hint")
 	}
-	if events := strings.Count(downloadResponse.Body.String(), "BEGIN:VEVENT\r\n"); events != 180 {
-		t.Fatalf("calendar event count = %d, want 180", events)
+	local, err := time.LoadLocation(storage.profiles[42].Timezone)
+	if err != nil {
+		t.Fatal(err)
+	}
+	upcoming, err := occasions.Between(now.In(local), 30, storage.profiles[42].HijriAdjustment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedEvents := 180 + len(upcoming)
+	if events := strings.Count(downloadResponse.Body.String(), "BEGIN:VEVENT\r\n"); events != expectedEvents {
+		t.Fatalf("calendar event count = %d, want %d", events, expectedEvents)
+	}
+	if len(upcoming) > 0 && !strings.Contains(downloadResponse.Body.String(), "CATEGORIES:Islamic Occasions") {
+		t.Fatal("calendar response is missing its Islamic occasion events")
 	}
 	if !strings.Contains(downloadResponse.Body.String(), subscription.UIDNamespace+"-20260717-fajr@global-prayer-bot") {
 		t.Fatal("calendar response is missing its stable event UID")
@@ -383,7 +404,8 @@ func TestPreferencesUpdateSavesSettingsAndRemindersTogether(t *testing.T) {
 	body := `{
 		"settings":{"language":"ar","method":"isna","madhab":"hanafi","high_latitude_rule":"middle_of_night","hijri_adjustment":1,
 		"adjustments":{"fajr":2,"sunrise":0,"dhuhr":0,"asr":1,"maghrib":0,"isha":-1}},
-		"reminders":{"prayer":true,"pre_prayer_minutes":20,"fasting":true,"kahf":false}
+		"reminders":{"prayer":true,"pre_prayer_minutes":20,"fasting":true,"kahf":false,
+		"occasion_major":true,"occasion_fasting":true,"occasion_observed":false}
 	}`
 	request := httptest.NewRequest(http.MethodPut, "/api/miniapp/preferences", strings.NewReader(body))
 	request.Header.Set("X-Telegram-Init-Data", signedInitData(t, "test-token", now, initDataUser{ID: 42, FirstName: "Amina", LanguageCode: "en"}))
@@ -403,7 +425,8 @@ func TestPreferencesUpdateSavesSettingsAndRemindersTogether(t *testing.T) {
 		t.Fatal(err)
 	}
 	if data.Locale != "ar" || !data.Reminders.Prayer || data.Reminders.PrePrayerMinutes != 20 ||
-		!data.Reminders.Fasting || data.Reminders.Kahf || planner.rebuilds != 1 {
+		!data.Reminders.Fasting || data.Reminders.Kahf || !data.Reminders.OccasionMajor ||
+		!data.Reminders.OccasionFasting || data.Reminders.OccasionObserved || planner.rebuilds != 1 {
 		t.Fatalf("unexpected updated state: response=%+v rebuilds=%d", data.Reminders, planner.rebuilds)
 	}
 }
@@ -423,11 +446,13 @@ func TestValidateRemindersRejectsUnsupportedLeadTime(t *testing.T) {
 	enabled, disabled := true, false
 	if err := validateReminders(remindersRequest{
 		Prayer: &enabled, PrePrayerMinutes: 20, Fasting: &disabled, Kahf: &disabled,
+		OccasionMajor: &disabled, OccasionFasting: &disabled, OccasionObserved: &disabled,
 	}); err != nil {
 		t.Fatalf("20-minute pre-reminder was rejected: %v", err)
 	}
 	if err := validateReminders(remindersRequest{
 		Prayer: &enabled, PrePrayerMinutes: 17, Fasting: &disabled, Kahf: &disabled,
+		OccasionMajor: &disabled, OccasionFasting: &disabled, OccasionObserved: &disabled,
 	}); err == nil {
 		t.Fatal("unsupported pre-reminder lead time was accepted")
 	}
@@ -501,7 +526,7 @@ func (s *fakeStorage) EnableDefaultRules(_ context.Context, chatID int64) error 
 
 func (s *fakeStorage) DisableRules(_ context.Context, chatID int64) error {
 	for index := range s.rules[chatID] {
-		if !s.rules[chatID][index].Kind.Weekly() {
+		if prayerReminderKind(s.rules[chatID][index].Kind) {
 			s.rules[chatID][index].Enabled = false
 		}
 	}
@@ -510,7 +535,7 @@ func (s *fakeStorage) DisableRules(_ context.Context, chatID int64) error {
 
 func (s *fakeStorage) ConfigurePrayerRules(_ context.Context, chatID int64, enabled bool, beforeMinutes int) error {
 	for index := range s.rules[chatID] {
-		if !s.rules[chatID][index].Kind.Weekly() {
+		if prayerReminderKind(s.rules[chatID][index].Kind) {
 			s.rules[chatID][index].Enabled = false
 		}
 	}
@@ -527,7 +552,22 @@ func (s *fakeStorage) ConfigurePrayerRules(_ context.Context, chatID int64, enab
 	return nil
 }
 
+func prayerReminderKind(kind domain.ReminderKind) bool {
+	return kind == domain.ReminderBefore || kind == domain.ReminderAt || kind == domain.ReminderTomorrow
+}
+
 func (s *fakeStorage) SetWeeklyRule(_ context.Context, chatID int64, kind domain.ReminderKind, enabled bool) error {
+	for index := range s.rules[chatID] {
+		if s.rules[chatID][index].Kind == kind {
+			s.rules[chatID][index].Enabled = enabled
+			return nil
+		}
+	}
+	s.rules[chatID] = append(s.rules[chatID], domain.ReminderRule{ChatID: chatID, Kind: kind, Enabled: enabled})
+	return nil
+}
+
+func (s *fakeStorage) SetOccasionRule(_ context.Context, chatID int64, kind domain.ReminderKind, enabled bool) error {
 	for index := range s.rules[chatID] {
 		if s.rules[chatID][index].Kind == kind {
 			s.rules[chatID][index].Enabled = enabled

--- a/global/internal/miniapp/static/app.css
+++ b/global/internal/miniapp/static/app.css
@@ -150,6 +150,69 @@ button { -webkit-tap-highlight-color: transparent; }
 .panel { margin-top: 14px; padding: 20px; }
 .panel-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 10px; }
 .panel-heading h2 { margin: 3px 0 0; font-size: 19px; letter-spacing: -.02em; }
+.panel-help { margin: 5px 0 0; color: var(--app-muted); font-size: 11px; line-height: 1.45; }
+.section-icon { font-size: 25px; }
+
+.occasions-panel { padding-bottom: 16px; }
+.occasions-heading { align-items: flex-start; margin-bottom: 15px; }
+.occasion-list { display: grid; gap: 11px; }
+.occasion-card {
+  padding: 15px;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--surface-alt) 66%, var(--surface));
+}
+.occasion-card-heading { display: flex; align-items: flex-start; gap: 11px; }
+.occasion-card-heading > div { min-width: 0; }
+.occasion-emoji {
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  flex: 0 0 38px;
+  border-radius: 12px;
+  background: var(--surface);
+  font-size: 19px;
+  box-shadow: 0 5px 15px rgba(25, 57, 45, .07);
+}
+.occasion-category {
+  display: inline-flex;
+  padding: 4px 7px;
+  border-radius: 999px;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  font-size: 9px;
+  font-weight: 850;
+  letter-spacing: .02em;
+}
+.occasion-category-fasting { color: #8a6117; background: rgba(196, 147, 48, .13); }
+.occasion-category-observed { color: var(--app-muted); background: color-mix(in srgb, var(--app-muted) 10%, transparent); }
+.occasion-card h3 { margin: 7px 0 3px; font-size: 15px; letter-spacing: -.01em; }
+.occasion-dates { margin: 0; color: var(--app-muted); font-size: 10px; }
+.occasion-summary, .occasion-recommendation { margin: 11px 0 0; font-size: 11px; line-height: 1.55; }
+.occasion-recommendation {
+  padding: 10px 11px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--accent) 6%, var(--surface));
+}
+.occasion-sources { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px; }
+.occasion-source {
+  padding: 5px 8px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--accent);
+  background: var(--surface);
+  font-size: 9px;
+  font-weight: 750;
+  text-decoration: none;
+}
+.occasion-disclaimer {
+  margin: 13px 2px 0;
+  color: var(--app-muted);
+  font-size: 10px;
+  line-height: 1.45;
+  text-align: center;
+}
 
 .tools-panel { padding-bottom: 18px; }
 .tool-grid { display: grid; gap: 12px; }

--- a/global/internal/miniapp/static/app.js
+++ b/global/internal/miniapp/static/app.js
@@ -191,6 +191,14 @@
     setText("kahf-reminders-label", labels.kahf_reminders);
     setText("fasting-schedule", labels.fasting_schedule);
     setText("kahf-schedule", labels.kahf_schedule);
+    setText("occasions-title", labels.occasions_title);
+    setText("occasions-help", labels.occasions_help);
+    setText("occasions-disclaimer", labels.occasions_disclaimer);
+    setText("occasion-major-reminders-label", labels.occasion_major_reminders);
+    setText("occasion-fasting-reminders-label", labels.occasion_fasting_reminders);
+    setText("occasion-observed-reminders-label", labels.occasion_observed_reminders);
+    ["occasion-major-schedule", "occasion-fasting-schedule", "occasion-observed-schedule"]
+      .forEach((id) => setText(id, labels.occasion_schedule));
     setText("language-label", labels.language);
     setText("method-label", labels.method);
     setText("madhab-label", labels.madhab);
@@ -355,7 +363,74 @@
     fillSelect("pre-prayer-minutes", state.options.pre_reminders, state.reminders.pre_prayer_minutes);
     byId("fasting-reminders").checked = state.reminders.fasting;
     byId("kahf-reminders").checked = state.reminders.kahf;
+    byId("occasion-major-reminders").checked = state.reminders.occasion_major;
+    byId("occasion-fasting-reminders").checked = state.reminders.occasion_fasting;
+    byId("occasion-observed-reminders").checked = state.reminders.occasion_observed;
     syncPreReminderAvailability();
+  }
+
+  function sourceLink(source) {
+    let url;
+    try {
+      url = new URL(source.url);
+    } catch (_) {
+      return null;
+    }
+    if (url.protocol !== "https:") return null;
+    const link = document.createElement("a");
+    link.className = "occasion-source";
+    link.href = url.href;
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+    link.textContent = source.label;
+    return link;
+  }
+
+  function renderOccasions() {
+    const list = byId("occasion-list");
+    list.replaceChildren();
+    (state.occasions || []).forEach((occasion) => {
+      const article = document.createElement("article");
+      article.className = "occasion-card";
+
+      const header = document.createElement("div");
+      header.className = "occasion-card-heading";
+      const emoji = document.createElement("span");
+      emoji.className = "occasion-emoji";
+      emoji.textContent = occasion.emoji;
+      const heading = document.createElement("div");
+      const category = document.createElement("span");
+      category.className = `occasion-category occasion-category-${occasion.category}`;
+      category.textContent = occasion.category_label;
+      const title = document.createElement("h3");
+      title.textContent = occasion.title;
+      const dates = document.createElement("p");
+      dates.className = "occasion-dates";
+      dates.textContent = `${occasion.hijri} · ${occasion.gregorian}`;
+      heading.append(category, title, dates);
+      header.append(emoji, heading);
+
+      const summary = document.createElement("p");
+      summary.className = "occasion-summary";
+      summary.textContent = occasion.summary;
+      const recommendation = document.createElement("p");
+      recommendation.className = "occasion-recommendation";
+      const recommendationLabel = document.createElement("strong");
+      recommendationLabel.textContent = `${state.labels.occasion_recommended}: `;
+      recommendation.append(recommendationLabel, document.createTextNode(occasion.action));
+
+      const sources = document.createElement("div");
+      sources.className = "occasion-sources";
+      (occasion.sources || []).forEach((source) => {
+        const link = sourceLink(source);
+        if (link) sources.append(link);
+      });
+      if (sources.childElementCount > 0) {
+        sources.setAttribute("aria-label", state.labels.occasion_sources);
+      }
+      article.append(header, summary, recommendation, sources);
+      list.append(article);
+    });
   }
 
   function syncPreReminderAvailability() {
@@ -378,6 +453,7 @@
     dashboard.classList.remove("hidden");
     renderSchedule();
     renderTools();
+    renderOccasions();
     renderReminders();
     renderSettings();
     setDirty(false);
@@ -500,6 +576,9 @@
       pre_prayer_minutes: Number(byId("pre-prayer-minutes").value),
       fasting: byId("fasting-reminders").checked,
       kahf: byId("kahf-reminders").checked,
+      occasion_major: byId("occasion-major-reminders").checked,
+      occasion_fasting: byId("occasion-fasting-reminders").checked,
+      occasion_observed: byId("occasion-observed-reminders").checked,
     };
   }
 
@@ -881,7 +960,9 @@
   byId("share-prayer-card").addEventListener("click", sharePrayerCard);
   byId("save-preferences").addEventListener("click", savePreferences);
   byId("retry-app").addEventListener("click", bootstrapApp);
-  ["prayer-reminders", "pre-prayer-minutes", "fasting-reminders", "kahf-reminders", "language", "method", "madhab", "highlat", "hijri-adjustment"]
+  ["prayer-reminders", "pre-prayer-minutes", "fasting-reminders", "kahf-reminders",
+    "occasion-major-reminders", "occasion-fasting-reminders", "occasion-observed-reminders",
+    "language", "method", "madhab", "highlat", "hijri-adjustment"]
     .forEach((id) => byId(id).addEventListener("change", () => setDirty(true)));
   byId("prayer-reminders").addEventListener("change", syncPreReminderAvailability);
   byId("adjustment-grid").addEventListener("input", () => setDirty(true));

--- a/global/internal/miniapp/static/index.html
+++ b/global/internal/miniapp/static/index.html
@@ -66,6 +66,18 @@
         </article>
       </section>
 
+      <section class="panel occasions-panel">
+        <div class="panel-heading occasions-heading">
+          <div>
+            <h2 id="occasions-title">Upcoming Islamic dates</h2>
+            <p id="occasions-help" class="panel-help">Calculated from your corrected Hijri calendar.</p>
+          </div>
+          <span class="section-icon" aria-hidden="true">🌙</span>
+        </div>
+        <div id="occasion-list" class="occasion-list"></div>
+        <p id="occasions-disclaimer" class="occasion-disclaimer"></p>
+      </section>
+
       <section class="panel tools-panel">
         <div class="panel-heading">
           <h2 id="tools-title">Tools</h2>
@@ -174,6 +186,21 @@
         <label class="toggle-row">
           <span><strong id="kahf-reminders-label">Friday Al-Kahf</strong><small id="kahf-schedule"></small></span>
           <input id="kahf-reminders" type="checkbox">
+          <span class="toggle" aria-hidden="true"></span>
+        </label>
+        <label class="toggle-row">
+          <span><strong id="occasion-major-reminders-label">Major Islamic occasions</strong><small id="occasion-major-schedule"></small></span>
+          <input id="occasion-major-reminders" type="checkbox">
+          <span class="toggle" aria-hidden="true"></span>
+        </label>
+        <label class="toggle-row">
+          <span><strong id="occasion-fasting-reminders-label">Special fasting days</strong><small id="occasion-fasting-schedule"></small></span>
+          <input id="occasion-fasting-reminders" type="checkbox">
+          <span class="toggle" aria-hidden="true"></span>
+        </label>
+        <label class="toggle-row">
+          <span><strong id="occasion-observed-reminders-label">Commonly observed dates</strong><small id="occasion-observed-schedule"></small></span>
+          <input id="occasion-observed-reminders" type="checkbox">
           <span class="toggle" aria-hidden="true"></span>
         </label>
       </section>

--- a/global/internal/miniapp/static/sw.js
+++ b/global/internal/miniapp/static/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const cacheName = "global-prayer-miniapp-shell-v1";
+const cacheName = "global-prayer-miniapp-shell-v2";
 const shellAssets = [
   "./",
   "./app.css",

--- a/global/internal/occasions/occasions.go
+++ b/global/internal/occasions/occasions.go
@@ -1,0 +1,146 @@
+// Package occasions provides the curated Islamic-date catalog used by the
+// Mini App, calendar feed, and reminder planner.
+package occasions
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/escalopa/prayer-bot/global/internal/hijri"
+)
+
+type Category string
+
+const (
+	CategoryMajor    Category = "major"
+	CategoryFasting  Category = "fasting"
+	CategoryObserved Category = "observed"
+)
+
+type Source struct {
+	Label string
+	URL   string
+}
+
+type Definition struct {
+	ID       string
+	Month    int
+	Day      int
+	Category Category
+	Emoji    string
+	Sources  []Source
+}
+
+type Occurrence struct {
+	Definition Definition
+	Date       time.Time
+	Hijri      hijri.Date
+}
+
+var catalog = []Definition{
+	{
+		ID: "ashura", Month: 1, Day: 10, Category: CategoryFasting, Emoji: "🌊",
+		Sources: []Source{{Label: "Sahih Muslim 1162a", URL: "https://sunnah.com/muslim:1162a"}},
+	},
+	{
+		ID: "mawlid", Month: 3, Day: 12, Category: CategoryObserved, Emoji: "ﷺ",
+		Sources: []Source{
+			{Label: "Quran 33:56", URL: "https://quran.com/33/56"},
+			{Label: "Sahih Muslim 1162e", URL: "https://sunnah.com/muslim:1162e"},
+		},
+	},
+	{
+		ID: "isra_miraj", Month: 7, Day: 27, Category: CategoryObserved, Emoji: "✨",
+		Sources: []Source{{Label: "Quran 17:1", URL: "https://quran.com/17/1"}},
+	},
+	{
+		ID: "mid_shaban", Month: 8, Day: 15, Category: CategoryObserved, Emoji: "🌕",
+	},
+	{
+		ID: "ramadan_start", Month: 9, Day: 1, Category: CategoryMajor, Emoji: "🌙",
+		Sources: []Source{{Label: "Quran 2:185", URL: "https://quran.com/2/185"}},
+	},
+	{
+		ID: "last_ten_nights", Month: 9, Day: 21, Category: CategoryMajor, Emoji: "🤲",
+		Sources: []Source{
+			{Label: "Surah Al-Qadr", URL: "https://quran.com/al-qadr"},
+			{Label: "Sahih al-Bukhari 2017", URL: "https://sunnah.com/bukhari:2017"},
+			{Label: "Jami at-Tirmidhi 3513", URL: "https://sunnah.com/tirmidhi/48/144"},
+		},
+	},
+	{
+		ID: "eid_fitr", Month: 10, Day: 1, Category: CategoryMajor, Emoji: "🎉",
+		Sources: []Source{{Label: "Quran 2:185", URL: "https://quran.com/2/185"}},
+	},
+	{
+		ID: "dhul_hijjah_start", Month: 12, Day: 1, Category: CategoryMajor, Emoji: "🕋",
+		Sources: []Source{{Label: "Sahih al-Bukhari 969", URL: "https://sunnah.com/bukhari:969"}},
+	},
+	{
+		ID: "arafah", Month: 12, Day: 9, Category: CategoryFasting, Emoji: "🤍",
+		Sources: []Source{{Label: "Sahih Muslim 1162a", URL: "https://sunnah.com/muslim:1162a"}},
+	},
+	{
+		ID: "eid_adha", Month: 12, Day: 10, Category: CategoryMajor, Emoji: "🐑",
+		Sources: []Source{{Label: "Quran 22:36", URL: "https://quran.com/22/36"}},
+	},
+}
+
+func Catalog() []Definition {
+	result := make([]Definition, len(catalog))
+	for index, definition := range catalog {
+		result[index] = definition
+		result[index].Sources = append([]Source(nil), definition.Sources...)
+	}
+	return result
+}
+
+func Between(start time.Time, days, adjustment int) ([]Occurrence, error) {
+	if days < 1 || days > 400 {
+		return nil, fmt.Errorf("occasion range must be between 1 and 400 days")
+	}
+	var result []Occurrence
+	for offset := 0; offset < days; offset++ {
+		date := start.AddDate(0, 0, offset)
+		hijriDate, err := hijri.FromGregorian(date, adjustment)
+		if err != nil {
+			return nil, err
+		}
+		for _, definition := range catalog {
+			if definition.Month == hijriDate.Month && definition.Day == hijriDate.Day {
+				result = append(result, Occurrence{
+					Definition: definition,
+					Date:       date,
+					Hijri:      hijriDate,
+				})
+			}
+		}
+	}
+	return result, nil
+}
+
+func Next(start time.Time, adjustment int, category Category) (Occurrence, error) {
+	upcoming, err := Between(start, 400, adjustment)
+	if err != nil {
+		return Occurrence{}, err
+	}
+	for _, occurrence := range upcoming {
+		if occurrence.Definition.Category == category {
+			return occurrence, nil
+		}
+	}
+	return Occurrence{}, fmt.Errorf("no %s occasion found in the next 400 days", category)
+}
+
+func OnDate(date time.Time, adjustment int, category Category) (Occurrence, bool) {
+	upcoming, err := Between(date, 1, adjustment)
+	if err != nil {
+		return Occurrence{}, false
+	}
+	for _, occurrence := range upcoming {
+		if occurrence.Definition.Category == category {
+			return occurrence, true
+		}
+	}
+	return Occurrence{}, false
+}

--- a/global/internal/occasions/occasions_test.go
+++ b/global/internal/occasions/occasions_test.go
@@ -1,0 +1,66 @@
+package occasions
+
+import (
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestCatalogHasUniqueStableIDsAndValidSources(t *testing.T) {
+	seen := map[string]bool{}
+	for _, definition := range Catalog() {
+		if definition.ID == "" || seen[definition.ID] {
+			t.Fatalf("invalid or duplicate ID %q", definition.ID)
+		}
+		seen[definition.ID] = true
+		if definition.Month < 1 || definition.Month > 12 ||
+			definition.Day < 1 || definition.Day > 30 {
+			t.Fatalf("invalid Hijri date for %q", definition.ID)
+		}
+		for _, source := range definition.Sources {
+			if source.Label == "" || source.URL == "" {
+				t.Fatalf("incomplete source for %q", definition.ID)
+			}
+			parsed, err := url.Parse(source.URL)
+			if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+				t.Fatalf("invalid HTTPS source for %q: %q", definition.ID, source.URL)
+			}
+		}
+	}
+}
+
+func TestBetweenRespectsHijriAdjustment(t *testing.T) {
+	start := time.Date(2026, time.January, 1, 12, 0, 0, 0, time.UTC)
+	withoutAdjustment, err := Between(start, 400, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	withAdjustment, err := Between(start, 400, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	find := func(values []Occurrence, id string) time.Time {
+		for _, value := range values {
+			if value.Definition.ID == id {
+				return value.Date
+			}
+		}
+		return time.Time{}
+	}
+	base := find(withoutAdjustment, "arafah")
+	adjusted := find(withAdjustment, "arafah")
+	if base.IsZero() || adjusted.IsZero() || !adjusted.Equal(base.AddDate(0, 0, -1)) {
+		t.Fatalf("adjustment did not move Arafah: base=%v adjusted=%v", base, adjusted)
+	}
+}
+
+func TestNextFiltersCategory(t *testing.T) {
+	start := time.Date(2026, time.January, 1, 12, 0, 0, 0, time.UTC)
+	occurrence, err := Next(start, 0, CategoryObserved)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if occurrence.Definition.Category != CategoryObserved || occurrence.Date.Before(start) {
+		t.Fatalf("unexpected occurrence: %+v", occurrence)
+	}
+}

--- a/global/internal/reminders/planner.go
+++ b/global/internal/reminders/planner.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/escalopa/prayer-bot/global/internal/domain"
+	"github.com/escalopa/prayer-bot/global/internal/occasions"
 	"github.com/escalopa/prayer-bot/global/internal/prayertime"
 )
 
@@ -55,6 +56,9 @@ func (p *Planner) Next(ctx context.Context, profile domain.PrayerProfile, rule d
 	if rule.Kind.Weekly() {
 		return nextWeekly(profile, rule, after, location)
 	}
+	if rule.Kind.Occasion() {
+		return nextOccasion(profile, rule, after, location)
+	}
 	localAfter := after.In(location)
 	for dayOffset := 0; dayOffset < 8; dayOffset++ {
 		date := localAfter.AddDate(0, 0, dayOffset)
@@ -90,6 +94,55 @@ func (p *Planner) Next(ctx context.Context, profile domain.PrayerProfile, rule d
 		}, nil
 	}
 	return domain.ReminderSchedule{}, fmt.Errorf("no valid occurrence found in the next eight days")
+}
+
+func nextOccasion(profile domain.PrayerProfile, rule domain.ReminderRule, after time.Time, location *time.Location) (domain.ReminderSchedule, error) {
+	category, ok := occasionCategory(rule.Kind)
+	if !ok {
+		return domain.ReminderSchedule{}, fmt.Errorf("unsupported occasion reminder kind %q", rule.Kind)
+	}
+	hour, minute, err := parseLocalTime(rule.LocalTime)
+	if err != nil {
+		return domain.ReminderSchedule{}, err
+	}
+	localAfter := after.In(location)
+	upcoming, err := occasions.Between(localAfter, 400, profile.HijriAdjustment)
+	if err != nil {
+		return domain.ReminderSchedule{}, err
+	}
+	for _, occurrence := range upcoming {
+		if occurrence.Definition.Category != category {
+			continue
+		}
+		target := time.Date(
+			occurrence.Date.Year(), occurrence.Date.Month(), occurrence.Date.Day(),
+			0, 0, 0, 0, location,
+		)
+		previous := target.AddDate(0, 0, -1)
+		nextRun := time.Date(previous.Year(), previous.Month(), previous.Day(), hour, minute, 0, 0, location)
+		if !nextRun.After(after) {
+			continue
+		}
+		return domain.ReminderSchedule{
+			RuleID: rule.ID, ChatID: rule.ChatID, ProfileVersion: profile.Version,
+			LocalDate: target.Format("2006-01-02"), PrayerAt: target,
+			NextRunAt: nextRun.UTC(), State: "pending",
+		}, nil
+	}
+	return domain.ReminderSchedule{}, fmt.Errorf("no valid occasion found in the next 400 days")
+}
+
+func occasionCategory(kind domain.ReminderKind) (occasions.Category, bool) {
+	switch kind {
+	case domain.ReminderOccasionMajor:
+		return occasions.CategoryMajor, true
+	case domain.ReminderOccasionFasting:
+		return occasions.CategoryFasting, true
+	case domain.ReminderOccasionObserved:
+		return occasions.CategoryObserved, true
+	default:
+		return "", false
+	}
 }
 
 func nextWeekly(profile domain.PrayerProfile, rule domain.ReminderRule, after time.Time, location *time.Location) (domain.ReminderSchedule, error) {

--- a/global/internal/reminders/planner_test.go
+++ b/global/internal/reminders/planner_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/escalopa/prayer-bot/global/internal/domain"
+	"github.com/escalopa/prayer-bot/global/internal/occasions"
 )
 
 type fixedCalculator struct{ prayerAt time.Time }
@@ -66,5 +67,33 @@ func TestNextFridayKahfReminderUsesFridayMorning(t *testing.T) {
 	}
 	if got := next.NextRunAt.In(location).Format("Monday 2006-01-02 15:04"); got != "Friday 2026-07-24 09:00" {
 		t.Fatalf("unexpected Al-Kahf reminder: %s", got)
+	}
+}
+
+func TestNextIslamicOccasionUsesCorrectedHijriDateAndPreviousEvening(t *testing.T) {
+	location, _ := time.LoadLocation("Africa/Cairo")
+	after := time.Date(2026, 1, 1, 12, 0, 0, 0, location)
+	profile := domain.PrayerProfile{Timezone: "Africa/Cairo", Version: 5, HijriAdjustment: 1}
+	rule := domain.ReminderRule{
+		ID: 10, ChatID: 20, Kind: domain.ReminderOccasionFasting, LocalTime: "20:00",
+	}
+	occurrence, err := occasions.Next(after, profile.HijriAdjustment, occasions.CategoryFasting)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	next, err := (&Planner{}).Next(context.Background(), profile, rule, after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next.LocalDate != occurrence.Date.Format("2006-01-02") {
+		t.Fatalf("occasion date = %s, want %s", next.LocalDate, occurrence.Date.Format("2006-01-02"))
+	}
+	expectedRun := time.Date(
+		occurrence.Date.Year(), occurrence.Date.Month(), occurrence.Date.Day()-1,
+		20, 0, 0, 0, location,
+	)
+	if !next.NextRunAt.Equal(expectedRun.UTC()) {
+		t.Fatalf("occasion run = %s, want %s", next.NextRunAt, expectedRun.UTC())
 	}
 }

--- a/global/internal/reminders/sender.go
+++ b/global/internal/reminders/sender.go
@@ -3,6 +3,8 @@ package reminders
 import (
 	"context"
 	"fmt"
+	"html"
+	"strings"
 	"time"
 
 	botapi "github.com/go-telegram/bot"
@@ -10,6 +12,7 @@ import (
 
 	"github.com/escalopa/prayer-bot/global/internal/domain"
 	"github.com/escalopa/prayer-bot/global/internal/i18n"
+	"github.com/escalopa/prayer-bot/global/internal/occasions"
 	"github.com/escalopa/prayer-bot/global/internal/store"
 )
 
@@ -126,6 +129,8 @@ func notificationCategory(kind domain.ReminderKind) string {
 		return "weekly_kahf"
 	case domain.ReminderTomorrow:
 		return "tomorrow"
+	case domain.ReminderOccasionMajor, domain.ReminderOccasionFasting, domain.ReminderOccasionObserved:
+		return "islamic_occasion"
 	default:
 		// Before-prayer and at-prayer messages intentionally share a slot.
 		// A pre-reminder replaces the previous prayer, and the arrival message
@@ -146,9 +151,47 @@ func reminderText(rule domain.ReminderRule, schedule domain.ReminderSchedule, pr
 		return fmt.Sprintf(locale.Message("reminder_before"), name, rule.OffsetMinutes, timeText)
 	case domain.ReminderTomorrow:
 		return fmt.Sprintf(locale.Message("reminder_tomorrow"), name, timeText)
+	case domain.ReminderOccasionMajor, domain.ReminderOccasionFasting, domain.ReminderOccasionObserved:
+		return occasionReminderText(rule, schedule, profile, locale)
 	default:
 		return fmt.Sprintf(locale.Message("reminder_at"), name)
 	}
+}
+
+func occasionReminderText(rule domain.ReminderRule, schedule domain.ReminderSchedule, profile domain.PrayerProfile, locale i18n.Locale) string {
+	category, ok := occasionCategory(rule.Kind)
+	if !ok {
+		return ""
+	}
+	location := mustLocation(profile.Timezone)
+	date, err := time.ParseInLocation("2006-01-02", schedule.LocalDate, location)
+	if err != nil {
+		return ""
+	}
+	occurrence, ok := occasions.OnDate(date, profile.HijriAdjustment, category)
+	if !ok {
+		return ""
+	}
+	copy := locale.Occasion(occurrence.Definition.ID)
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "<b>%s %s</b>\n📅 %d %s %d\n\n%s\n\n💡 %s",
+		html.EscapeString(occurrence.Definition.Emoji),
+		html.EscapeString(copy.Title),
+		date.Day(), html.EscapeString(locale.Month(int(date.Month()))), date.Year(),
+		html.EscapeString(copy.Summary),
+		html.EscapeString(copy.Action),
+	)
+	if len(occurrence.Definition.Sources) > 0 {
+		builder.WriteString("\n\n📚 ")
+		for index, source := range occurrence.Definition.Sources {
+			if index > 0 {
+				builder.WriteString(" · ")
+			}
+			fmt.Fprintf(&builder, `<a href="%s">%s</a>`,
+				html.EscapeString(source.URL), html.EscapeString(source.Label))
+		}
+	}
+	return builder.String()
 }
 
 func mustLocation(name string) *time.Location {

--- a/global/internal/reminders/sender_test.go
+++ b/global/internal/reminders/sender_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/escalopa/prayer-bot/global/internal/domain"
 	"github.com/escalopa/prayer-bot/global/internal/i18n"
+	"github.com/escalopa/prayer-bot/global/internal/occasions"
 )
 
 func TestReminderTextUsesSelectedLocale(t *testing.T) {
@@ -45,5 +46,34 @@ func TestPrayerNotificationsShareOneCleanupCategory(t *testing.T) {
 func TestNotificationLifetimeFitsTelegramDeletionWindow(t *testing.T) {
 	if notificationLifetime <= 0 || notificationLifetime >= 48*time.Hour {
 		t.Fatalf("notification lifetime %s must remain inside Telegram's 48-hour deletion window", notificationLifetime)
+	}
+}
+
+func TestIslamicOccasionReminderIncludesLocalizedGuidanceAndSources(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	occurrence, err := occasions.Next(start, 0, occasions.CategoryFasting)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rule := domain.ReminderRule{Kind: domain.ReminderOccasionFasting}
+	schedule := domain.ReminderSchedule{
+		LocalDate: occurrence.Date.Format("2006-01-02"),
+		PrayerAt:  occurrence.Date,
+	}
+	text := reminderText(rule, schedule, domain.PrayerProfile{Timezone: "UTC"}, i18n.Resolve("en"))
+	copy := i18n.Resolve("en").Occasion(occurrence.Definition.ID)
+	for _, expected := range []string{copy.Title, copy.Action, occurrence.Definition.Sources[0].URL} {
+		if !strings.Contains(text, expected) {
+			t.Errorf("occasion reminder missing %q: %s", expected, text)
+		}
+	}
+	for _, kind := range []domain.ReminderKind{
+		domain.ReminderOccasionMajor,
+		domain.ReminderOccasionFasting,
+		domain.ReminderOccasionObserved,
+	} {
+		if got := notificationCategory(kind); got != "islamic_occasion" {
+			t.Fatalf("notificationCategory(%q) = %q", kind, got)
+		}
 	}
 }

--- a/global/internal/store/postgres.go
+++ b/global/internal/store/postgres.go
@@ -272,6 +272,9 @@ func (s *Store) AdminMetrics(ctx context.Context) (AdminDashboard, error) {
 				WHEN kind IN ('before', 'at', 'tomorrow') THEN 'prayer'
 				WHEN kind = 'weekly_fasting' THEN 'fasting'
 				WHEN kind = 'weekly_kahf' THEN 'kahf'
+				WHEN kind = 'occasion_major' THEN 'occasion_major'
+				WHEN kind = 'occasion_fasting' THEN 'occasion_fasting'
+				WHEN kind = 'occasion_observed' THEN 'occasion_observed'
 			END AS category
 			FROM global_bot.reminder_rules r
 			JOIN global_bot.chats c ON c.telegram_chat_id = r.chat_id
@@ -433,6 +436,38 @@ func (s *Store) SetWeeklyRule(ctx context.Context, chatID int64, kind domain.Rem
 			ON CONFLICT (chat_id, kind, prayer, offset_minutes) DO UPDATE SET
 				local_time = excluded.local_time, enabled = true, updated_at = now()`,
 			chatID, kind, localTime); err != nil {
+			return err
+		}
+	} else {
+		if _, err = tx.Exec(ctx, `UPDATE global_bot.reminder_rules SET enabled = false, updated_at = now()
+			WHERE chat_id = $1 AND kind = $2`, chatID, kind); err != nil {
+			return err
+		}
+		if _, err = tx.Exec(ctx, `DELETE FROM global_bot.reminder_schedules s
+			USING global_bot.reminder_rules r
+			WHERE s.rule_id = r.id AND r.chat_id = $1 AND r.kind = $2`, chatID, kind); err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
+}
+
+func (s *Store) SetOccasionRule(ctx context.Context, chatID int64, kind domain.ReminderKind, enabled bool) error {
+	if !kind.Occasion() {
+		return fmt.Errorf("unsupported occasion reminder kind %q", kind)
+	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+	if enabled {
+		if _, err = tx.Exec(ctx, `
+			INSERT INTO global_bot.reminder_rules (chat_id, kind, prayer, local_time, enabled)
+			VALUES ($1, $2, 'fajr', '20:00', true)
+			ON CONFLICT (chat_id, kind, prayer, offset_minutes) DO UPDATE SET
+				local_time = excluded.local_time, enabled = true, updated_at = now()`,
+			chatID, kind); err != nil {
 			return err
 		}
 	} else {

--- a/global/internal/telegram/admin.go
+++ b/global/internal/telegram/admin.go
@@ -204,13 +204,19 @@ func formatAdminReminders(metrics store.AdminDashboard) string {
 		"<b>Reminder adoption</b> 🔔\n\n"+
 			"🕌 Prayer times: <b>%d</b>\n"+
 			"🌙 Monday &amp; Thursday fasting: <b>%d</b>\n"+
-			"📖 Friday Al-Kahf: <b>%d</b>\n\n"+
+			"📖 Friday Al-Kahf: <b>%d</b>\n"+
+			"🕋 Major Islamic occasions: <b>%d</b>\n"+
+			"🤲 Special fasting days: <b>%d</b>\n"+
+			"🌙 Commonly observed dates: <b>%d</b>\n\n"+
 			"Users with any reminder: %d · %.1f%%\n"+
 			"Enabled rules: %d\n"+
 			"Pending schedules: %d",
 		counts["prayer"],
 		counts["fasting"],
 		counts["kahf"],
+		counts["occasion_major"],
+		counts["occasion_fasting"],
+		counts["occasion_observed"],
 		metrics.ReminderUsers,
 		percentage(metrics.ReminderUsers, metrics.Users),
 		metrics.EnabledRules,

--- a/global/internal/telegram/admin_test.go
+++ b/global/internal/telegram/admin_test.go
@@ -76,7 +76,11 @@ func TestAdminDashboardFormatsAggregateViews(t *testing.T) {
 		FailedUpdates24Hours:    4,
 		Languages:               []store.MetricCount{{Key: "en", Count: 70}, {Key: "ar", Count: 30}},
 		Methods:                 []store.MetricCount{{Key: "egyptian", Count: 60}, {Key: "mwl", Count: 20}},
-		ReminderKinds:           []store.MetricCount{{Key: "prayer", Count: 30}, {Key: "fasting", Count: 10}, {Key: "kahf", Count: 8}},
+		ReminderKinds: []store.MetricCount{
+			{Key: "prayer", Count: 30}, {Key: "fasting", Count: 10}, {Key: "kahf", Count: 8},
+			{Key: "occasion_major", Count: 6}, {Key: "occasion_fasting", Count: 5},
+			{Key: "occasion_observed", Count: 3},
+		},
 	}
 	now := time.Date(2026, time.July, 17, 12, 30, 0, 0, time.FixedZone("EET", 2*60*60))
 	expectations := map[adminView]string{

--- a/global/internal/telegram/callbacks.go
+++ b/global/internal/telegram/callbacks.go
@@ -223,6 +223,18 @@ func (h *Handler) handleReminderCallback(ctx context.Context, message *models.Me
 		if err := h.store.SetWeeklyRule(ctx, message.Chat.ID, domain.ReminderWeeklyKahf, enabled); err != nil {
 			return err
 		}
+	case "occasion_major":
+		if err := h.store.SetOccasionRule(ctx, message.Chat.ID, domain.ReminderOccasionMajor, enabled); err != nil {
+			return err
+		}
+	case "occasion_fasting":
+		if err := h.store.SetOccasionRule(ctx, message.Chat.ID, domain.ReminderOccasionFasting, enabled); err != nil {
+			return err
+		}
+	case "occasion_observed":
+		if err := h.store.SetOccasionRule(ctx, message.Chat.ID, domain.ReminderOccasionObserved, enabled); err != nil {
+			return err
+		}
 	default:
 		return nil
 	}

--- a/global/internal/telegram/commands.go
+++ b/global/internal/telegram/commands.go
@@ -305,6 +305,9 @@ type reminderState struct {
 	PrePrayerMinutes int
 	Fasting          bool
 	Kahf             bool
+	OccasionMajor    bool
+	OccasionFasting  bool
+	OccasionObserved bool
 }
 
 func (h *Handler) loadReminderState(ctx context.Context, chatID int64) (reminderState, error) {
@@ -319,6 +322,12 @@ func (h *Handler) loadReminderState(ctx context.Context, chatID int64) (reminder
 			state.Fasting = true
 		case domain.ReminderWeeklyKahf:
 			state.Kahf = true
+		case domain.ReminderOccasionMajor:
+			state.OccasionMajor = true
+		case domain.ReminderOccasionFasting:
+			state.OccasionFasting = true
+		case domain.ReminderOccasionObserved:
+			state.OccasionObserved = true
 		case domain.ReminderAt:
 			state.Prayer = true
 		case domain.ReminderBefore:
@@ -339,11 +348,14 @@ func formatReminders(state reminderState, locale i18n.Locale) string {
 	if state.PrePrayerMinutes > 0 {
 		preReminder = fmt.Sprintf(locale.Message("minutes_before"), state.PrePrayerMinutes)
 	}
-	return fmt.Sprintf("%s\n\n🔔 <b>%s</b> · %s\n   ⏳ %s\n\n🌙 <b>%s</b> · %s\n   %s\n\n📖 <b>%s</b> · %s\n   %s",
+	return fmt.Sprintf("%s\n\n🔔 <b>%s</b> · %s\n   ⏳ %s\n\n🌙 <b>%s</b> · %s\n   %s\n\n📖 <b>%s</b> · %s\n   %s\n\n🕌 <b>%s</b> · %s\n   %s\n\n🤲 <b>%s</b> · %s\n   %s\n\n🌙 <b>%s</b> · %s\n   %s",
 		locale.Message("reminders_title"), escape(locale.Button("prayer_reminders")), status(state.Prayer),
 		escape(preReminder),
 		escape(locale.Button("fasting_reminders")), status(state.Fasting), escape(locale.Message("fasting_schedule")),
-		escape(locale.Button("kahf_reminders")), status(state.Kahf), escape(locale.Message("kahf_schedule")))
+		escape(locale.Button("kahf_reminders")), status(state.Kahf), escape(locale.Message("kahf_schedule")),
+		escape(locale.OccasionUI("major_reminders")), status(state.OccasionMajor), escape(locale.OccasionUI("schedule")),
+		escape(locale.OccasionUI("fasting_reminders")), status(state.OccasionFasting), escape(locale.OccasionUI("schedule")),
+		escape(locale.OccasionUI("observed_reminders")), status(state.OccasionObserved), escape(locale.OccasionUI("schedule")))
 }
 
 func localizedDate(date time.Time, locale i18n.Locale) string {

--- a/global/internal/telegram/keyboards.go
+++ b/global/internal/telegram/keyboards.go
@@ -129,6 +129,9 @@ func remindersKeyboard(state reminderState, locale i18n.Locale) *models.InlineKe
 		[]models.InlineKeyboardButton{callbackButton("⏳ "+preReminder, "reminders:pre:choose")},
 		[]models.InlineKeyboardButton{toggle(locale.Button("fasting_reminders"), "fasting", state.Fasting)},
 		[]models.InlineKeyboardButton{toggle(locale.Button("kahf_reminders"), "kahf", state.Kahf)},
+		[]models.InlineKeyboardButton{toggle(locale.OccasionUI("major_reminders"), "occasion_major", state.OccasionMajor)},
+		[]models.InlineKeyboardButton{toggle(locale.OccasionUI("fasting_reminders"), "occasion_fasting", state.OccasionFasting)},
+		[]models.InlineKeyboardButton{toggle(locale.OccasionUI("observed_reminders"), "occasion_observed", state.OccasionObserved)},
 		[]models.InlineKeyboardButton{callbackButton(locale.Button("close"), "close")},
 	)
 }

--- a/global/migrations/00005_islamic_occasions.sql
+++ b/global/migrations/00005_islamic_occasions.sql
@@ -1,0 +1,43 @@
+-- +goose Up
+-- +goose ENVSUB ON
+ALTER TABLE ${GLOBAL_DB_SCHEMA}.reminder_rules
+    DROP CONSTRAINT reminder_rules_kind_check;
+
+ALTER TABLE ${GLOBAL_DB_SCHEMA}.reminder_rules
+    ADD CONSTRAINT reminder_rules_kind_check
+    CHECK (kind IN (
+        'before', 'at', 'tomorrow', 'weekly_fasting', 'weekly_kahf',
+        'occasion_major', 'occasion_fasting', 'occasion_observed'
+    ));
+
+ALTER TABLE ${GLOBAL_DB_SCHEMA}.notification_message_slots
+    DROP CONSTRAINT notification_message_slots_category_check;
+
+ALTER TABLE ${GLOBAL_DB_SCHEMA}.notification_message_slots
+    ADD CONSTRAINT notification_message_slots_category_check
+    CHECK (category IN (
+        'prayer', 'tomorrow', 'weekly_fasting', 'weekly_kahf',
+        'islamic_occasion'
+    ));
+
+-- +goose Down
+DELETE FROM ${GLOBAL_DB_SCHEMA}.reminder_rules
+WHERE kind IN ('occasion_major', 'occasion_fasting', 'occasion_observed');
+
+DELETE FROM ${GLOBAL_DB_SCHEMA}.notification_message_slots
+WHERE category = 'islamic_occasion';
+
+ALTER TABLE ${GLOBAL_DB_SCHEMA}.notification_message_slots
+    DROP CONSTRAINT notification_message_slots_category_check;
+
+ALTER TABLE ${GLOBAL_DB_SCHEMA}.notification_message_slots
+    ADD CONSTRAINT notification_message_slots_category_check
+    CHECK (category IN ('prayer', 'tomorrow', 'weekly_fasting', 'weekly_kahf'));
+
+ALTER TABLE ${GLOBAL_DB_SCHEMA}.reminder_rules
+    DROP CONSTRAINT reminder_rules_kind_check;
+
+ALTER TABLE ${GLOBAL_DB_SCHEMA}.reminder_rules
+    ADD CONSTRAINT reminder_rules_kind_check
+    CHECK (kind IN ('before', 'at', 'tomorrow', 'weekly_fasting', 'weekly_kahf'));
+-- +goose ENVSUB OFF


### PR DESCRIPTION
## Summary
- add one curated Hijri occasion catalog shared by the Mini App, rolling calendar, and reminder planner
- show the next three localized dates with recommended actions and Quran/Hadith source links
- add independent opt-in reminders for major occasions, special fasting days, and commonly observed dates
- schedule occasion reminders at 20:00 on the preceding local evening and reuse one cleanup slot to avoid notification buildup
- add all-day occasion events to each private rolling calendar using the saved Hijri correction
- expose adoption metrics in the owner dashboard and document the architecture, data model, flows, and operations

## Safety and rollout
- all new reminder groups are disabled by default
- commonly observed/disputed dates are clearly labelled and use cautious copy
- prayer calculations are unchanged; Hijri correction affects only Hijri labels and occasion matching
- migration 00005 extends only the isolated global-bot schema constraints
- no new service, cron job, external API, secret, or Terraform resource is introduced

## Verification
- gofmt -d cmd internal
- go vet ./...
- go test -race ./...
- node --check internal/miniapp/static/app.js
- docker build -t global-prayer-bot:islamic-occasions .
- terraform fmt -check -recursive
- terraform init -backend=false
- terraform validate
- linked Quran.com and Sunnah.com references opened and reviewed