### PR TITLE
README: lead with the global worldwide bot as the flagship

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,9 @@
 
 A serverless Telegram bot that provides Muslim prayer times and sends notifications when prayers are approaching.
 
-The global bot's prayer calculations, high-latitude rules, Qibla bearing, Gregorian--Hijri conversion, Islamic occasions, and rolling calendar are documented on the public [calculation methodology site](https://escalopa.github.io/prayer-bot/). The versioned [LaTeX source](docs/calculation-methods.tex) is maintained in this repository.
+The **worldwide [global bot](global/) is the flagship, actively developed version** and the focus of future work. It serves prayer times anywhere from a shared location and adds a Telegram Mini App, Qibla direction, Gregorian--Hijri calendar, Islamic occasions, a rolling calendar feed, and configurable reminders. It has its own [engineering and architecture guide](global/docs/README.md) covering the runtime, Mini App, reminder pipeline, database schemas, and GCP deployment. Its prayer calculations, high-latitude rules, Qibla bearing, Gregorian--Hijri conversion, Islamic occasions, and rolling calendar are documented on the public [calculation methodology site](https://escalopa.github.io/prayer-bot/), with versioned [LaTeX source](docs/calculation-methods.tex) maintained in this repository.
 
-The separate worldwide bot under [`global/`](global/) has its own
-[engineering and architecture guide](global/docs/README.md). Use that guide for
-the global runtime, Mini App, reminder pipeline, database schemas, and GCP
-deployment; the architecture below describes only the legacy city bots.
+The original **per-city bots** documented in the architecture below predate the global bot and remain available in maintenance mode.
 
 [![wakatime](https://wakatime.com/badge/user/965e81db-2a88-4564-b236-537c4a901130/project/635dffc4-6a06-4e43-9a87-5bb977437cdb.svg)](https://wakatime.com/badge/user/965e81db-2a88-4564-b236-537c4a901130/project/635dffc4-6a06-4e43-9a87-5bb977437cdb)
 [![Report card](https://goreportcard.com/badge/github.com/escalopa/gopray)](https://goreportcard.com/report/github.com/escalopa/gopray)


### PR DESCRIPTION
## What

Reframes the top of `README.md` so the **worldwide global bot** (`global/`) is presented as the flagship, actively developed version and the focus of future work. The original per-city bots are described as maintenance-mode predecessors.

## Why

The intro previously opened as a generic per-city prayer bot and mentioned the global bot only as "the separate worldwide bot," with the architecture section framed around the legacy city bots. The global bot is now the main direction, so the README should lead with it.

## Notes for reviewer

- **Docs-only**, no code touched. The legacy architecture section further down is unchanged.
- No factual claims changed: the [calculation methodology site](https://escalopa.github.io/prayer-bot/) still documents the global bot's calculations; the LaTeX source reference is preserved.
- **Not included here (needs your input):** the GitHub repo *About* description and homepage link still point at the legacy setup (`https://t.me/kazan_prayer_bot`). Updating those is a repo-metadata change (`gh repo edit`), not a PR, and the homepage swap needs the global bot's public Telegram handle, which isn't referenced anywhere in the repo yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)