### PR TITLE
Upgrade global bot to Go 1.26

### DIFF
--- a/.github/workflows/global-ci.yaml
+++ b/.github/workflows/global-ci.yaml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
           cache-dependency-path: global/go.sum
       - run: gofmt -d cmd internal | tee /tmp/gofmt.diff && test ! -s /tmp/gofmt.diff
       - run: go vet ./...

--- a/.github/workflows/global-deploy.yaml
+++ b/.github/workflows/global-deploy.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
           cache-dependency-path: global/go.sum
 
       - uses: hashicorp/setup-terraform@v3

--- a/global/Dockerfile
+++ b/global/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.25-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod go mod download

--- a/global/go.mod
+++ b/global/go.mod
@@ -1,6 +1,6 @@
 module github.com/escalopa/prayer-bot/global
 
-go 1.25.0
+go 1.26.0
 
 require (
 	cloud.google.com/go/cloudtasks v1.13.6


### PR DESCRIPTION
## What & why

Migrates the **global bot** to the latest stable Go (**1.26**, currently go1.26.5) from Go 1.25.

Scope is **global-only** by request — the legacy city bots (`root` + `serverless/*` modules and `deploy.yaml`) stay on Go 1.25, consistent with the global-first doctrine in `CLAUDE.md`.

## Changes
- `global/go.mod` — `go 1.25.0` → `go 1.26.0`
- `global/Dockerfile` — `golang:1.25-alpine` → `golang:1.26-alpine`
- `.github/workflows/global-ci.yaml` — `go-version: '1.25.x'` → `'1.26.x'`
- `.github/workflows/global-deploy.yaml` — `go-version: '1.25.x'` → `'1.26.x'`

No source or dependency changes were required.

## Verification
On go1.26.5: `go build ./...`, `go vet ./...`, and `go test ./...` (all 16 packages) pass; `go mod verify` reports all modules verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)