### PR TITLE
[codex] Fix Mini App updates and prayer card sharing

### DIFF
--- a/global/README.md
+++ b/global/README.md
@@ -30,7 +30,7 @@ in the same pull request.
 - Category-aware notification cleanup: a new prayer notice replaces the preceding prayer/pre-prayer message, weekly categories are independent, and every reminder expires within Telegram's deletion window.
 - A Qibla tool that calculates the initial great-circle bearing and distance to the Kaaba from the saved rounded coordinates, with optional live compass orientation on supported Telegram clients.
 - A revocable private Google Calendar subscription that serves a localized rolling 30-day prayer feed and automatically reflects the saved location and calculation settings when Google refreshes it.
-- Localized 1080×1350 prayer cards generated entirely in the Mini App and shared through the device share sheet, with a gallery-download fallback.
+- Localized 1080×1350 prayer cards generated entirely in the Mini App and shared through the device share sheet; Telegram WebViews without file sharing send the PNG to the user's bot chat for reliable saving or forwarding.
 - An embedded welcome illustration sent on `/start` and a generated bot avatar installed during profile synchronization.
 - A localized feedback and bug-report flow that accepts text or screenshots in a private chat and delivers them directly to the configured owner with the sender's disclosed Telegram identity.
 - An owner-only `/admin` dashboard with aggregate user activity, onboarding, language, calculation-method, reminder-adoption, queue, and delivery-health metrics.
@@ -55,7 +55,7 @@ Feedback arrives in the owner's private bot chat as a metadata message followed 
 | `dispatch` | Cloud Scheduler service account only | Claim due indexed schedules and create Cloud Tasks |
 | `sender` | Cloud Tasks service account only | Idempotent Telegram delivery, category cleanup, and next-occurrence planning |
 
-The three services use one immutable image and select `/webhook`, `/dispatch`, or `/send` as the command. The webhook binary embeds the Mini App and serves it at `/app/`, so the feature does not add another Cloud Run service, container image, database, migration, or secret. Offline snapshots remain on the user's device, and prayer cards are rendered in the browser; neither feature adds server storage or scheduled work.
+The three services use one immutable image and select `/webhook`, `/dispatch`, or `/send` as the command. The webhook binary embeds the Mini App and serves it at `/app/`, so the feature does not add another Cloud Run service, container image, database, migration, or secret. Offline snapshots remain on the user's device, and prayer cards are rendered in the browser. A card that cannot use the device share sheet is uploaded directly to Telegram as a photo in the user's bot chat and is not retained by the service; neither feature adds server storage or scheduled work.
 
 Calendar subscriptions use a random private bearer URL created only after the Mini App session has been authenticated. The URL exposes neither the Telegram user ID nor the bot token and can be revoked from the Mini App. Each fetch calculates today and the following 29 local days, including prayer times and Islamic occasions, so no daily cron or stored calendar events are required. Google controls when subscribed calendars refresh, so updates are not guaranteed to appear exactly at local midnight. Qibla calculations and calendar generation use the existing saved profile and local calculation engines, so neither feature adds an external API call from the bot or a recurring job.
 

--- a/global/cmd/webhook/main.go
+++ b/global/cmd/webhook/main.go
@@ -45,7 +45,7 @@ func main() {
 	handler := telegramhandler.NewHandler(
 		telegramBot, storage, resolver, calculator, planner, cfg.OwnerID,
 	)
-	miniApp := miniapp.NewHandler(cfg.TelegramToken, storage, resolver, calculator, planner, logger)
+	miniApp := miniapp.NewHandler(cfg.TelegramToken, storage, resolver, calculator, planner, logger, telegramBot)
 
 	mux := http.NewServeMux()
 	httpx.HealthMux(mux)

--- a/global/docs/architecture.md
+++ b/global/docs/architecture.md
@@ -43,8 +43,9 @@ This is a client-side entry point to the same signed Mini App and creates no new
 service or authentication path. Prayer cards are likewise generated entirely
 in the browser as localized PNG files from the selected today/tomorrow
 schedule. The native device share sheet is used when file sharing is supported;
-otherwise the image is downloaded for manual sharing. Cards are not uploaded or
-stored by the bot.
+otherwise an authenticated, size- and dimension-validated request sends the PNG
+to the user's private bot chat for reliable saving or forwarding. The service
+streams that fallback image directly to Telegram and does not retain it.
 
 Calendar connection first creates or reuses a random private subscription URL
 from an authenticated Mini App request. Google Calendar fetches that URL without

--- a/global/docs/operations.md
+++ b/global/docs/operations.md
@@ -25,6 +25,7 @@ payload.
 | Duplicate reminder messages in the same minute | A sender 5xx after Telegram accepted the first message, followed by a successful Cloud Tasks retry of the same delivery key | [Reminder delivery](reminder-delivery.md) |
 | `prepared statement ... already exists` (`42P05`) | pgx named statement caching used through a transaction pooler | [Runtime and deployment](runtime-and-deployment.md#database-connections) |
 | `prepared statement ... does not exist` (`26000`) | The pooler moved a cached statement to a different PostgreSQL connection | [Runtime and deployment](runtime-and-deployment.md#database-connections) |
+| `invalid input syntax for type json` (`22P02`) during profile or outbox writes | A JSONB value was passed as Go `[]byte` while pgx used `QueryExecModeExec` | [Runtime and deployment](runtime-and-deployment.md#database-connections) |
 | Reminder is late but eventually arrives | Cloud Run cold start, queue backoff, or transient sender 5xx | [Reminder delivery](reminder-delivery.md#retry-configuration) |
 | Old notification remains | Immediate Telegram deletion failed and its durable deletion task is retrying or expired past Telegram's limit | [Reminder delivery](reminder-delivery.md#cleanup-categories) |
 | Existing schedules work but location update fails | Google Time Zone or Geocoding failure | [Maps failure mode](#maps-failure-mode) |

--- a/global/docs/request-flows.md
+++ b/global/docs/request-flows.md
@@ -88,9 +88,11 @@ Telegram session still fails closed with the normal reopen-from-Telegram state;
 the cache never bypasses server authentication.
 
 The selected day's schedule can be rendered into a localized portrait PNG and
-sent to the platform share sheet without an API request. When file sharing is
-unavailable, the browser saves the PNG instead. No card contents leave the
-device through the bot backend.
+sent to the platform share sheet without an API request. Some Telegram Android
+WebViews ignore browser download links, so an unavailable or rejected file
+share falls back to an authenticated multipart upload. The webhook validates a
+PNG of the expected 1080×1350 dimensions and immediately sends it to the user's
+private bot chat. The bot does not retain the image.
 
 ## Prayer schedule display
 

--- a/global/docs/runtime-and-deployment.md
+++ b/global/docs/runtime-and-deployment.md
@@ -71,6 +71,12 @@ disable the named prepared-statement cache by selecting
 `SQLSTATE 42P05 prepared statement already exists` and
 `SQLSTATE 26000 prepared statement does not exist`.
 
+In this execution mode, JSONB parameters must be passed as JSON text rather than
+Go `[]byte`. pgx otherwise encodes the byte slice as PostgreSQL `bytea` before
+the target JSONB type is resolved, causing `SQLSTATE 22P02 invalid input syntax
+for type json`. All profile adjustments and outbox payloads use the shared
+JSON-text encoder in `internal/store`.
+
 ## Deployment workflow
 
 The **Deploy global prayer bot** workflow is manual and accepts `testing` or

--- a/global/internal/miniapp/handler.go
+++ b/global/internal/miniapp/handler.go
@@ -1,17 +1,22 @@
 package miniapp
 
 import (
+	"bytes"
 	"context"
 	"embed"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"image/png"
 	"io"
 	"io/fs"
 	"log/slog"
 	"math"
 	"net/http"
 	"time"
+
+	botapi "github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
 
 	"github.com/escalopa/prayer-bot/global/internal/domain"
 	"github.com/escalopa/prayer-bot/global/internal/hijri"
@@ -24,6 +29,7 @@ import (
 )
 
 const initDataMaxAge = 24 * time.Hour
+const maxPrayerCardBytes = 5 << 20
 
 //go:embed static/*
 var embeddedStatic embed.FS
@@ -50,24 +56,41 @@ type ReminderPlanner interface {
 	RebuildChat(context.Context, int64, time.Time) error
 }
 
-type Handler struct {
-	botToken   string
-	store      Storage
-	resolver   location.Resolver
-	calculator prayertime.Calculator
-	planner    ReminderPlanner
-	logger     *slog.Logger
-	now        func() time.Time
+type PhotoSender interface {
+	SendPhoto(context.Context, *botapi.SendPhotoParams) (*models.Message, error)
 }
 
-func NewHandler(botToken string, storage Storage, resolver location.Resolver, calculator prayertime.Calculator, planner ReminderPlanner, logger *slog.Logger) *Handler {
+type Handler struct {
+	botToken    string
+	store       Storage
+	resolver    location.Resolver
+	calculator  prayertime.Calculator
+	planner     ReminderPlanner
+	photoSender PhotoSender
+	logger      *slog.Logger
+	now         func() time.Time
+}
+
+func NewHandler(
+	botToken string,
+	storage Storage,
+	resolver location.Resolver,
+	calculator prayertime.Calculator,
+	planner ReminderPlanner,
+	logger *slog.Logger,
+	photoSenders ...PhotoSender,
+) *Handler {
 	if logger == nil {
 		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	}
-	return &Handler{
+	handler := &Handler{
 		botToken: botToken, store: storage, resolver: resolver,
 		calculator: calculator, planner: planner, logger: logger, now: time.Now,
 	}
+	if len(photoSenders) > 0 {
+		handler.photoSender = photoSenders[0]
+	}
+	return handler
 }
 
 func (h *Handler) Register(mux *http.ServeMux) {
@@ -85,6 +108,7 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("PUT /api/miniapp/preferences", h.api(h.updatePreferences))
 	mux.HandleFunc("PUT /api/miniapp/settings", h.api(h.updateSettings))
 	mux.HandleFunc("PUT /api/miniapp/reminders", h.api(h.updateReminders))
+	mux.HandleFunc("POST /api/miniapp/prayer-card", h.api(h.sendPrayerCard))
 	mux.HandleFunc("POST /api/miniapp/calendar-subscription", h.api(h.createCalendarSubscription))
 	mux.HandleFunc("DELETE /api/miniapp/calendar-subscription", h.api(h.disableCalendarSubscription))
 	mux.HandleFunc("GET /api/miniapp/calendar.ics", h.calendarDownload)
@@ -182,6 +206,39 @@ func (h *Handler) updateLocation(w http.ResponseWriter, r *http.Request, identit
 	}
 	data.LocationName = resolved.City
 	return writeJSON(w, data)
+}
+
+func (h *Handler) sendPrayerCard(w http.ResponseWriter, r *http.Request, identity Identity) error {
+	if h.photoSender == nil {
+		return fmt.Errorf("prayer card sender is unavailable")
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxPrayerCardBytes+(1<<20))
+	if err := r.ParseMultipartForm(maxPrayerCardBytes); err != nil {
+		return badRequest("invalid_prayer_card")
+	}
+	file, _, err := r.FormFile("card")
+	if err != nil {
+		return badRequest("invalid_prayer_card")
+	}
+	defer file.Close() //nolint:errcheck
+	content, err := io.ReadAll(io.LimitReader(file, maxPrayerCardBytes+1))
+	if err != nil || len(content) == 0 || len(content) > maxPrayerCardBytes {
+		return badRequest("invalid_prayer_card")
+	}
+	config, err := png.DecodeConfig(bytes.NewReader(content))
+	if err != nil || config.Width != 1080 || config.Height != 1350 {
+		return badRequest("invalid_prayer_card")
+	}
+	if _, err := h.photoSender.SendPhoto(r.Context(), &botapi.SendPhotoParams{
+		ChatID: identity.UserID,
+		Photo: &models.InputFileUpload{
+			Filename: "prayer-times.png",
+			Data:     bytes.NewReader(content),
+		},
+	}); err != nil {
+		return fmt.Errorf("send prayer card to Telegram chat: %w", err)
+	}
+	return writeJSON(w, map[string]string{"status": "sent"})
 }
 
 type settingsRequest struct {
@@ -775,7 +832,7 @@ func labels(locale i18n.Locale) map[string]string {
 		"home_add": copy.HomeAdd, "home_added": copy.HomeAdded,
 		"share_title": copy.ShareTitle, "share_help": copy.ShareHelp,
 		"share_action": copy.ShareAction, "share_preparing": copy.SharePreparing,
-		"share_downloaded": copy.ShareDownloaded, "share_failed": copy.ShareFailed,
+		"share_sent": copy.ShareSent, "share_failed": copy.ShareFailed,
 		"share_card_heading": copy.ShareCardHeading, "share_card_footer": copy.ShareCardFooter,
 		"share_message": copy.ShareMessage,
 	}
@@ -795,7 +852,7 @@ type miniAppCopy struct {
 	OfflineTitle, OfflineHelp                             string
 	HomeTitle, HomeHelp, HomeAdd, HomeAdded               string
 	ShareTitle, ShareHelp, ShareAction, SharePreparing    string
-	ShareDownloaded, ShareFailed                          string
+	ShareSent, ShareFailed                                string
 	ShareCardHeading, ShareCardFooter, ShareMessage       string
 }
 
@@ -821,7 +878,7 @@ var miniCopy = map[string]miniAppCopy{
 		HomeAdd: "Add to home screen", HomeAdded: "Added to home screen",
 		ShareTitle: "Share prayer card", ShareHelp: "Create a beautiful image with the selected day’s prayer times.",
 		ShareAction: "Create & share", SharePreparing: "Creating card…",
-		ShareDownloaded: "Card saved. Share it from your gallery.", ShareFailed: "The prayer card could not be created.",
+		ShareSent: "Card sent to this bot chat. Open the chat to save or forward it.", ShareFailed: "The prayer card could not be created.",
 		ShareCardHeading: "Daily prayer times", ShareCardFooter: "Global Prayer Times",
 		ShareMessage: "Prayer times",
 	},
@@ -846,7 +903,7 @@ var miniCopy = map[string]miniAppCopy{
 		HomeAdd: "إضافة إلى الشاشة الرئيسية", HomeAdded: "تمت الإضافة إلى الشاشة الرئيسية",
 		ShareTitle: "مشاركة بطاقة الصلاة", ShareHelp: "أنشئ صورة جميلة بمواقيت اليوم المحدد.",
 		ShareAction: "إنشاء ومشاركة", SharePreparing: "جارٍ إنشاء البطاقة…",
-		ShareDownloaded: "تم حفظ البطاقة. شاركها من معرض الصور.", ShareFailed: "تعذر إنشاء بطاقة الصلاة.",
+		ShareSent: "تم إرسال البطاقة إلى محادثة البوت. افتح المحادثة لحفظها أو إعادة توجيهها.", ShareFailed: "تعذر إنشاء بطاقة الصلاة.",
 		ShareCardHeading: "مواقيت الصلاة اليومية", ShareCardFooter: "مواقيت الصلاة العالمية",
 		ShareMessage: "مواقيت الصلاة",
 	},
@@ -871,7 +928,7 @@ var miniCopy = map[string]miniAppCopy{
 		HomeAdd: "Añadir a inicio", HomeAdded: "Añadido a inicio",
 		ShareTitle: "Compartir tarjeta", ShareHelp: "Crea una imagen con los horarios del día seleccionado.",
 		ShareAction: "Crear y compartir", SharePreparing: "Creando tarjeta…",
-		ShareDownloaded: "Tarjeta guardada. Compártela desde tu galería.", ShareFailed: "No se pudo crear la tarjeta.",
+		ShareSent: "La tarjeta se envió al chat del bot. Abre el chat para guardarla o reenviarla.", ShareFailed: "No se pudo crear la tarjeta.",
 		ShareCardHeading: "Horarios diarios de oración", ShareCardFooter: "Horarios de oración globales",
 		ShareMessage: "Horarios de oración",
 	},
@@ -896,7 +953,7 @@ var miniCopy = map[string]miniAppCopy{
 		HomeAdd: "Ajouter à l’accueil", HomeAdded: "Ajouté à l’accueil",
 		ShareTitle: "Partager une carte", ShareHelp: "Créez une image avec les horaires du jour sélectionné.",
 		ShareAction: "Créer et partager", SharePreparing: "Création de la carte…",
-		ShareDownloaded: "Carte enregistrée. Partagez-la depuis votre galerie.", ShareFailed: "Impossible de créer la carte.",
+		ShareSent: "La carte a été envoyée dans le chat du bot. Ouvrez le chat pour l’enregistrer ou la transférer.", ShareFailed: "Impossible de créer la carte.",
 		ShareCardHeading: "Horaires de prière du jour", ShareCardFooter: "Horaires de prière mondiaux",
 		ShareMessage: "Horaires de prière",
 	},
@@ -921,7 +978,7 @@ var miniCopy = map[string]miniAppCopy{
 		HomeAdd: "Добавить на главный экран", HomeAdded: "Добавлено на главный экран",
 		ShareTitle: "Поделиться карточкой", ShareHelp: "Создайте красивую карточку с расписанием выбранного дня.",
 		ShareAction: "Создать и поделиться", SharePreparing: "Создаём карточку…",
-		ShareDownloaded: "Карточка сохранена. Поделитесь ею из галереи.", ShareFailed: "Не удалось создать карточку.",
+		ShareSent: "Карточка отправлена в чат с ботом. Откройте чат, чтобы сохранить или переслать её.", ShareFailed: "Не удалось создать карточку.",
 		ShareCardHeading: "Время намаза на день", ShareCardFooter: "Global Prayer Times",
 		ShareMessage: "Время намаза",
 	},
@@ -946,7 +1003,7 @@ var miniCopy = map[string]miniAppCopy{
 		HomeAdd: "Ana ekrana ekle", HomeAdded: "Ana ekrana eklendi",
 		ShareTitle: "Namaz kartını paylaş", ShareHelp: "Seçilen günün vakitleriyle güzel bir görsel oluşturun.",
 		ShareAction: "Oluştur ve paylaş", SharePreparing: "Kart oluşturuluyor…",
-		ShareDownloaded: "Kart kaydedildi. Galerinizden paylaşın.", ShareFailed: "Namaz kartı oluşturulamadı.",
+		ShareSent: "Kart bot sohbetine gönderildi. Kaydetmek veya iletmek için sohbeti açın.", ShareFailed: "Namaz kartı oluşturulamadı.",
 		ShareCardHeading: "Günlük namaz vakitleri", ShareCardFooter: "Global Namaz Vakitleri",
 		ShareMessage: "Namaz vakitleri",
 	},
@@ -971,7 +1028,7 @@ var miniCopy = map[string]miniAppCopy{
 		HomeAdd: "Bosh ekranga qo‘shish", HomeAdded: "Bosh ekranga qo‘shildi",
 		ShareTitle: "Namoz kartasini ulashish", ShareHelp: "Tanlangan kun vaqtlari bilan chiroyli rasm yarating.",
 		ShareAction: "Yaratish va ulashish", SharePreparing: "Karta yaratilmoqda…",
-		ShareDownloaded: "Karta saqlandi. Uni galereyadan ulashing.", ShareFailed: "Namoz kartasini yaratib bo‘lmadi.",
+		ShareSent: "Karta bot chatiga yuborildi. Saqlash yoki ulashish uchun chatni oching.", ShareFailed: "Namoz kartasini yaratib bo‘lmadi.",
 		ShareCardHeading: "Kunlik namoz vaqtlari", ShareCardFooter: "Global Namoz Vaqtlari",
 		ShareMessage: "Namoz vaqtlari",
 	},
@@ -996,7 +1053,7 @@ var miniCopy = map[string]miniAppCopy{
 		HomeAdd: "Төп экранга өстәү", HomeAdded: "Төп экранга өстәлде",
 		ShareTitle: "Намаз карточкасын бүлешү", ShareHelp: "Сайланган көн вакытлары белән матур рәсем ясагыз.",
 		ShareAction: "Ясау һәм бүлешү", SharePreparing: "Карточка ясала…",
-		ShareDownloaded: "Карточка сакланды. Галереядән бүлешегез.", ShareFailed: "Намаз карточкасын ясап булмады.",
+		ShareSent: "Карточка бот чатына җибәрелде. Саклау яки җибәрү өчен чатны ачыгыз.", ShareFailed: "Намаз карточкасын ясап булмады.",
 		ShareCardHeading: "Көнлек намаз вакытлары", ShareCardFooter: "Глобаль намаз вакытлары",
 		ShareMessage: "Намаз вакытлары",
 	},

--- a/global/internal/miniapp/handler_test.go
+++ b/global/internal/miniapp/handler_test.go
@@ -1,8 +1,14 @@
 package miniapp
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"image"
+	"image/png"
+	"io"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -14,6 +20,8 @@ import (
 	"github.com/escalopa/prayer-bot/global/internal/location"
 	"github.com/escalopa/prayer-bot/global/internal/occasions"
 	"github.com/escalopa/prayer-bot/global/internal/prayertime"
+	botapi "github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
 	"github.com/jackc/pgx/v5"
 )
 
@@ -52,8 +60,13 @@ func TestStaticMiniAppIsEmbeddedWithSecurityHeaders(t *testing.T) {
 		!strings.Contains(string(script), "DeviceStorage") ||
 		!strings.Contains(string(script), "addToHomeScreen") ||
 		!strings.Contains(string(script), "navigator.share") ||
-		!strings.Contains(string(script), "canvas.toDataURL") {
+		!strings.Contains(string(script), "canvas.toDataURL") ||
+		!strings.Contains(string(script), "/api/miniapp/prayer-card") ||
+		!strings.Contains(string(script), "new FormData()") {
 		t.Fatal("Mini App is missing offline, home-screen, or prayer-card sharing support")
+	}
+	if strings.Contains(string(script), "link.download") {
+		t.Fatal("Mini App still claims an unreliable WebView anchor download saved the prayer card")
 	}
 	if !strings.Contains(html, "occasion-list") ||
 		!strings.Contains(html, "occasion-observed-reminders") ||
@@ -79,7 +92,7 @@ func TestOfflineAndSharingLabelsExistForEveryLocale(t *testing.T) {
 		"offline_updating", "offline_updating_help", "offline_title", "offline_help",
 		"home_title", "home_help", "home_add", "home_added",
 		"share_title", "share_help", "share_action", "share_preparing",
-		"share_downloaded", "share_failed", "share_card_heading",
+		"share_sent", "share_failed", "share_card_heading",
 		"share_card_footer", "share_message",
 	}
 	for _, locale := range i18n.Supported() {
@@ -104,6 +117,77 @@ func TestMiniAppAPIRejectsUnsignedRequests(t *testing.T) {
 	if response.Code != http.StatusUnauthorized || !strings.Contains(response.Body.String(), "unauthorized") {
 		t.Fatalf("unexpected response: %d %s", response.Code, response.Body.String())
 	}
+}
+
+func TestPrayerCardFallbackSendsValidatedPNGToTelegramChat(t *testing.T) {
+	now := time.Date(2026, time.July, 19, 12, 0, 0, 0, time.UTC)
+	sender := &fakePhotoSender{}
+	handler := NewHandler("test-token", nil, nil, nil, nil, nil, sender)
+	handler.now = func() time.Time { return now }
+	mux := http.NewServeMux()
+	handler.Register(mux)
+
+	body, contentType := prayerCardUpload(t, 1080, 1350)
+	request := httptest.NewRequest(http.MethodPost, "/api/miniapp/prayer-card", body)
+	request.Header.Set("Content-Type", contentType)
+	request.Header.Set("X-Telegram-Init-Data", signedInitData(
+		t, "test-token", now, initDataUser{ID: 42, FirstName: "Amina", LanguageCode: "en"},
+	))
+	response := httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	if sender.chatID != 42 || sender.filename != "prayer-times.png" || len(sender.content) == 0 {
+		t.Fatalf("unexpected Telegram photo upload: %+v", sender)
+	}
+	if !strings.Contains(response.Body.String(), `"status":"sent"`) {
+		t.Fatalf("unexpected response: %s", response.Body.String())
+	}
+}
+
+func TestPrayerCardFallbackRejectsUnexpectedImageDimensions(t *testing.T) {
+	now := time.Date(2026, time.July, 19, 12, 0, 0, 0, time.UTC)
+	sender := &fakePhotoSender{}
+	handler := NewHandler("test-token", nil, nil, nil, nil, nil, sender)
+	handler.now = func() time.Time { return now }
+	mux := http.NewServeMux()
+	handler.Register(mux)
+
+	body, contentType := prayerCardUpload(t, 1, 1)
+	request := httptest.NewRequest(http.MethodPost, "/api/miniapp/prayer-card", body)
+	request.Header.Set("Content-Type", contentType)
+	request.Header.Set("X-Telegram-Init-Data", signedInitData(
+		t, "test-token", now, initDataUser{ID: 42, FirstName: "Amina", LanguageCode: "en"},
+	))
+	response := httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+
+	if response.Code != http.StatusBadRequest || len(sender.content) != 0 {
+		t.Fatalf("unexpected invalid-card result: status=%d sender=%+v", response.Code, sender)
+	}
+}
+
+func prayerCardUpload(t *testing.T, width, height int) (*bytes.Buffer, string) {
+	t.Helper()
+	var card bytes.Buffer
+	if err := png.Encode(&card, image.NewRGBA(image.Rect(0, 0, width, height))); err != nil {
+		t.Fatal(err)
+	}
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("card", "card.png")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := part.Write(card.Bytes()); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return &body, writer.FormDataContentType()
 }
 
 func TestFormatScheduleIncludesLocalizedGregorianAndHijriDates(t *testing.T) {
@@ -463,6 +547,31 @@ type fakeStorage struct {
 	profiles      map[int64]domain.PrayerProfile
 	rules         map[int64][]domain.ReminderRule
 	subscriptions map[int64]domain.CalendarSubscription
+}
+
+type fakePhotoSender struct {
+	chatID   int64
+	filename string
+	content  []byte
+}
+
+func (s *fakePhotoSender) SendPhoto(_ context.Context, params *botapi.SendPhotoParams) (*models.Message, error) {
+	chatID, ok := params.ChatID.(int64)
+	if !ok {
+		return nil, fmt.Errorf("unexpected chat ID type %T", params.ChatID)
+	}
+	upload, ok := params.Photo.(*models.InputFileUpload)
+	if !ok {
+		return nil, fmt.Errorf("unexpected photo type %T", params.Photo)
+	}
+	content, err := io.ReadAll(upload.Data)
+	if err != nil {
+		return nil, err
+	}
+	s.chatID = chatID
+	s.filename = upload.Filename
+	s.content = content
+	return &models.Message{}, nil
 }
 
 func newFakeStorage() *fakeStorage {

--- a/global/internal/miniapp/static/app.js
+++ b/global/internal/miniapp/static/app.js
@@ -11,7 +11,7 @@
   let calendarFeedURL = "";
   let offlineMode = false;
   let homeScreenStatus = "unknown";
-  const offlineCacheVersion = 1;
+  const offlineCacheVersion = 2;
   const offlineCacheMaxAge = 48 * 60 * 60 * 1000;
 
   const launchCopy = {
@@ -857,15 +857,22 @@
     return new Blob([bytes], { type: mediaType });
   }
 
-  function downloadPrayerCard(blob, filename) {
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = filename;
-    document.body.append(link);
-    link.click();
-    link.remove();
-    window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+  async function sendPrayerCardToChat(blob, filename) {
+    const body = new FormData();
+    body.append("card", blob, filename);
+    const response = await fetch("/api/miniapp/prayer-card", {
+      method: "POST",
+      headers: { "X-Telegram-Init-Data": currentInitData() },
+      body,
+      credentials: "same-origin",
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const error = new Error(data.error || "temporary_failure");
+      error.code = data.error;
+      error.status = response.status;
+      throw error;
+    }
   }
 
   async function sharePrayerCard() {
@@ -878,16 +885,26 @@
       const blob = canvasBlob(prayerCardCanvas());
       const filename = `prayer-times-${activeDay}.png`;
       const file = typeof File === "function" ? new File([blob], filename, { type: "image/png" }) : null;
-      if (file && navigator.share && navigator.canShare && navigator.canShare({ files: [file] })) {
-        await navigator.share({
-          title: state.labels.share_card_heading,
-          text: `${state.labels.share_message}\n${state[activeDay].gregorian}`,
-          files: [file],
-        });
-      } else {
-        downloadPrayerCard(blob, filename);
-        showToast(state.labels.share_downloaded);
+      if (file && typeof navigator.share === "function") {
+        try {
+          // Some Telegram WebViews implement file sharing without exposing a
+          // reliable navigator.canShare result, so attempt the native sheet.
+          await navigator.share({
+            title: state.labels.share_card_heading,
+            text: `${state.labels.share_message}\n${state[activeDay].gregorian}`,
+            files: [file],
+          });
+          return;
+        } catch (error) {
+          if (error && error.name === "AbortError") return;
+          // Fall through to a Telegram chat upload when the WebView rejects
+          // file sharing. An <a download> click is silently ignored on many
+          // Android Telegram clients.
+        }
       }
+      await sendPrayerCardToChat(blob, filename);
+      showToast(state.labels.share_sent);
+      if (telegram && telegram.HapticFeedback) telegram.HapticFeedback.notificationOccurred("success");
     } catch (error) {
       if (!error || error.name !== "AbortError") showToast(state.labels.share_failed, true);
     } finally {

--- a/global/internal/miniapp/static/sw.js
+++ b/global/internal/miniapp/static/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const cacheName = "global-prayer-miniapp-shell-v2";
+const cacheName = "global-prayer-miniapp-shell-v3";
 const shellAssets = [
   "./",
   "./app.css",

--- a/global/internal/store/postgres.go
+++ b/global/internal/store/postgres.go
@@ -104,6 +104,17 @@ func qualifySQL(query, schema string) string {
 	return strings.ReplaceAll(query, "global_bot.", qualifiedSchema+".")
 }
 
+// marshalJSONText deliberately returns string rather than []byte. In pgx
+// QueryExecModeExec, []byte is encoded as bytea before PostgreSQL resolves the
+// target JSONB column, producing SQLSTATE 22P02 through transaction poolers.
+func marshalJSONText(value any) (string, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
+}
+
 func (s *Store) Close() { s.pool.Close() }
 
 func (s *Store) AcquireUpdate(ctx context.Context, updateID int64) (bool, error) {
@@ -335,7 +346,7 @@ func (s *Store) UpsertProfile(ctx context.Context, profile domain.PrayerProfile)
 	if err := profile.Validate(); err != nil {
 		return domain.PrayerProfile{}, err
 	}
-	adjustments, err := json.Marshal(profile.Adjustments)
+	adjustments, err := marshalJSONText(profile.Adjustments)
 	if err != nil {
 		return domain.PrayerProfile{}, err
 	}
@@ -578,7 +589,7 @@ func (s *Store) ClaimDue(ctx context.Context, now time.Time, limit int) (int, er
 
 	for _, schedule := range schedules {
 		deliveryKey := fmt.Sprintf("schedule:%d:%d:v%d", schedule.ID, schedule.NextRunAt.Unix(), schedule.ProfileVersion)
-		payload, err := json.Marshal(domain.DeliveryTask{
+		payload, err := marshalJSONText(domain.DeliveryTask{
 			DeliveryKey: deliveryKey, ScheduleID: schedule.ID, RuleID: schedule.RuleID,
 			ChatID: schedule.ChatID, ProfileVersion: schedule.ProfileVersion, ScheduledFor: schedule.NextRunAt,
 		})
@@ -720,7 +731,7 @@ func enqueueMessageDeletion(
 	reason string,
 ) error {
 	key := fmt.Sprintf("delete:%d:%d:%s", chatID, messageID, reason)
-	payload, err := json.Marshal(domain.MessageDeletionTask{
+	payload, err := marshalJSONText(domain.MessageDeletionTask{
 		DeletionKey: key,
 		ChatID:      chatID,
 		MessageID:   messageID,

--- a/global/internal/store/postgres_test.go
+++ b/global/internal/store/postgres_test.go
@@ -1,11 +1,13 @@
 package store
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
 
 	"github.com/escalopa/prayer-bot/global/internal/database"
+	"github.com/escalopa/prayer-bot/global/internal/domain"
 )
 
 func TestRuntimePoolConfigDisablesNamedPreparedStatements(t *testing.T) {
@@ -35,5 +37,22 @@ func TestQualifySQLDoesNotChangeUnrelatedNames(t *testing.T) {
 	query := qualifySQL("SELECT * FROM public.chats", database.ProductionSchema)
 	if query != "SELECT * FROM public.chats" {
 		t.Fatalf("unexpected query rewrite: %s", query)
+	}
+}
+
+func TestMarshalJSONTextProducesJSONBCompatibleTextParameter(t *testing.T) {
+	encoded, err := marshalJSONText(domain.Adjustments{Fajr: 2, Isha: -1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if encoded == "" || encoded[0] != '{' {
+		t.Fatalf("unexpected JSON text: %q", encoded)
+	}
+	var decoded domain.Adjustments
+	if err := json.Unmarshal([]byte(encoded), &decoded); err != nil {
+		t.Fatalf("JSON text cannot be decoded: %v", err)
+	}
+	if decoded.Fajr != 2 || decoded.Isha != -1 {
+		t.Fatalf("unexpected decoded adjustments: %+v", decoded)
 	}
 }


### PR DESCRIPTION
## Summary

- encode every PostgreSQL JSONB parameter as JSON text when using pgx `QueryExecModeExec`
- restore Mini App and conversational location updates, unified settings saves, and reminder outbox dispatch
- try the native mobile file share sheet without requiring an unreliable `navigator.canShare` result
- replace the ignored Android WebView download fallback with an authenticated, validated PNG upload that sends the card to the user's private bot chat
- bump the Mini App shell and offline-state cache versions so deployed clients receive the corrected behavior
- document the pooler/JSONB boundary and the prayer-card fallback

## Root cause

The earlier Supabase transaction-pooler repair correctly disabled named prepared statements by selecting pgx `QueryExecModeExec`, but JSON values were still passed as Go `[]byte`. In that mode pgx encoded them as PostgreSQL `bytea`; JSONB profile and outbox columns then rejected them with `SQLSTATE 22P02`.

Cloud Run logs showed:

- `PUT /api/miniapp/location` returned 500 at `save profile`
- `PUT /api/miniapp/preferences` returned 500 at the same profile write
- the Telegram location update was repeatedly retried after `save prayer profile` failed
- the dispatcher repeatedly failed at `claim due reminders` while inserting its JSON outbox payload

The prayer-card fallback used an `<a download>` click. Telegram Android WebViews can ignore that click while JavaScript still displays the success toast, so the UI claimed a gallery save that never happened.

## User impact

- location updates can persist again
- Islamic occasion reminder toggles and other preferences can save again
- reminder jobs can create their outbox tasks again
- supported clients open the native share sheet; unsupported clients receive the generated card as a Telegram photo in their bot chat, where it can be saved or forwarded
- prayer-card uploads are signed with Telegram init data, limited to 5 MiB, decoded as PNG, and required to be exactly 1080×1350; the service does not retain them

## Validation

- `node --check global/internal/miniapp/static/app.js`
- `gofmt -d global/cmd global/internal`
- `go vet ./...`
- `go test -race ./...`
- targeted storage and Mini App tests
- final production container build
- `git diff --check`
