### PR TITLE
Test global delivery path, fix at-least-once compensation, add testing foundation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ Two independent prayer-time Telegram bots share one Git repository but **not** o
 | [`global/docs/reminder-delivery.md`](global/docs/reminder-delivery.md) | **Source of truth** for planning, dispatch, retries, idempotency, cleanup categories |
 | [`global/docs/runtime-and-deployment.md`](global/docs/runtime-and-deployment.md) | Env isolation, runtime topology, secrets, **DB connection rules**, deploy workflow |
 | [`global/docs/operations.md`](global/docs/operations.md) | Health/logs, incident triage table, secret rotation, profile sync, recovery |
+| [`global/docs/testing.md`](global/docs/testing.md) | Test strategy: time injection, unit vs. integration, running `TEST_DATABASE_URL` integration tests |
 
 ## Global bot layout
 

--- a/global/docs/README.md
+++ b/global/docs/README.md
@@ -19,6 +19,7 @@ guide belong to `global/` and the `global_bot_testing` or
 | Change reminders, retries, idempotency, or message deletion | [Reminder delivery](reminder-delivery.md) |
 | Change Cloud Run, Cloud Tasks, Scheduler, secrets, or environments | [Runtime and deployment](runtime-and-deployment.md) |
 | Diagnose an incident or perform an operational action | [Operations](operations.md) |
+| Write tests, simulate time, or run integration tests | [Testing](testing.md) |
 
 ## Five-minute mental model
 

--- a/global/docs/code-map.md
+++ b/global/docs/code-map.md
@@ -44,6 +44,7 @@ with the container command, so the three Cloud Run services use the same build.
 | --- | --- |
 | `migrations/` | Versioned schema changes for both global environments |
 | `infra/gcp/` | Cloud Run, Cloud Tasks, Scheduler, service accounts, IAM, Secret Manager, Artifact Registry, and Maps key |
+| `internal/store/integration_test.go` | Env-gated (`TEST_DATABASE_URL`) real-SQL tests; see [Testing](testing.md) |
 | `.github/workflows/global-ci.yaml` | Global Go tests, image build, and Terraform validation |
 | `.github/workflows/global-deploy.yaml` | Manual testing/production build, migration, Terraform apply, and Telegram profile synchronization |
 

--- a/global/docs/testing.md
+++ b/global/docs/testing.md
@@ -1,0 +1,78 @@
+# Testing
+
+This document defines how the global bot is tested and how to add tests for new
+work. It is the owning document for test strategy; update it in the same pull
+request when the strategy changes.
+
+## Principles
+
+- **Never read the wall clock in business logic.** Time is a dependency. Planning,
+  dispatch, and store queries already take an explicit `now`/`after time.Time`
+  parameter, and the sender takes an injectable `now func() time.Time` (default
+  `time.Now`). This is how "real-time execution" is simulated: a test passes the
+  instant it wants instead of sleeping. Do not introduce a bare `time.Now()` in
+  `internal/*` business logic — thread the instant through, or inject a clock.
+- **Isolate collaborators behind interfaces.** Each orchestrator declares the
+  narrow store/bot/enqueuer interface it needs (`DispatchStore`, `PlanningStore`,
+  `SenderStore`, `MessageSender`, `TaskEnqueuer`, `nextPlanner`). The concrete
+  `*store.Store`, `*Planner`, and Telegram client satisfy them in production;
+  hand-written fakes satisfy them in tests. No mocking framework is used.
+- **Standard library only.** Tests use `testing` and table-driven subtests. Keep
+  fakes small, local to the package, and named `fake*`.
+- **Deterministic.** No sleeps, no network, no randomness in unit tests. Fixed
+  timezones and dates make prayer/reminder assertions reproducible.
+
+## Test layers
+
+| Layer | Scope | Depends on | Runs in `make test` |
+| --- | --- | --- | --- |
+| Unit | One package, pure logic and orchestration over fakes | Nothing external | Always |
+| Integration | Real SQL through `internal/store` against PostgreSQL | `TEST_DATABASE_URL` | Only when the variable is set |
+
+### Unit tests
+
+Most coverage is unit level. Examples worth copying:
+
+- `internal/reminders/planner_test.go` — a `fixedCalculator` fake and explicit
+  `after` instants assert next-occurrence timing across weekly, occasion, and
+  before-prayer rules.
+- `internal/reminders/sender_process_test.go` — fakes for `SenderStore`,
+  `nextPlanner`, and `MessageSender`, plus an injected clock, cover the full
+  delivery state machine: send, complete, staleness, lease contention, and the
+  post-send compensation described in [Reminder delivery](reminder-delivery.md).
+- `internal/domain/domain_test.go` — pure validation and value-type behavior.
+
+### Integration tests
+
+`internal/store/integration_test.go` exercises real SQL because the parts that
+break under the Supabase transaction pooler — `pgx.QueryExecModeExec`, JSONB
+passed as text, and the transactional outbox — are invisible to fakes. A missing
+integration test is exactly why the JSONB-as-`[]byte` profile-save bug reached
+production; `TestIntegrationProfileRoundTripPreservesJSONBAdjustments` now guards
+that incident.
+
+The harness reads every goose `Up` section from `migrations/`, substitutes
+`${GLOBAL_DB_SCHEMA}`, and applies it to a freshly recreated
+`global_bot_testing` schema. It skips automatically when `TEST_DATABASE_URL` is
+unset, so `make test` stays fast and dependency-free.
+
+Run against a disposable database:
+
+```sh
+docker run -d --name pb-pg-test -e POSTGRES_PASSWORD=postgres -p 55432:5432 postgres:16-alpine
+export TEST_DATABASE_URL='postgres://postgres:postgres@localhost:55432/postgres?sslmode=disable'
+go test ./internal/store/
+docker rm -f pb-pg-test
+```
+
+> The harness drops and recreates the `global_bot_testing` schema. Never point
+> `TEST_DATABASE_URL` at a database that holds real data.
+
+## Adding tests for new work
+
+1. If the change adds business logic, keep time and I/O injectable and cover the
+   logic with unit tests over fakes.
+2. If the change adds or alters SQL, add a store integration test that round-trips
+   the data, especially any JSONB column or transactional flow.
+3. If the change alters delivery, planning, or cleanup semantics, update the
+   assertions here and in [Reminder delivery](reminder-delivery.md) together.

--- a/global/internal/domain/domain_test.go
+++ b/global/internal/domain/domain_test.go
@@ -1,0 +1,174 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+func validProfile() PrayerProfile {
+	return PrayerProfile{
+		Latitude:         30.0,
+		Longitude:        31.0,
+		Timezone:         "Africa/Cairo",
+		Method:           MethodEgyptian,
+		Madhab:           MadhabShafii,
+		HighLatitudeRule: HighLatitudeAngleBased,
+		HijriAdjustment:  0,
+	}
+}
+
+func TestPrayerProfileValidateAcceptsAWellFormedProfile(t *testing.T) {
+	if err := validProfile().Validate(); err != nil {
+		t.Fatalf("expected a valid profile, got %v", err)
+	}
+}
+
+func TestPrayerProfileValidateRejectsEachInvalidField(t *testing.T) {
+	tests := map[string]func(*PrayerProfile){
+		"latitude below range":  func(p *PrayerProfile) { p.Latitude = -91 },
+		"latitude above range":  func(p *PrayerProfile) { p.Latitude = 91 },
+		"longitude below range": func(p *PrayerProfile) { p.Longitude = -181 },
+		"longitude above range": func(p *PrayerProfile) { p.Longitude = 181 },
+		"blank timezone":        func(p *PrayerProfile) { p.Timezone = "   " },
+		"unknown timezone":      func(p *PrayerProfile) { p.Timezone = "Mars/Olympus" },
+		"unsupported method":    func(p *PrayerProfile) { p.Method = "made_up" },
+		"unsupported madhab":    func(p *PrayerProfile) { p.Madhab = "made_up" },
+		"unsupported highlat":   func(p *PrayerProfile) { p.HighLatitudeRule = "made_up" },
+		"hijri below range":     func(p *PrayerProfile) { p.HijriAdjustment = -3 },
+		"hijri above range":     func(p *PrayerProfile) { p.HijriAdjustment = 3 },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			profile := validProfile()
+			mutate(&profile)
+			if err := profile.Validate(); err == nil {
+				t.Fatalf("expected %s to be rejected", name)
+			}
+		})
+	}
+}
+
+func TestPrayerProfileValidateAcceptsHijriBoundaries(t *testing.T) {
+	for _, adjustment := range []int{-2, -1, 0, 1, 2} {
+		profile := validProfile()
+		profile.HijriAdjustment = adjustment
+		if err := profile.Validate(); err != nil {
+			t.Fatalf("hijri adjustment %d should be valid: %v", adjustment, err)
+		}
+	}
+}
+
+func TestRoundedCoordinatesLimitsToThreeDecimals(t *testing.T) {
+	tests := []struct {
+		lat, lon         float64
+		wantLat, wantLon float64
+	}{
+		{55.1234567, 49.9876543, 55.123, 49.988},
+		{-33.86785, 151.20732, -33.868, 151.207},
+		{0, 0, 0, 0},
+	}
+	for _, tc := range tests {
+		gotLat, gotLon := RoundedCoordinates(tc.lat, tc.lon)
+		if gotLat != tc.wantLat || gotLon != tc.wantLon {
+			t.Fatalf("RoundedCoordinates(%v, %v) = (%v, %v), want (%v, %v)",
+				tc.lat, tc.lon, gotLat, gotLon, tc.wantLat, tc.wantLon)
+		}
+	}
+}
+
+func TestMethodValidCoversEverySupportedMethod(t *testing.T) {
+	for _, method := range SupportedMethods() {
+		if !method.Valid() {
+			t.Fatalf("supported method %q reported invalid", method)
+		}
+	}
+	if Method("nonsense").Valid() {
+		t.Fatal("unknown method reported valid")
+	}
+	if len(SupportedMethods()) != 9 {
+		t.Fatalf("expected 9 supported methods, got %d", len(SupportedMethods()))
+	}
+}
+
+func TestMadhabAndHighLatitudeRuleValidation(t *testing.T) {
+	for _, madhab := range []Madhab{MadhabShafii, MadhabHanafi} {
+		if !madhab.Valid() {
+			t.Fatalf("madhab %q should be valid", madhab)
+		}
+	}
+	if Madhab("maliki").Valid() {
+		t.Fatal("unsupported madhab reported valid")
+	}
+	for _, rule := range []HighLatitudeRule{HighLatitudeAngleBased, HighLatitudeMiddleNight, HighLatitudeSeventhNight} {
+		if !rule.Valid() {
+			t.Fatalf("high-latitude rule %q should be valid", rule)
+		}
+	}
+	if HighLatitudeRule("none").Valid() {
+		t.Fatal("unsupported high-latitude rule reported valid")
+	}
+}
+
+func TestPrayerValid(t *testing.T) {
+	for _, prayer := range []Prayer{PrayerFajr, PrayerSunrise, PrayerDhuhr, PrayerAsr, PrayerMaghrib, PrayerIsha} {
+		if !prayer.Valid() {
+			t.Fatalf("prayer %q should be valid", prayer)
+		}
+	}
+	if Prayer("tahajjud").Valid() {
+		t.Fatal("unknown prayer reported valid")
+	}
+}
+
+func TestReminderKindClassifiers(t *testing.T) {
+	weekly := []ReminderKind{ReminderWeeklyFasting, ReminderWeeklyKahf}
+	occasion := []ReminderKind{ReminderOccasionMajor, ReminderOccasionFasting, ReminderOccasionObserved}
+	neither := []ReminderKind{ReminderBefore, ReminderAt, ReminderTomorrow}
+
+	for _, kind := range weekly {
+		if !kind.Weekly() || kind.Occasion() {
+			t.Fatalf("%q must classify as weekly only", kind)
+		}
+	}
+	for _, kind := range occasion {
+		if !kind.Occasion() || kind.Weekly() {
+			t.Fatalf("%q must classify as occasion only", kind)
+		}
+	}
+	for _, kind := range neither {
+		if kind.Weekly() || kind.Occasion() {
+			t.Fatalf("%q must be neither weekly nor occasion", kind)
+		}
+	}
+}
+
+func TestValidPreReminderMinutes(t *testing.T) {
+	for _, minutes := range SupportedPreReminderMinutes() {
+		if !ValidPreReminderMinutes(minutes) {
+			t.Fatalf("supported pre-reminder %d reported invalid", minutes)
+		}
+	}
+	for _, minutes := range []int{-5, 1, 7, 25, 90} {
+		if ValidPreReminderMinutes(minutes) {
+			t.Fatalf("unsupported pre-reminder %d reported valid", minutes)
+		}
+	}
+}
+
+func TestDayScheduleAt(t *testing.T) {
+	at := time.Date(2026, time.July, 20, 5, 12, 0, 0, time.UTC)
+	schedule := DaySchedule{Times: map[Prayer]time.Time{
+		PrayerFajr: at,
+		PrayerAsr:  {}, // present but zero: treated as absent
+	}}
+
+	if got, ok := schedule.At(PrayerFajr); !ok || !got.Equal(at) {
+		t.Fatalf("At(fajr) = (%s, %v), want (%s, true)", got, ok, at)
+	}
+	if _, ok := schedule.At(PrayerAsr); ok {
+		t.Fatal("a zero prayer time must be reported as absent")
+	}
+	if _, ok := schedule.At(PrayerIsha); ok {
+		t.Fatal("a missing prayer must be reported as absent")
+	}
+}

--- a/global/internal/reminders/sender.go
+++ b/global/internal/reminders/sender.go
@@ -21,16 +21,40 @@ type MessageSender interface {
 	DeleteMessages(context.Context, *botapi.DeleteMessagesParams) (bool, error)
 }
 
+// SenderStore is the subset of *store.Store the Sender depends on. Declaring it
+// as an interface keeps the delivery orchestration unit-testable with fakes,
+// the same way DispatchStore and PlanningStore already isolate their stores.
+type SenderStore interface {
+	Schedule(context.Context, int64) (domain.ReminderSchedule, error)
+	AcquireDelivery(context.Context, domain.DeliveryTask) (bool, error)
+	FailDelivery(context.Context, string, error) error
+	MarkDeliveryStale(context.Context, string) error
+	Profile(context.Context, int64) (domain.PrayerProfile, error)
+	Rule(context.Context, int64) (domain.ReminderRule, error)
+	Chat(context.Context, int64) (domain.Chat, error)
+	CompleteDelivery(context.Context, domain.DeliveryTask, int64, domain.ReminderSchedule, string, time.Time) (int64, error)
+	ClearNotificationMessage(context.Context, int64, int64) error
+}
+
+// nextPlanner is satisfied by *Planner. It lets the Sender be tested without a
+// real prayer calculator or planning store.
+type nextPlanner interface {
+	Next(context.Context, domain.PrayerProfile, domain.ReminderRule, time.Time) (domain.ReminderSchedule, error)
+}
+
 const notificationLifetime = 36 * time.Hour
 
 type Sender struct {
-	store   *store.Store
-	planner *Planner
+	store   SenderStore
+	planner nextPlanner
 	bot     MessageSender
+	// now is injected so the scheduled cleanup expiry is deterministic in
+	// tests. Production wiring leaves it as time.Now.
+	now func() time.Time
 }
 
-func NewSender(storage *store.Store, planner *Planner, bot MessageSender) *Sender {
-	return &Sender{store: storage, planner: planner, bot: bot}
+func NewSender(storage SenderStore, planner nextPlanner, bot MessageSender) *Sender {
+	return &Sender{store: storage, planner: planner, bot: bot, now: time.Now}
 }
 
 func (s *Sender) Process(ctx context.Context, task domain.DeliveryTask) error {
@@ -80,9 +104,19 @@ func (s *Sender) Process(ctx context.Context, task domain.DeliveryTask) error {
 	if err != nil {
 		return fail(fmt.Errorf("Telegram reminder send failed"))
 	}
+	// After a successful send, any failure must compensate by deleting the
+	// just-sent message before returning a retryable error. The message slot
+	// never recorded this message ID, so the Cloud Tasks retry cannot find and
+	// replace it; without compensation the retry's send would leave a duplicate.
+	failAfterSend := func(cause error) error {
+		_, _ = s.bot.DeleteMessages(ctx, &botapi.DeleteMessagesParams{
+			ChatID: task.ChatID, MessageIDs: []int{message.ID},
+		})
+		return fail(cause)
+	}
 	next, err := s.planner.Next(ctx, profile, rule, task.ScheduledFor.Add(time.Second))
 	if err != nil {
-		return fail(fmt.Errorf("plan next reminder: %w", err))
+		return failAfterSend(fmt.Errorf("plan next reminder: %w", err))
 	}
 	previousMessageID, err := s.store.CompleteDelivery(
 		ctx,
@@ -90,10 +124,10 @@ func (s *Sender) Process(ctx context.Context, task domain.DeliveryTask) error {
 		int64(message.ID),
 		next,
 		notificationCategory(rule.Kind),
-		time.Now().Add(notificationLifetime),
+		s.now().Add(notificationLifetime),
 	)
 	if err != nil {
-		return fail(fmt.Errorf("complete delivery: %w", err))
+		return failAfterSend(fmt.Errorf("complete delivery: %w", err))
 	}
 	if previousMessageID != 0 && previousMessageID != int64(message.ID) {
 		// Best effort for immediate chat cleanup. The transaction also created

--- a/global/internal/reminders/sender_process_test.go
+++ b/global/internal/reminders/sender_process_test.go
@@ -1,0 +1,254 @@
+package reminders
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	botapi "github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+
+	"github.com/escalopa/prayer-bot/global/internal/domain"
+)
+
+// fakeSenderStore records the delivery-lifecycle calls the Sender makes so tests
+// can assert idempotency, staleness, and compensation behavior without Postgres.
+type fakeSenderStore struct {
+	schedule    domain.ReminderSchedule
+	scheduleErr error
+	acquired    bool
+	acquireErr  error
+	profile     domain.PrayerProfile
+	rule        domain.ReminderRule
+	chat        domain.Chat
+
+	completePrev  int64
+	completeErr   error
+	completeCalls int
+	completeArgs  struct {
+		messageID int64
+		category  string
+		expiresAt time.Time
+	}
+
+	failedKeys []string
+	staleKeys  []string
+	cleared    [][2]int64
+}
+
+func (f *fakeSenderStore) Schedule(context.Context, int64) (domain.ReminderSchedule, error) {
+	return f.schedule, f.scheduleErr
+}
+
+func (f *fakeSenderStore) AcquireDelivery(context.Context, domain.DeliveryTask) (bool, error) {
+	return f.acquired, f.acquireErr
+}
+
+func (f *fakeSenderStore) FailDelivery(_ context.Context, key string, _ error) error {
+	f.failedKeys = append(f.failedKeys, key)
+	return nil
+}
+
+func (f *fakeSenderStore) MarkDeliveryStale(_ context.Context, key string) error {
+	f.staleKeys = append(f.staleKeys, key)
+	return nil
+}
+
+func (f *fakeSenderStore) Profile(context.Context, int64) (domain.PrayerProfile, error) {
+	return f.profile, nil
+}
+
+func (f *fakeSenderStore) Rule(context.Context, int64) (domain.ReminderRule, error) {
+	return f.rule, nil
+}
+
+func (f *fakeSenderStore) Chat(context.Context, int64) (domain.Chat, error) {
+	return f.chat, nil
+}
+
+func (f *fakeSenderStore) CompleteDelivery(_ context.Context, _ domain.DeliveryTask, messageID int64, _ domain.ReminderSchedule, category string, expiresAt time.Time) (int64, error) {
+	f.completeCalls++
+	f.completeArgs.messageID = messageID
+	f.completeArgs.category = category
+	f.completeArgs.expiresAt = expiresAt
+	return f.completePrev, f.completeErr
+}
+
+func (f *fakeSenderStore) ClearNotificationMessage(_ context.Context, chatID, messageID int64) error {
+	f.cleared = append(f.cleared, [2]int64{chatID, messageID})
+	return nil
+}
+
+type fakeBot struct {
+	sendID  int
+	sendErr error
+	sent    []string
+	deleted [][]int
+}
+
+func (f *fakeBot) SendMessage(_ context.Context, params *botapi.SendMessageParams) (*models.Message, error) {
+	if f.sendErr != nil {
+		return nil, f.sendErr
+	}
+	f.sent = append(f.sent, params.Text)
+	return &models.Message{ID: f.sendID}, nil
+}
+
+func (f *fakeBot) DeleteMessages(_ context.Context, params *botapi.DeleteMessagesParams) (bool, error) {
+	f.deleted = append(f.deleted, params.MessageIDs)
+	return true, nil
+}
+
+type fakeNextPlanner struct {
+	schedule domain.ReminderSchedule
+	err      error
+}
+
+func (f fakeNextPlanner) Next(context.Context, domain.PrayerProfile, domain.ReminderRule, time.Time) (domain.ReminderSchedule, error) {
+	return f.schedule, f.err
+}
+
+// alignedFixture returns a task, store, and sender whose schedule/profile/rule
+// all agree, so Process proceeds to a real send instead of a staleness skip.
+func alignedFixture(t *testing.T) (domain.DeliveryTask, *fakeSenderStore, *fakeBot, *Sender) {
+	t.Helper()
+	runAt := time.Date(2026, time.July, 20, 18, 45, 0, 0, time.UTC)
+	task := domain.DeliveryTask{
+		DeliveryKey: "chat3:rule2:v5", ScheduleID: 1, RuleID: 2, ChatID: 3,
+		ProfileVersion: 5, ScheduledFor: runAt,
+	}
+	store := &fakeSenderStore{
+		schedule: domain.ReminderSchedule{
+			ID: 1, RuleID: 2, ChatID: 3, ProfileVersion: 5,
+			PrayerAt: runAt, NextRunAt: runAt,
+		},
+		acquired: true,
+		profile:  domain.PrayerProfile{ChatID: 3, Timezone: "UTC", Version: 5},
+		rule:     domain.ReminderRule{ID: 2, ChatID: 3, Kind: domain.ReminderAt, Prayer: domain.PrayerMaghrib, Enabled: true},
+		chat:     domain.Chat{TelegramChatID: 3, LanguageCode: "en"},
+	}
+	bot := &fakeBot{sendID: 555}
+	sender := NewSender(store, fakeNextPlanner{}, bot)
+	return task, store, bot, sender
+}
+
+func TestProcessSendsAndCompletesWithDeterministicExpiry(t *testing.T) {
+	task, store, bot, sender := alignedFixture(t)
+	fixedNow := time.Date(2026, time.July, 20, 18, 35, 0, 0, time.UTC)
+	sender.now = func() time.Time { return fixedNow }
+
+	if err := sender.Process(context.Background(), task); err != nil {
+		t.Fatal(err)
+	}
+	if len(bot.sent) != 1 {
+		t.Fatalf("expected exactly one send, got %d", len(bot.sent))
+	}
+	if store.completeCalls != 1 || store.completeArgs.messageID != 555 {
+		t.Fatalf("unexpected completion: calls=%d messageID=%d", store.completeCalls, store.completeArgs.messageID)
+	}
+	if want := fixedNow.Add(notificationLifetime); !store.completeArgs.expiresAt.Equal(want) {
+		t.Fatalf("expiry = %s, want %s (deterministic clock)", store.completeArgs.expiresAt, want)
+	}
+	if store.completeArgs.category != "prayer" {
+		t.Fatalf("category = %q, want prayer", store.completeArgs.category)
+	}
+	if len(store.failedKeys) != 0 || len(store.staleKeys) != 0 {
+		t.Fatalf("delivery should be neither failed nor stale: failed=%v stale=%v", store.failedKeys, store.staleKeys)
+	}
+}
+
+func TestProcessDeletesReplacedMessageInSameCategory(t *testing.T) {
+	task, store, bot, sender := alignedFixture(t)
+	store.completePrev = 100 // a prior message in the "prayer" slot
+
+	if err := sender.Process(context.Background(), task); err != nil {
+		t.Fatal(err)
+	}
+	if len(bot.deleted) != 1 || len(bot.deleted[0]) != 1 || bot.deleted[0][0] != 100 {
+		t.Fatalf("expected best-effort deletion of replaced message 100, got %v", bot.deleted)
+	}
+}
+
+// TestProcessCompensatesWhenCompletionFailsAfterSend is required by the delivery
+// contract: if PostgreSQL cannot commit the completion after Telegram accepted
+// the message, the sender must delete that just-sent message before returning a
+// retryable error, so the Cloud Tasks retry leaves only its own copy.
+func TestProcessCompensatesWhenCompletionFailsAfterSend(t *testing.T) {
+	task, store, bot, sender := alignedFixture(t)
+	store.completeErr = errors.New("connection reset")
+
+	err := sender.Process(context.Background(), task)
+	if err == nil {
+		t.Fatal("expected a retryable error when completion fails after send")
+	}
+	if len(bot.sent) != 1 {
+		t.Fatalf("expected the first message to be sent once, got %d", len(bot.sent))
+	}
+	if len(bot.deleted) != 1 || bot.deleted[0][0] != 555 {
+		t.Fatalf("expected compensating deletion of the orphaned message 555, got %v", bot.deleted)
+	}
+	if len(store.failedKeys) != 1 {
+		t.Fatalf("expected the delivery to be marked failed for retry, got %v", store.failedKeys)
+	}
+
+	// The Cloud Tasks retry now succeeds and sends a fresh message. Only that
+	// retry's message must survive; the orphaned first message was compensated.
+	bot.sendID = 556
+	store.completeErr = nil
+	if err := sender.Process(context.Background(), task); err != nil {
+		t.Fatalf("retry should succeed: %v", err)
+	}
+	if store.completeArgs.messageID != 556 {
+		t.Fatalf("retry completed with message %d, want 556", store.completeArgs.messageID)
+	}
+}
+
+func TestProcessCompensatesWhenPlanningNextFailsAfterSend(t *testing.T) {
+	task, store, bot, sender := alignedFixture(t)
+	sender.planner = fakeNextPlanner{err: errors.New("no occurrence")}
+
+	if err := sender.Process(context.Background(), task); err == nil {
+		t.Fatal("expected an error when planning the next occurrence fails")
+	}
+	if len(bot.deleted) != 1 || bot.deleted[0][0] != 555 {
+		t.Fatalf("expected compensating deletion after a post-send planning failure, got %v", bot.deleted)
+	}
+	if store.completeCalls != 0 {
+		t.Fatal("completion must not run when planning the next occurrence failed")
+	}
+}
+
+func TestProcessMarksStaleOnProfileVersionMismatch(t *testing.T) {
+	task, store, bot, sender := alignedFixture(t)
+	store.profile.Version = 6 // profile changed after the task was queued
+
+	if err := sender.Process(context.Background(), task); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.staleKeys) != 1 || store.staleKeys[0] != task.DeliveryKey {
+		t.Fatalf("expected the task to be marked stale, got %v", store.staleKeys)
+	}
+	if len(bot.sent) != 0 {
+		t.Fatal("a stale task must not send a message")
+	}
+}
+
+func TestProcessSkipsWhenLeaseNotAcquired(t *testing.T) {
+	task, store, bot, sender := alignedFixture(t)
+	store.acquired = false // another sender instance owns the delivery
+
+	if err := sender.Process(context.Background(), task); err != nil {
+		t.Fatal(err)
+	}
+	if len(bot.sent) != 0 || store.completeCalls != 0 {
+		t.Fatal("an unacquired delivery must do nothing")
+	}
+}
+
+func TestProcessRejectsInvalidTask(t *testing.T) {
+	_, _, _, sender := alignedFixture(t)
+	if err := sender.Process(context.Background(), domain.DeliveryTask{}); err == nil {
+		t.Fatal("expected an error for a task missing identifiers")
+	}
+}

--- a/global/internal/store/integration_test.go
+++ b/global/internal/store/integration_test.go
@@ -1,0 +1,229 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/escalopa/prayer-bot/global/internal/database"
+	"github.com/escalopa/prayer-bot/global/internal/domain"
+)
+
+// Integration tests run only when TEST_DATABASE_URL points at a disposable
+// PostgreSQL database. They exercise real SQL through pgx in QueryExecModeExec,
+// which is the only place the JSONB-as-text encoding and the transactional
+// outbox can be verified end-to-end. `make test` skips them automatically.
+//
+//	TEST_DATABASE_URL='postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable' go test ./internal/store/
+//
+// WARNING: the harness drops and recreates the global_bot_testing schema, so
+// never point TEST_DATABASE_URL at a database with real data.
+func openTestStore(t *testing.T) *Store {
+	t.Helper()
+	url := strings.TrimSpace(os.Getenv("TEST_DATABASE_URL"))
+	if url == "" {
+		t.Skip("set TEST_DATABASE_URL to run store integration tests")
+	}
+	ctx := context.Background()
+	applyMigrations(t, ctx, url, database.TestingSchema)
+
+	storage, err := Open(ctx, url, database.TestingSchema)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(storage.Close)
+	return storage
+}
+
+// applyMigrations recreates the target schema and runs every goose "Up" section
+// in order. It uses the simple protocol so multi-statement DDL executes in one
+// call, and substitutes ${GLOBAL_DB_SCHEMA} the way goose ENVSUB would.
+func applyMigrations(t *testing.T, ctx context.Context, url, schema string) {
+	t.Helper()
+	config, err := pgx.ParseConfig(url)
+	if err != nil {
+		t.Fatalf("parse migration url: %v", err)
+	}
+	config.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
+	conn, err := pgx.ConnectConfig(ctx, config)
+	if err != nil {
+		t.Fatalf("connect for migrations: %v", err)
+	}
+	defer conn.Close(ctx)
+
+	if _, err := conn.Exec(ctx, "DROP SCHEMA IF EXISTS "+pgx.Identifier{schema}.Sanitize()+" CASCADE"); err != nil {
+		t.Fatalf("reset schema: %v", err)
+	}
+
+	dir := filepath.Join("..", "..", "migrations")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read migrations dir: %v", err)
+	}
+	var files []string
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), ".sql") {
+			files = append(files, entry.Name())
+		}
+	}
+	sort.Strings(files)
+
+	for _, name := range files {
+		raw, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("read migration %s: %v", name, err)
+		}
+		up := goosUpSection(string(raw))
+		up = strings.ReplaceAll(up, "${GLOBAL_DB_SCHEMA}", schema)
+		if strings.TrimSpace(up) == "" {
+			continue
+		}
+		if _, err := conn.Exec(ctx, up); err != nil {
+			t.Fatalf("apply migration %s: %v", name, err)
+		}
+	}
+}
+
+func goosUpSection(content string) string {
+	var (
+		builder   strings.Builder
+		capturing bool
+	)
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "-- +goose Up") {
+			capturing = true
+			continue
+		}
+		if strings.HasPrefix(trimmed, "-- +goose Down") {
+			break
+		}
+		if !capturing || strings.HasPrefix(trimmed, "-- +goose") {
+			continue
+		}
+		builder.WriteString(line)
+		builder.WriteString("\n")
+	}
+	return builder.String()
+}
+
+func seedChat(t *testing.T, storage *Store, chatID int64) {
+	t.Helper()
+	if err := storage.UpsertChat(context.Background(), domain.Chat{
+		TelegramChatID: chatID, Type: "private", LanguageCode: "en",
+	}); err != nil {
+		t.Fatalf("seed chat: %v", err)
+	}
+}
+
+// TestIntegrationProfileRoundTripPreservesJSONBAdjustments guards the exact
+// production incident: under the Supabase transaction pooler, adjustments passed
+// as []byte failed with SQLSTATE 22P02. This asserts the JSON-text encoding
+// persists and reads back correctly.
+func TestIntegrationProfileRoundTripPreservesJSONBAdjustments(t *testing.T) {
+	storage := openTestStore(t)
+	ctx := context.Background()
+	seedChat(t, storage, 3)
+
+	profile := domain.PrayerProfile{
+		ChatID: 3, Latitude: 30.044, Longitude: 31.236, Timezone: "Africa/Cairo",
+		Method: domain.MethodEgyptian, Madhab: domain.MadhabShafii,
+		HighLatitudeRule: domain.HighLatitudeAngleBased,
+		Adjustments:      domain.Adjustments{Fajr: 2, Dhuhr: 3, Isha: -1},
+		HijriAdjustment:  1,
+	}
+	saved, err := storage.UpsertProfile(ctx, profile)
+	if err != nil {
+		t.Fatalf("upsert profile: %v", err)
+	}
+	if saved.Version < 1 {
+		t.Fatalf("expected a positive version, got %d", saved.Version)
+	}
+
+	got, err := storage.Profile(ctx, 3)
+	if err != nil {
+		t.Fatalf("read profile: %v", err)
+	}
+	if got.Adjustments != profile.Adjustments {
+		t.Fatalf("adjustments round-trip mismatch: got %+v want %+v", got.Adjustments, profile.Adjustments)
+	}
+	if got.Method != domain.MethodEgyptian || got.Timezone != "Africa/Cairo" || got.HijriAdjustment != 1 {
+		t.Fatalf("profile fields did not round-trip: %+v", got)
+	}
+}
+
+// TestIntegrationClaimDueWritesOutboxWithJSONPayload verifies the transactional
+// outbox: a due schedule is claimed, a JSON-text delivery payload is written and
+// decodes cleanly, and the delivery lease is single-owner.
+func TestIntegrationClaimDueWritesOutboxWithJSONPayload(t *testing.T) {
+	storage := openTestStore(t)
+	ctx := context.Background()
+	seedChat(t, storage, 7)
+
+	profile, err := storage.UpsertProfile(ctx, domain.PrayerProfile{
+		ChatID: 7, Latitude: 51.507, Longitude: -0.128, Timezone: "Europe/London",
+		Method: domain.MethodMWL, Madhab: domain.MadhabShafii,
+		HighLatitudeRule: domain.HighLatitudeMiddleNight,
+	})
+	if err != nil {
+		t.Fatalf("upsert profile: %v", err)
+	}
+	if err := storage.SetWeeklyRule(ctx, 7, domain.ReminderWeeklyKahf, true); err != nil {
+		t.Fatalf("enable weekly rule: %v", err)
+	}
+	rules, err := storage.EnabledRules(ctx, 7)
+	if err != nil || len(rules) != 1 {
+		t.Fatalf("expected exactly one enabled rule, got %d (%v)", len(rules), err)
+	}
+
+	due := time.Now().Add(-time.Minute)
+	schedule, err := storage.UpsertSchedule(ctx, domain.ReminderSchedule{
+		RuleID: rules[0].ID, ChatID: 7, ProfileVersion: profile.Version,
+		LocalDate: "2026-07-24", PrayerAt: due, NextRunAt: due,
+	})
+	if err != nil {
+		t.Fatalf("upsert schedule: %v", err)
+	}
+
+	count, err := storage.ClaimDue(ctx, time.Now(), 10)
+	if err != nil {
+		t.Fatalf("claim due: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("claimed %d schedules, want 1", count)
+	}
+
+	items, err := storage.PendingOutbox(ctx, 10)
+	if err != nil {
+		t.Fatalf("pending outbox: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("outbox has %d items, want 1", len(items))
+	}
+	var task domain.DeliveryTask
+	if err := json.Unmarshal(items[0].Payload, &task); err != nil {
+		t.Fatalf("outbox payload is not valid JSON: %v", err)
+	}
+	if task.ScheduleID != schedule.ID || task.ChatID != 7 || task.RuleID != rules[0].ID {
+		t.Fatalf("unexpected delivery task: %+v", task)
+	}
+
+	acquired, err := storage.AcquireDelivery(ctx, task)
+	if err != nil || !acquired {
+		t.Fatalf("first AcquireDelivery = (%v, %v), want (true, nil)", acquired, err)
+	}
+	again, err := storage.AcquireDelivery(ctx, task)
+	if err != nil {
+		t.Fatalf("second AcquireDelivery error: %v", err)
+	}
+	if again {
+		t.Fatal("a held delivery lease must not be acquired twice")
+	}
+}


### PR DESCRIPTION
## Summary

Improves the global bot's test coverage and, in doing so, fixes a real latent delivery bug. Also establishes a documented testing foundation for future work. Answers the "how do we simulate real-time execution?" question: **we don't touch the wall clock — time is dependency-injected**, which the codebase already does almost everywhere.

## Bug fixed (behavior change)

`Sender.Process` was **missing the at-least-once compensation** that `docs/reminder-delivery.md` and `docs/architecture.md` require. On a post-send failure (planning the next occurrence or committing the completion fails *after* Telegram accepted the message), the message ID was never written to the cleanup slot, so the Cloud Tasks retry sent a **duplicate** and the first message leaked. `Process` now issues a compensating `deleteMessages` for the just-sent message before returning a retryable error.

## Testability

- New `SenderStore` and `nextPlanner` interfaces (same pattern as the existing `DispatchStore`/`PlanningStore`) and an injectable `now func() time.Time` clock. Production wiring is unchanged — `*store.Store` and `*Planner` satisfy the interfaces and the clock defaults to `time.Now`.

## New tests

- **`internal/reminders/sender_process_test.go`** — full delivery state machine over fakes: send + complete with deterministic expiry, replacement cleanup, staleness on profile-version change, lease contention, invalid task, and the mandated **"send ok → completion fails → retry leaves only its own message"** scenario.
- **`internal/domain/domain_test.go`** — previously untested: `PrayerProfile.Validate` (every branch), `RoundedCoordinates`, all `Valid()`/classifier helpers, `DaySchedule.At`.
- **`internal/store/integration_test.go`** — env-gated on `TEST_DATABASE_URL`, applies the goose migrations to a fresh `global_bot_testing` schema and exercises real SQL: the **JSONB profile round-trip that guards the recent `22P02` production incident**, and the `claim → outbox → delivery-lease` lifecycle. Skips cleanly when no DB is set, so `make test` stays fast and dependency-free.

## Docs

- New **`global/docs/testing.md`** (owning doc for test strategy) linked from the docs index, code map, and root `CLAUDE.md`.

## Verification

- `make check` passes (gofmt, vet, full unit suite).
- Integration tests **run green against an ephemeral `postgres:16` container**.
- Confirmed the JSONB regression test **fails with `SQLSTATE 22P02`** when the old `[]byte` encoding is reintroduced, and passes with the current `marshalJSONText` code.

## Reviewer notes

- Stdlib-only, no test frameworks added (matches existing style).
- The only production-code change is `sender.go` (the compensation fix + interface/clock seam); everything else is tests and docs.
- Not exhaustive by design — this is the foundation. Natural follow-ups: wiring integration tests into CI with a Postgres service, and unit tests for the remaining thin packages (`location`, `qibla`, `httpx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)