### PR TITLE
Add Zakat niSab price & currency pipeline

### DIFF
--- a/global/cmd/dispatch/main.go
+++ b/global/cmd/dispatch/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/escalopa/prayer-bot/global/internal/config"
 	"github.com/escalopa/prayer-bot/global/internal/httpx"
+	"github.com/escalopa/prayer-bot/global/internal/metals"
 	"github.com/escalopa/prayer-bot/global/internal/reminders"
 	"github.com/escalopa/prayer-bot/global/internal/store"
 )
@@ -34,6 +35,7 @@ func main() {
 	}
 	defer enqueuer.Close()
 	dispatcher := reminders.NewDispatcher(storage, enqueuer, cfg.DispatchBatchSize)
+	metalsClient := metals.NewClient(cfg.HTTPTimeout)
 
 	mux := http.NewServeMux()
 	httpx.HealthMux(mux)
@@ -48,6 +50,16 @@ func main() {
 		w.WriteHeader(http.StatusNoContent)
 	})
 	mux.HandleFunc("POST /maintenance", func(w http.ResponseWriter, r *http.Request) {
+		// The niSab price refresh is best-effort: a failure logs a warning and
+		// keeps the previously cached prices, and must not fail the request or
+		// block retention cleanup.
+		if prices, err := metalsClient.Fetch(r.Context()); err != nil {
+			logger.Warn("metal price refresh failed; keeping cached prices", "error", err)
+		} else if err := storage.UpsertMetalPrices(r.Context(), prices); err != nil {
+			logger.Warn("metal price persist failed; keeping cached prices", "error", err)
+		} else {
+			logger.Info("metal prices refreshed")
+		}
 		count, err := storage.Cleanup(r.Context(), time.Now(), 1000)
 		if err != nil {
 			logger.Error("retention cleanup failed", "error", err)

--- a/global/docs/architecture.md
+++ b/global/docs/architecture.md
@@ -79,6 +79,19 @@ The current calculation engine is `github.com/hablullah/go-prayer`, hidden behin
 
 Daily schedule headers use the calculated Umm al-Qura calendar from `github.com/hablullah/go-hijri`. The independently stored -2 to +2 day correction accounts for local moon-sighting differences. It is applied to displayed Hijri dates and occasion matching, but does not affect prayer-time calculations.
 
+## Zakat niSab pricing
+
+The Mini App includes a Zakat calculator whose niSab threshold is fixed in
+Islamic law as grams of gold or silver, but whose monetary value depends on live
+metal prices. A single shared `metal_prices` row caches the daily gold/silver
+spot price and a USD currency rate table. The dispatch service's existing daily
+maintenance job refreshes it from two free, key-less HTTP APIs (a metals price
+feed and a broader USD FX feed), so no new secret, service, or Scheduler job is
+introduced. This and the location-change path are the only server-side external
+calls; everything else remains calculated locally. The cache is public market
+data with no user identifiers, and the calculation runs in the browser from the
+bootstrap snapshot.
+
 ## Delivery behavior
 
 The dispatcher selects only due rows from the partial due-time index using `FOR UPDATE SKIP LOCKED`. It writes a durable outbox record in the same transaction and uses a deterministic Cloud Task name. The sender leases a delivery key before calling Telegram and records the next occurrence after a successful send. Prayer reminders, configurable pre-prayer notices, and opt-in weekly fasting/Al-Kahf reminders share this delivery path; all recurrence calculations use the profile's IANA timezone.

--- a/global/docs/data-model.md
+++ b/global/docs/data-model.md
@@ -106,6 +106,11 @@ profile version increases whenever a change can affect calculated times.
 Queued tasks carry this version and become stale instead of sending after a
 profile change.
 
+`country_code` (ISO 3166-1 alpha-2) is written from the country already resolved
+on every location change. It is used only to default the Zakat calculator's
+currency and never affects calculated prayer times, so it rides on the existing
+location-driven version bump rather than causing its own.
+
 ### `reminder_rules`
 
 Represents desired behavior, not a queued job. The unique key prevents duplicate
@@ -156,6 +161,15 @@ keeps the same identity when its calculated time changes. Disabling the row
 immediately rejects future feed fetches; reconnecting issues a new feed token
 but keeps the UID namespace stable.
 
+### `metal_prices`
+
+A single shared row (`CHECK (id = 1)`) caching the daily gold and silver spot
+price (USD per troy ounce) and a USD-based currency rate table (`rates` JSONB).
+It is global infrastructure, not chat-owned: it has no `chat_id`, is not part of
+the `chats` cascade, and is untouched by `/delete_me`. The maintenance job
+overwrites it once a day; the Mini App reads it to localize the Zakat niSab. It
+contains only public market data — no user identifiers.
+
 ## Retention
 
 | Data | Retention behavior |
@@ -165,6 +179,7 @@ but keeps the UID namespace stable.
 | Telegram notification messages | Scheduled for deletion after 36 hours |
 | Profiles and reminder configuration | Kept until `/delete_me` or chat deletion |
 | Calendar subscription | Kept until `/delete_me`; its feed token can be disabled or replaced |
+| Cached metal prices | Single row overwritten daily; kept indefinitely |
 | Feedback content | Never stored in PostgreSQL |
 
 Retention runs in bounded batches from the authenticated maintenance Scheduler

--- a/global/docs/request-flows.md
+++ b/global/docs/request-flows.md
@@ -152,6 +152,34 @@ Google decides when it refreshes subscribed calendars. The URL is a bearer
 credential and must remain private. It and the event UIDs expose neither the
 Telegram user ID nor bot token.
 
+## Daily maintenance and niSab pricing
+
+Cloud Scheduler invokes the dispatch service's `/maintenance` endpoint once a
+day. Besides retention cleanup, it refreshes the cached precious-metal prices
+used by the Zakat calculator:
+
+1. Fetch gold (XAU) and silver (XAG) spot prices, USD per troy ounce, from a
+   free, key-less metals API.
+2. Fetch a USD-based currency rate table from a free, key-less FX API, because
+   the metals API covers only a few major currencies while the bot's audience
+   needs many more.
+3. Validate the data (positive prices, USD-based rates) and upsert the single
+   `metal_prices` row.
+
+The refresh is best-effort: any upstream or persistence failure logs a warning
+and keeps the previously cached row, and never blocks retention cleanup or fails
+the maintenance request. Once-a-day granularity is sufficient because the niSab
+threshold does not need intraday precision, and the single shared row is read by
+every user, so user volume never affects upstream call counts. These are the
+only server-side external calls outside the location-change path.
+
+The Mini App bootstrap includes a `nisab` block (spot prices, the fixed 85 g
+gold / 595 g silver thresholds, the currency rate table, the sorted list of
+selectable currencies, and a default currency derived from the profile's country
+— or timezone as a fallback). The Zakat calculation itself runs entirely in the
+browser. The block is omitted until the maintenance job has populated prices at
+least once.
+
 ## Feedback
 
 Feedback is accepted only after an explicit localized prompt. Private text,

--- a/global/docs/runtime-and-deployment.md
+++ b/global/docs/runtime-and-deployment.md
@@ -38,6 +38,13 @@ Scheduler job, or separate runtime. Google fetches the URL on its own schedule;
 each request calculates the current rolling 30-day window from the user's saved
 profile.
 
+The Zakat niSab pricing integration adds no new service, Scheduler job, or
+secret. The existing daily `/maintenance` job on the dispatch service fetches
+gold/silver spot prices and a USD currency rate table from two free, key-less
+HTTP APIs and caches them in one PostgreSQL row. Both calls use default Cloud
+Run egress and run at most once a day regardless of user volume. The refresh is
+best-effort and never blocks retention cleanup.
+
 ## Secrets
 
 Runtime services read environment-specific Secret Manager values:

--- a/global/internal/domain/domain.go
+++ b/global/internal/domain/domain.go
@@ -82,6 +82,7 @@ type PrayerProfile struct {
 	Timezone         string
 	PlaceID          string
 	LocationLabel    string // Only a user-supplied label may be persisted here.
+	CountryCode      string // ISO 3166-1 alpha-2, resolved from the location; used only to default currency.
 	Method           Method
 	Madhab           Madhab
 	HighLatitudeRule HighLatitudeRule
@@ -118,6 +119,28 @@ func (p PrayerProfile) Validate() error {
 // Telegram coordinates should only live long enough to resolve the timezone.
 func RoundedCoordinates(latitude, longitude float64) (float64, float64) {
 	return math.Round(latitude*1000) / 1000, math.Round(longitude*1000) / 1000
+}
+
+// Zakat niSab thresholds in grams of pure metal. These are fixed in Islamic law
+// (85 g gold or 595 g silver); the monetary value is derived from live prices.
+const (
+	NisabGoldGrams   = 85.0
+	NisabSilverGrams = 595.0
+)
+
+// MetalPrices is the daily-cached precious-metal spot price used to localize the
+// Zakat niSab. Prices are USD per troy ounce; Rates convert USD to other
+// currencies (base USD, so Rates["USD"] == 1).
+type MetalPrices struct {
+	GoldUSDPerOunce   float64
+	SilverUSDPerOunce float64
+	Rates             map[string]float64
+	FetchedAt         time.Time
+}
+
+// Valid reports whether the prices are usable for a niSab calculation.
+func (p MetalPrices) Valid() bool {
+	return p.GoldUSDPerOunce > 0 && p.SilverUSDPerOunce > 0 && p.Rates["USD"] == 1
 }
 
 type Prayer string

--- a/global/internal/location/currency.go
+++ b/global/internal/location/currency.go
@@ -1,0 +1,86 @@
+package location
+
+import "strings"
+
+// currencyByCountry maps ISO 3166-1 alpha-2 country codes to their ISO 4217
+// currency code. It is used only to choose a sensible default currency for the
+// Zakat calculator; the user can always override the selection. Coverage favors
+// the bot's audience (Muslim-majority countries) and major economies; unlisted
+// countries fall back to USD at the call site.
+var currencyByCountry = map[string]string{
+	// Middle East & North Africa
+	"SA": "SAR", "AE": "AED", "EG": "EGP", "QA": "QAR", "KW": "KWD",
+	"BH": "BHD", "OM": "OMR", "JO": "JOD", "LB": "LBP", "IQ": "IQD",
+	"SY": "SYP", "YE": "YER", "PS": "ILS", "IL": "ILS", "DZ": "DZD",
+	"MA": "MAD", "TN": "TND", "LY": "LYD", "SD": "SDG", "MR": "MRU",
+	// Türkiye, Iran, South & Central Asia
+	"TR": "TRY", "IR": "IRR", "PK": "PKR", "IN": "INR", "BD": "BDT",
+	"AF": "AFN", "LK": "LKR", "MV": "MVR", "NP": "NPR",
+	"UZ": "UZS", "KZ": "KZT", "KG": "KGS", "TJ": "TJS", "TM": "TMT",
+	"AZ": "AZN", "GE": "GEL", "AM": "AMD",
+	// Southeast & East Asia
+	"ID": "IDR", "MY": "MYR", "BN": "BND", "SG": "SGD", "TH": "THB",
+	"PH": "PHP", "VN": "VND", "CN": "CNY", "JP": "JPY", "KR": "KRW",
+	"HK": "HKD", "TW": "TWD",
+	// Sub-Saharan Africa
+	"NG": "NGN", "SO": "SOS", "DJ": "DJF", "KM": "KMF", "SN": "XOF",
+	"ML": "XOF", "NE": "XOF", "BF": "XOF", "CI": "XOF", "TD": "XAF",
+	"CM": "XAF", "GN": "GNF", "GM": "GMD", "SL": "SLE", "KE": "KES",
+	"TZ": "TZS", "UG": "UGX", "ET": "ETB", "ZA": "ZAR", "GH": "GHS",
+	// Europe (euro area)
+	"DE": "EUR", "FR": "EUR", "ES": "EUR", "IT": "EUR", "NL": "EUR",
+	"BE": "EUR", "AT": "EUR", "PT": "EUR", "IE": "EUR", "FI": "EUR",
+	"GR": "EUR", "SK": "EUR", "SI": "EUR", "LT": "EUR", "LV": "EUR",
+	"EE": "EUR", "LU": "EUR", "CY": "EUR", "MT": "EUR", "HR": "EUR",
+	// Europe (non-euro) & CIS
+	"GB": "GBP", "CH": "CHF", "SE": "SEK", "NO": "NOK", "DK": "DKK",
+	"PL": "PLN", "CZ": "CZK", "HU": "HUF", "RO": "RON", "BG": "BGN",
+	"RS": "RSD", "UA": "UAH", "RU": "RUB", "BY": "BYN", "AL": "ALL",
+	"BA": "BAM", "MK": "MKD", "MD": "MDL",
+	// Americas & Oceania
+	"US": "USD", "CA": "CAD", "MX": "MXN", "BR": "BRL", "AR": "ARS",
+	"CL": "CLP", "CO": "COP", "PE": "PEN", "AU": "AUD", "NZ": "NZD",
+}
+
+// timezoneCountry maps common IANA timezones to a country code. It is a
+// best-effort fallback for profiles saved before country codes were persisted,
+// so it only needs to cover frequently used zones; anything unlisted falls back
+// to USD at the call site.
+var timezoneCountry = map[string]string{
+	"Africa/Cairo": "EG", "Africa/Algiers": "DZ", "Africa/Casablanca": "MA",
+	"Africa/Tunis": "TN", "Africa/Tripoli": "LY", "Africa/Khartoum": "SD",
+	"Africa/Lagos": "NG", "Africa/Nairobi": "KE", "Africa/Mogadishu": "SO",
+	"Africa/Johannesburg": "ZA", "Africa/Addis_Ababa": "ET",
+	"Asia/Riyadh": "SA", "Asia/Dubai": "AE", "Asia/Qatar": "QA",
+	"Asia/Kuwait": "KW", "Asia/Bahrain": "BH", "Asia/Muscat": "OM",
+	"Asia/Amman": "JO", "Asia/Beirut": "LB", "Asia/Baghdad": "IQ",
+	"Asia/Damascus": "SY", "Asia/Jerusalem": "IL", "Asia/Gaza": "PS",
+	"Asia/Tehran": "IR", "Asia/Karachi": "PK", "Asia/Kolkata": "IN",
+	"Asia/Dhaka": "BD", "Asia/Kabul": "AF", "Asia/Colombo": "LK",
+	"Asia/Tashkent": "UZ", "Asia/Samarkand": "UZ", "Asia/Almaty": "KZ",
+	"Asia/Bishkek": "KG", "Asia/Dushanbe": "TJ", "Asia/Ashgabat": "TM",
+	"Asia/Baku": "AZ", "Asia/Tbilisi": "GE", "Asia/Yerevan": "AM",
+	"Asia/Jakarta": "ID", "Asia/Kuala_Lumpur": "MY", "Asia/Brunei": "BN",
+	"Asia/Singapore": "SG", "Asia/Bangkok": "TH", "Asia/Manila": "PH",
+	"Asia/Shanghai": "CN", "Asia/Tokyo": "JP", "Asia/Seoul": "KR",
+	"Europe/Istanbul": "TR", "Europe/London": "GB", "Europe/Paris": "FR",
+	"Europe/Berlin": "DE", "Europe/Madrid": "ES", "Europe/Rome": "IT",
+	"Europe/Amsterdam": "NL", "Europe/Zurich": "CH", "Europe/Warsaw": "PL",
+	"Europe/Moscow": "RU", "Europe/Kiev": "UA", "Europe/Kyiv": "UA",
+	"Europe/Minsk":     "BY",
+	"America/New_York": "US", "America/Chicago": "US", "America/Denver": "US",
+	"America/Los_Angeles": "US", "America/Toronto": "CA", "America/Mexico_City": "MX",
+	"America/Sao_Paulo": "BR", "Australia/Sydney": "AU",
+}
+
+// CurrencyForCountry returns the ISO 4217 currency for an ISO 3166-1 alpha-2
+// country code, or "" if the country is unknown or empty.
+func CurrencyForCountry(countryCode string) string {
+	return currencyByCountry[strings.ToUpper(strings.TrimSpace(countryCode))]
+}
+
+// CurrencyForTimezone returns a best-effort currency derived from an IANA
+// timezone, or "" if the timezone is not mapped.
+func CurrencyForTimezone(timezone string) string {
+	return CurrencyForCountry(timezoneCountry[strings.TrimSpace(timezone)])
+}

--- a/global/internal/location/currency_test.go
+++ b/global/internal/location/currency_test.go
@@ -1,0 +1,33 @@
+package location
+
+import "testing"
+
+func TestCurrencyForCountry(t *testing.T) {
+	cases := map[string]string{
+		"EG": "EGP", "eg": "EGP", " TR ": "TRY", "PK": "PKR",
+		"UZ": "UZS", "US": "USD", "FR": "EUR", "DE": "EUR",
+		"": "", "ZZ": "", "XX": "",
+	}
+	for input, want := range cases {
+		if got := CurrencyForCountry(input); got != want {
+			t.Errorf("CurrencyForCountry(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestCurrencyForTimezone(t *testing.T) {
+	cases := map[string]string{
+		"Africa/Cairo":     "EGP",
+		"Europe/Istanbul":  "TRY",
+		"Asia/Tashkent":    "UZS",
+		"Europe/Moscow":    "RUB",
+		"America/New_York": "USD",
+		"Antarctica/Troll": "",
+		"":                 "",
+	}
+	for input, want := range cases {
+		if got := CurrencyForTimezone(input); got != want {
+			t.Errorf("CurrencyForTimezone(%q) = %q, want %q", input, got, want)
+		}
+	}
+}

--- a/global/internal/metals/metals.go
+++ b/global/internal/metals/metals.go
@@ -1,0 +1,133 @@
+// Package metals fetches the daily gold/silver spot price and USD currency
+// rate table used to localize the Zakat niSab. Both upstreams are free and
+// require no API key, so no new secret is introduced. The maintenance job calls
+// Fetch once a day and caches the result; user requests never reach these APIs.
+package metals
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/escalopa/prayer-bot/global/internal/domain"
+)
+
+const (
+	// defaultGoldURL returns gold (XAU) and silver (XAG) spot prices in USD per
+	// troy ounce, e.g. GET {defaultGoldURL}/XAU. No key required.
+	defaultGoldURL = "https://api.gold-api.com/price"
+	// defaultFXURL returns every supported currency rate with base USD in one
+	// response. gold-api.com only covers a handful of major currencies, so this
+	// separate feed provides the currencies the bot's audience actually uses.
+	defaultFXURL = "https://open.er-api.com/v6/latest/USD"
+)
+
+// Client fetches metal prices and currency rates. Endpoints are overridable so
+// tests can point at an httptest server.
+type Client struct {
+	http    *http.Client
+	goldURL string
+	fxURL   string
+}
+
+// Option customizes a Client.
+type Option func(*Client)
+
+// WithEndpoints overrides the upstream URLs (used in tests).
+func WithEndpoints(goldURL, fxURL string) Option {
+	return func(c *Client) {
+		c.goldURL = goldURL
+		c.fxURL = fxURL
+	}
+}
+
+// NewClient returns a metals client with the given per-request timeout.
+func NewClient(timeout time.Duration, opts ...Option) *Client {
+	c := &Client{
+		http:    &http.Client{Timeout: timeout},
+		goldURL: defaultGoldURL,
+		fxURL:   defaultFXURL,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// Fetch retrieves gold and silver spot prices plus the USD currency rate table.
+// It returns an error if any upstream fails or returns unusable data; callers
+// should keep the previously cached value on error rather than overwriting it.
+func (c *Client) Fetch(ctx context.Context) (domain.MetalPrices, error) {
+	gold, err := c.metalPrice(ctx, "XAU")
+	if err != nil {
+		return domain.MetalPrices{}, fmt.Errorf("fetch gold price: %w", err)
+	}
+	silver, err := c.metalPrice(ctx, "XAG")
+	if err != nil {
+		return domain.MetalPrices{}, fmt.Errorf("fetch silver price: %w", err)
+	}
+	rates, err := c.currencyRates(ctx)
+	if err != nil {
+		return domain.MetalPrices{}, fmt.Errorf("fetch currency rates: %w", err)
+	}
+	prices := domain.MetalPrices{
+		GoldUSDPerOunce:   gold,
+		SilverUSDPerOunce: silver,
+		Rates:             rates,
+	}
+	if !prices.Valid() {
+		return domain.MetalPrices{}, fmt.Errorf("fetched metal prices are invalid")
+	}
+	return prices, nil
+}
+
+func (c *Client) metalPrice(ctx context.Context, symbol string) (float64, error) {
+	var payload struct {
+		Price float64 `json:"price"`
+	}
+	if err := c.getJSON(ctx, c.goldURL+"/"+symbol, &payload); err != nil {
+		return 0, err
+	}
+	if payload.Price <= 0 {
+		return 0, fmt.Errorf("non-positive price for %s", symbol)
+	}
+	return payload.Price, nil
+}
+
+func (c *Client) currencyRates(ctx context.Context) (map[string]float64, error) {
+	var payload struct {
+		Result string             `json:"result"`
+		Rates  map[string]float64 `json:"rates"`
+	}
+	if err := c.getJSON(ctx, c.fxURL, &payload); err != nil {
+		return nil, err
+	}
+	if payload.Result != "success" {
+		return nil, fmt.Errorf("currency feed returned result %q", payload.Result)
+	}
+	if payload.Rates["USD"] != 1 {
+		return nil, fmt.Errorf("currency feed is not USD-based")
+	}
+	return payload.Rates, nil
+}
+
+func (c *Client) getJSON(ctx context.Context, url string, target any) error {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	response, err := c.http.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close() //nolint:errcheck
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d", response.StatusCode)
+	}
+	if err := json.NewDecoder(response.Body).Decode(target); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}

--- a/global/internal/metals/metals_test.go
+++ b/global/internal/metals/metals_test.go
@@ -1,0 +1,86 @@
+package metals
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newTestClient(t *testing.T, goldHandler, fxHandler http.HandlerFunc) *Client {
+	t.Helper()
+	gold := httptest.NewServer(goldHandler)
+	fx := httptest.NewServer(fxHandler)
+	t.Cleanup(gold.Close)
+	t.Cleanup(fx.Close)
+	return NewClient(5*time.Second, WithEndpoints(gold.URL+"/price", fx.URL))
+}
+
+func TestFetchSuccess(t *testing.T) {
+	client := newTestClient(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case strings.HasSuffix(r.URL.Path, "/XAU"):
+				_, _ = w.Write([]byte(`{"price":4053.7,"symbol":"XAU"}`))
+			case strings.HasSuffix(r.URL.Path, "/XAG"):
+				_, _ = w.Write([]byte(`{"price":58.28,"symbol":"XAG"}`))
+			default:
+				http.NotFound(w, r)
+			}
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"result":"success","rates":{"USD":1,"EGP":51.3,"TRY":47.3}}`))
+		},
+	)
+	prices, err := client.Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if prices.GoldUSDPerOunce != 4053.7 || prices.SilverUSDPerOunce != 58.28 {
+		t.Fatalf("unexpected prices: %+v", prices)
+	}
+	if prices.Rates["EGP"] != 51.3 || prices.Rates["USD"] != 1 {
+		t.Fatalf("unexpected rates: %+v", prices.Rates)
+	}
+	if !prices.Valid() {
+		t.Fatal("prices should be valid")
+	}
+}
+
+func TestFetchRejectsNonUSDBase(t *testing.T) {
+	client := newTestClient(t,
+		func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(`{"price":1}`)) },
+		func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"result":"success","rates":{"USD":0.9}}`))
+		},
+	)
+	if _, err := client.Fetch(context.Background()); err == nil {
+		t.Fatal("expected error for non-USD base rate table")
+	}
+}
+
+func TestFetchRejectsNonPositivePrice(t *testing.T) {
+	client := newTestClient(t,
+		func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(`{"price":0}`)) },
+		func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"result":"success","rates":{"USD":1}}`))
+		},
+	)
+	if _, err := client.Fetch(context.Background()); err == nil {
+		t.Fatal("expected error for non-positive metal price")
+	}
+}
+
+func TestFetchPropagatesUpstreamFailure(t *testing.T) {
+	client := newTestClient(t,
+		func(w http.ResponseWriter, r *http.Request) { http.Error(w, "boom", http.StatusBadGateway) },
+		func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"result":"success","rates":{"USD":1}}`))
+		},
+	)
+	if _, err := client.Fetch(context.Background()); err == nil {
+		t.Fatal("expected error when the gold upstream fails")
+	}
+}

--- a/global/internal/miniapp/handler.go
+++ b/global/internal/miniapp/handler.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"math"
 	"net/http"
+	"sort"
 	"time"
 
 	botapi "github.com/go-telegram/bot"
@@ -40,6 +41,7 @@ type Storage interface {
 	SetLanguage(context.Context, int64, string) error
 	Profile(context.Context, int64) (domain.PrayerProfile, error)
 	UpsertProfile(context.Context, domain.PrayerProfile) (domain.PrayerProfile, error)
+	MetalPrices(context.Context) (domain.MetalPrices, error)
 	EnabledRules(context.Context, int64) ([]domain.ReminderRule, error)
 	EnableDefaultRules(context.Context, int64) error
 	DisableRules(context.Context, int64) error
@@ -180,7 +182,7 @@ func (h *Handler) updateLocation(w http.ResponseWriter, r *http.Request, identit
 	latitude, longitude := domain.RoundedCoordinates(*request.Latitude, *request.Longitude)
 	profile := domain.PrayerProfile{
 		ChatID: identity.UserID, Latitude: latitude, Longitude: longitude,
-		Timezone: resolved.Timezone, PlaceID: resolved.PlaceID,
+		Timezone: resolved.Timezone, PlaceID: resolved.PlaceID, CountryCode: resolved.CountryCode,
 		Method: location.RecommendedMethod(resolved.CountryCode), Madhab: domain.MadhabShafii,
 		HighLatitudeRule: domain.HighLatitudeAngleBased,
 	}
@@ -468,8 +470,23 @@ type bootstrapResponse struct {
 	Calendar      calendarSubscriptionResponse `json:"calendar"`
 	Occasions     []occasionResponse           `json:"occasions,omitempty"`
 	Reminders     reminderResponse             `json:"reminders"`
+	Nisab         *nisabResponse               `json:"nisab,omitempty"`
 	Options       optionsResponse              `json:"options"`
 	Labels        map[string]string            `json:"labels"`
+}
+
+// nisabResponse carries everything the Mini App Zakat calculator needs to show
+// the niSab threshold and compute zakat in the user's currency, entirely client
+// side. Prices are USD per troy ounce; Rates convert USD to each currency.
+type nisabResponse struct {
+	GoldUSDPerOunce   float64            `json:"gold_usd_per_ounce"`
+	SilverUSDPerOunce float64            `json:"silver_usd_per_ounce"`
+	GoldGrams         float64            `json:"gold_grams"`
+	SilverGrams       float64            `json:"silver_grams"`
+	Rates             map[string]float64 `json:"rates"`
+	Currencies        []string           `json:"currencies"`
+	DefaultCurrency   string             `json:"default_currency"`
+	FetchedAt         string             `json:"fetched_at"`
 }
 
 type userResponse struct {
@@ -563,13 +580,24 @@ func (h *Handler) build(ctx context.Context, identity Identity) (bootstrapRespon
 	if err != nil {
 		return bootstrapResponse{}, err
 	}
+	prices, pricesErr := h.store.MetalPrices(ctx)
+	havePrices := pricesErr == nil
+	if pricesErr != nil && !store.IsNotFound(pricesErr) {
+		return bootstrapResponse{}, fmt.Errorf("load metal prices: %w", pricesErr)
+	}
 	profile, err := h.store.Profile(ctx, identity.UserID)
 	if store.IsNotFound(err) {
 		response.NeedsLocation = true
+		if havePrices {
+			response.Nisab = buildNisab(prices, domain.PrayerProfile{})
+		}
 		return response, nil
 	}
 	if err != nil {
 		return bootstrapResponse{}, fmt.Errorf("load profile: %w", err)
+	}
+	if havePrices {
+		response.Nisab = buildNisab(prices, profile)
 	}
 	subscription, err := h.store.CalendarSubscription(ctx, identity.UserID)
 	if err == nil {
@@ -682,6 +710,41 @@ func formatSchedule(schedule domain.DaySchedule, profile domain.PrayerProfile, l
 		}
 	}
 	return result
+}
+
+func buildNisab(prices domain.MetalPrices, profile domain.PrayerProfile) *nisabResponse {
+	currencies := make([]string, 0, len(prices.Rates))
+	for code := range prices.Rates {
+		currencies = append(currencies, code)
+	}
+	sort.Strings(currencies)
+	return &nisabResponse{
+		GoldUSDPerOunce:   prices.GoldUSDPerOunce,
+		SilverUSDPerOunce: prices.SilverUSDPerOunce,
+		GoldGrams:         domain.NisabGoldGrams,
+		SilverGrams:       domain.NisabSilverGrams,
+		Rates:             prices.Rates,
+		Currencies:        currencies,
+		DefaultCurrency:   defaultCurrency(prices.Rates, profile),
+		FetchedAt:         prices.FetchedAt.UTC().Format(time.RFC3339),
+	}
+}
+
+// defaultCurrency picks the calculator's initial currency from the profile's
+// country (or timezone as a fallback for profiles saved before the country was
+// persisted), always yielding a currency present in the rate table.
+func defaultCurrency(rates map[string]float64, profile domain.PrayerProfile) string {
+	currency := location.CurrencyForCountry(profile.CountryCode)
+	if currency == "" {
+		currency = location.CurrencyForTimezone(profile.Timezone)
+	}
+	if currency == "" {
+		return "USD"
+	}
+	if _, ok := rates[currency]; !ok {
+		return "USD"
+	}
+	return currency
 }
 
 func options(locale i18n.Locale) optionsResponse {

--- a/global/internal/miniapp/handler_test.go
+++ b/global/internal/miniapp/handler_test.go
@@ -240,6 +240,113 @@ func TestBootstrapUsesSignedTelegramIdentityAndReturnsLocationGate(t *testing.T)
 	}
 }
 
+func TestBootstrapIncludesNisabWithCountryDefaultCurrency(t *testing.T) {
+	now := time.Date(2026, time.July, 17, 12, 0, 0, 0, time.UTC)
+	storage := newFakeStorage()
+	storage.chats[42] = domain.Chat{TelegramChatID: 42, Type: "private", LanguageCode: "en"}
+	storage.profiles[42] = domain.PrayerProfile{
+		ChatID: 42, Latitude: 30.044, Longitude: 31.236, Timezone: "Africa/Cairo",
+		CountryCode: "EG", Method: domain.MethodEgyptian, Madhab: domain.MadhabShafii,
+		HighLatitudeRule: domain.HighLatitudeAngleBased,
+	}
+	storage.metalPrices = &domain.MetalPrices{
+		GoldUSDPerOunce: 4053.7, SilverUSDPerOunce: 58.28,
+		Rates:     map[string]float64{"USD": 1, "EGP": 51.3, "TRY": 47.3},
+		FetchedAt: now,
+	}
+	handler := NewHandler("test-token", storage, nil, prayertime.New(), nil, nil)
+	handler.now = func() time.Time { return now }
+	mux := http.NewServeMux()
+	handler.Register(mux)
+
+	request := httptest.NewRequest(http.MethodPost, "/api/miniapp/bootstrap", nil)
+	request.Header.Set("X-Telegram-Init-Data", signedInitData(t, "test-token", now, initDataUser{
+		ID: 42, FirstName: "Amina", LanguageCode: "ar",
+	}))
+	response := httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	var data bootstrapResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &data); err != nil {
+		t.Fatal(err)
+	}
+	if data.Nisab == nil {
+		t.Fatal("expected niSab data in bootstrap response")
+	}
+	if data.Nisab.DefaultCurrency != "EGP" {
+		t.Fatalf("default currency = %q, want EGP", data.Nisab.DefaultCurrency)
+	}
+	if data.Nisab.GoldGrams != domain.NisabGoldGrams || data.Nisab.SilverGrams != domain.NisabSilverGrams {
+		t.Fatalf("unexpected niSab grams: %+v", data.Nisab)
+	}
+	if got := data.Nisab.Currencies; len(got) != 3 || got[0] != "EGP" || got[1] != "TRY" || got[2] != "USD" {
+		t.Fatalf("currencies not sorted as expected: %v", got)
+	}
+	if data.Nisab.Rates["EGP"] != 51.3 {
+		t.Fatalf("missing EGP rate: %+v", data.Nisab.Rates)
+	}
+}
+
+func TestBootstrapNisabFallsBackToUSDWithoutProfile(t *testing.T) {
+	now := time.Date(2026, time.July, 17, 12, 0, 0, 0, time.UTC)
+	storage := newFakeStorage()
+	storage.metalPrices = &domain.MetalPrices{
+		GoldUSDPerOunce: 4053.7, SilverUSDPerOunce: 58.28,
+		Rates:     map[string]float64{"USD": 1, "EGP": 51.3},
+		FetchedAt: now,
+	}
+	handler := NewHandler("test-token", storage, nil, nil, nil, nil)
+	handler.now = func() time.Time { return now }
+	mux := http.NewServeMux()
+	handler.Register(mux)
+
+	request := httptest.NewRequest(http.MethodPost, "/api/miniapp/bootstrap", nil)
+	request.Header.Set("X-Telegram-Init-Data", signedInitData(t, "test-token", now, initDataUser{
+		ID: 7, FirstName: "Yusuf", LanguageCode: "en",
+	}))
+	response := httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+
+	var data bootstrapResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &data); err != nil {
+		t.Fatal(err)
+	}
+	if !data.NeedsLocation {
+		t.Fatal("expected needs-location gate without a profile")
+	}
+	if data.Nisab == nil || data.Nisab.DefaultCurrency != "USD" {
+		t.Fatalf("expected niSab with USD default, got %+v", data.Nisab)
+	}
+}
+
+func TestLocationUpdatePersistsCountryCode(t *testing.T) {
+	now := time.Date(2026, time.July, 17, 12, 0, 0, 0, time.UTC)
+	storage := newFakeStorage()
+	storage.chats[42] = domain.Chat{TelegramChatID: 42, Type: "private", LanguageCode: "en"}
+	resolver := &fakeResolver{resolved: location.Resolved{
+		Timezone: "Africa/Cairo", PlaceID: "cairo", City: "Cairo", CountryCode: "EG",
+	}}
+	handler := NewHandler("test-token", storage, resolver, prayertime.New(), &fakePlanner{}, nil)
+	handler.now = func() time.Time { return now }
+	mux := http.NewServeMux()
+	handler.Register(mux)
+
+	request := httptest.NewRequest(http.MethodPut, "/api/miniapp/location", strings.NewReader(`{"latitude":30.04442,"longitude":31.23571}`))
+	request.Header.Set("X-Telegram-Init-Data", signedInitData(t, "test-token", now, initDataUser{ID: 42, FirstName: "Amina", LanguageCode: "en"}))
+	response := httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	if got := storage.profiles[42].CountryCode; got != "EG" {
+		t.Fatalf("stored country code = %q, want EG", got)
+	}
+}
+
 func TestLocationUpdatePreservesCalculationSettingsAndRoundsCoordinates(t *testing.T) {
 	now := time.Date(2026, time.July, 17, 12, 0, 0, 0, time.UTC)
 	storage := newFakeStorage()
@@ -547,6 +654,7 @@ type fakeStorage struct {
 	profiles      map[int64]domain.PrayerProfile
 	rules         map[int64][]domain.ReminderRule
 	subscriptions map[int64]domain.CalendarSubscription
+	metalPrices   *domain.MetalPrices
 }
 
 type fakePhotoSender struct {
@@ -616,6 +724,13 @@ func (s *fakeStorage) Profile(_ context.Context, chatID int64) (domain.PrayerPro
 func (s *fakeStorage) UpsertProfile(_ context.Context, profile domain.PrayerProfile) (domain.PrayerProfile, error) {
 	s.profiles[profile.ChatID] = profile
 	return profile, nil
+}
+
+func (s *fakeStorage) MetalPrices(_ context.Context) (domain.MetalPrices, error) {
+	if s.metalPrices == nil {
+		return domain.MetalPrices{}, pgx.ErrNoRows
+	}
+	return *s.metalPrices, nil
 }
 
 func (s *fakeStorage) EnabledRules(_ context.Context, chatID int64) ([]domain.ReminderRule, error) {

--- a/global/internal/store/postgres.go
+++ b/global/internal/store/postgres.go
@@ -323,11 +323,11 @@ func (s *Store) Profile(ctx context.Context, chatID int64) (domain.PrayerProfile
 	var adjustments []byte
 	err := s.pool.QueryRow(ctx, `
 		SELECT chat_id, latitude::float8, longitude::float8, timezone_id,
-		       google_place_id, user_location_label, method, madhab,
+		       google_place_id, user_location_label, country_code, method, madhab,
 		       high_latitude_rule, adjustments, hijri_adjustment, version, updated_at
 		FROM global_bot.prayer_profiles WHERE chat_id = $1`, chatID).Scan(
 		&profile.ChatID, &profile.Latitude, &profile.Longitude, &profile.Timezone,
-		&profile.PlaceID, &profile.LocationLabel, &method, &madhab,
+		&profile.PlaceID, &profile.LocationLabel, &profile.CountryCode, &method, &madhab,
 		&highLatitude, &adjustments, &profile.HijriAdjustment, &profile.Version, &profile.UpdatedAt,
 	)
 	if err != nil {
@@ -353,17 +353,18 @@ func (s *Store) UpsertProfile(ctx context.Context, profile domain.PrayerProfile)
 	err = s.pool.QueryRow(ctx, `
 		INSERT INTO global_bot.prayer_profiles
 			(chat_id, latitude, longitude, timezone_id, google_place_id, user_location_label,
-			 method, madhab, high_latitude_rule, adjustments, hijri_adjustment)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+			 country_code, method, madhab, high_latitude_rule, adjustments, hijri_adjustment)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 		ON CONFLICT (chat_id) DO UPDATE SET
 			latitude = excluded.latitude, longitude = excluded.longitude,
 			timezone_id = excluded.timezone_id, google_place_id = excluded.google_place_id,
-			user_location_label = excluded.user_location_label, method = excluded.method,
-			madhab = excluded.madhab, high_latitude_rule = excluded.high_latitude_rule,
+			user_location_label = excluded.user_location_label, country_code = excluded.country_code,
+			method = excluded.method, madhab = excluded.madhab,
+			high_latitude_rule = excluded.high_latitude_rule,
 			adjustments = excluded.adjustments, hijri_adjustment = excluded.hijri_adjustment,
 			version = global_bot.prayer_profiles.version + 1, updated_at = now()
 		RETURNING version, updated_at`, profile.ChatID, profile.Latitude, profile.Longitude,
-		profile.Timezone, profile.PlaceID, profile.LocationLabel, profile.Method,
+		profile.Timezone, profile.PlaceID, profile.LocationLabel, profile.CountryCode, profile.Method,
 		profile.Madhab, profile.HighLatitudeRule, adjustments, profile.HijriAdjustment).Scan(&profile.Version, &profile.UpdatedAt)
 	if err != nil {
 		return domain.PrayerProfile{}, err
@@ -648,6 +649,44 @@ func (s *Store) Cleanup(ctx context.Context, now time.Time, limit int) (int64, e
 		return updates.RowsAffected(), err
 	}
 	return updates.RowsAffected() + deliveries.RowsAffected(), nil
+}
+
+// MetalPrices returns the single cached precious-metal price row. It returns
+// pgx.ErrNoRows (see IsNotFound) until the maintenance job has fetched prices at
+// least once.
+func (s *Store) MetalPrices(ctx context.Context) (domain.MetalPrices, error) {
+	var prices domain.MetalPrices
+	var rates []byte
+	err := s.pool.QueryRow(ctx, `
+		SELECT gold_usd_per_ounce::float8, silver_usd_per_ounce::float8, rates, fetched_at
+		FROM global_bot.metal_prices WHERE id = 1`).Scan(
+		&prices.GoldUSDPerOunce, &prices.SilverUSDPerOunce, &rates, &prices.FetchedAt)
+	if err != nil {
+		return domain.MetalPrices{}, err
+	}
+	if err := json.Unmarshal(rates, &prices.Rates); err != nil {
+		return domain.MetalPrices{}, fmt.Errorf("decode currency rates: %w", err)
+	}
+	return prices, nil
+}
+
+// UpsertMetalPrices replaces the cached price row. fetched_at is stamped by the
+// database so a successful call always reflects when the data was persisted.
+func (s *Store) UpsertMetalPrices(ctx context.Context, prices domain.MetalPrices) error {
+	rates, err := marshalJSONText(prices.Rates)
+	if err != nil {
+		return err
+	}
+	_, err = s.pool.Exec(ctx, `
+		INSERT INTO global_bot.metal_prices
+			(id, gold_usd_per_ounce, silver_usd_per_ounce, rates, fetched_at)
+		VALUES (1, $1, $2, $3, now())
+		ON CONFLICT (id) DO UPDATE SET
+			gold_usd_per_ounce = excluded.gold_usd_per_ounce,
+			silver_usd_per_ounce = excluded.silver_usd_per_ounce,
+			rates = excluded.rates, fetched_at = now()`,
+		prices.GoldUSDPerOunce, prices.SilverUSDPerOunce, rates)
+	return err
 }
 
 func (s *Store) AcquireDelivery(ctx context.Context, task domain.DeliveryTask) (bool, error) {

--- a/global/internal/telegram/commands.go
+++ b/global/internal/telegram/commands.go
@@ -32,7 +32,7 @@ func (h *Handler) handleLocation(ctx context.Context, message *models.Message, l
 	latitude, longitude = domain.RoundedCoordinates(latitude, longitude)
 	profile := domain.PrayerProfile{
 		ChatID: message.Chat.ID, Latitude: latitude, Longitude: longitude,
-		Timezone: resolved.Timezone, PlaceID: resolved.PlaceID,
+		Timezone: resolved.Timezone, PlaceID: resolved.PlaceID, CountryCode: resolved.CountryCode,
 		Method: location.RecommendedMethod(resolved.CountryCode), Madhab: domain.MadhabShafii,
 		HighLatitudeRule: domain.HighLatitudeAngleBased,
 	}

--- a/global/migrations/00006_metal_prices_and_country.sql
+++ b/global/migrations/00006_metal_prices_and_country.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+-- +goose ENVSUB ON
+-- Persisted country code lets the Mini App default the Zakat calculator to the
+-- user's local currency without an extra geocoding request. It is written from
+-- the country already resolved on every location change, so it does not affect
+-- calculated prayer times and rides on the existing profile version bump.
+ALTER TABLE ${GLOBAL_DB_SCHEMA}.prayer_profiles
+    ADD COLUMN country_code TEXT NOT NULL DEFAULT '';
+
+-- A single shared row caches the daily gold/silver spot price (USD per troy
+-- ounce) and the USD-based currency rate table used to localize niSab. The
+-- CHECK (id = 1) constraint keeps it a singleton.
+CREATE TABLE ${GLOBAL_DB_SCHEMA}.metal_prices (
+    id SMALLINT PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+    gold_usd_per_ounce NUMERIC NOT NULL CHECK (gold_usd_per_ounce > 0),
+    silver_usd_per_ounce NUMERIC NOT NULL CHECK (silver_usd_per_ounce > 0),
+    rates JSONB NOT NULL,
+    fetched_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- +goose Down
+DROP TABLE ${GLOBAL_DB_SCHEMA}.metal_prices;
+
+ALTER TABLE ${GLOBAL_DB_SCHEMA}.prayer_profiles
+    DROP COLUMN country_code;
+-- +goose ENVSUB OFF


### PR DESCRIPTION
## What & why

Foundation for the Mini App **Zakat calculator**: a daily-cached gold/silver spot price and USD currency rate table, so the app can show the niṣāb threshold and compute zakat in the user's own currency — with **no new secret** (both upstreams are free and key-less) and **no new service or Scheduler job** (it rides on the existing daily `/maintenance` tick).

This PR is the **backend pipeline**. The calculator **UI** (app.js + 8-locale strings) is a stacked follow-up that only consumes the bootstrap fields added here.

## How it works

- **`migration 00006`** — singleton `metal_prices` table (`CHECK (id = 1)`) + nullable `prayer_profiles.country_code`.
- **`internal/metals`** — key-less fetcher: gold-api.com `XAU`/`XAG` (USD/oz) + open.er-api.com USD FX table, with validation (positive prices, USD-based rates).
- **`cmd/dispatch` `/maintenance`** — refreshes prices once a day, **best-effort**: any failure logs a warning and keeps the previously cached row, and never blocks retention cleanup. One shared row → user volume never affects upstream call counts (~60 calls/month total).
- **`internal/location`** — country→currency (+ timezone fallback) map for the default currency.
- **`internal/store`** — `MetalPrices`/`UpsertMetalPrices`; `country_code` read/write. Country is written from the **already-resolved** location, so no extra Google request and no profile-version churn (it doesn't affect prayer times).
- **Mini App bootstrap** — new `nisab` block: spot prices, the fixed **85 g gold / 595 g silver** thresholds, the rate table, a sorted currency list, and a **default currency derived from the profile's country** (timezone fallback for older profiles, USD otherwise). The Zakat math itself runs entirely in the browser. Omitted until the maintenance job has run once.

## niṣāb sourcing decisions (for reviewers)

- **Grams are the anchor** (currency-independent, always correct); the monetary value is a convenience layer.
- gold-api.com only covers ~9 major currencies (not EGP/TRY/PKR/RUB/…), so a separate **key-less USD FX feed** provides the currencies the audience actually uses.
- Most scholars use the lower **silver** threshold; the client will default to it (UI PR).

## Tests & docs

- New: `internal/metals` (httptest: success, non-USD base, non-positive price, upstream failure), `internal/location` currency mapping, Mini App bootstrap niṣāb (country default, USD fallback, `country_code` persistence).
- `gofmt` / `go vet` / `go test ./...` all clean.
- Docs updated in-PR: `data-model.md`, `request-flows.md`, `runtime-and-deployment.md`, `architecture.md`.

## Follow-ups
- Zakat calculator UI (app.js, index.html, app.css) + 8-locale strings.
- Optional owner-set niṣāb config value as an ultimate backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)