### PR TITLE
Add Zakat calculator to the Mini App

### DIFF
--- a/global/internal/miniapp/handler.go
+++ b/global/internal/miniapp/handler.go
@@ -898,6 +898,11 @@ func labels(locale i18n.Locale) map[string]string {
 		"share_sent": copy.ShareSent, "share_failed": copy.ShareFailed,
 		"share_card_heading": copy.ShareCardHeading, "share_card_footer": copy.ShareCardFooter,
 		"share_message": copy.ShareMessage,
+		"zakat_title":   copy.ZakatTitle, "zakat_help": copy.ZakatHelp,
+		"zakat_currency": copy.ZakatCurrency, "zakat_holdings": copy.ZakatHoldings,
+		"zakat_nisab": copy.ZakatNisab, "zakat_nisab_note": copy.ZakatNisabNote,
+		"zakat_due": copy.ZakatDue, "zakat_below": copy.ZakatBelow,
+		"zakat_disclaimer": copy.ZakatDisclaimer, "zakat_updated": copy.ZakatUpdated,
 	}
 }
 
@@ -917,6 +922,9 @@ type miniAppCopy struct {
 	ShareTitle, ShareHelp, ShareAction, SharePreparing    string
 	ShareSent, ShareFailed                                string
 	ShareCardHeading, ShareCardFooter, ShareMessage       string
+	ZakatTitle, ZakatHelp, ZakatCurrency, ZakatHoldings   string
+	ZakatNisab, ZakatNisabNote, ZakatDue, ZakatBelow      string
+	ZakatDisclaimer, ZakatUpdated                         string
 }
 
 var miniCopy = map[string]miniAppCopy{
@@ -944,6 +952,12 @@ var miniCopy = map[string]miniAppCopy{
 		ShareSent: "Card sent to this bot chat. Open the chat to save or forward it.", ShareFailed: "The prayer card could not be created.",
 		ShareCardHeading: "Daily prayer times", ShareCardFooter: "Global Prayer Times",
 		ShareMessage: "Prayer times",
+		ZakatTitle:   "Zakat calculator", ZakatHelp: "Estimate zakat on your savings at 2.5% above the nisab.",
+		ZakatCurrency: "Currency", ZakatHoldings: "Your zakatable wealth",
+		ZakatNisab: "Nisab (minimum)", ZakatNisabNote: "Gold nisab {gold} · Silver nisab {silver}",
+		ZakatDue: "Zakat due (2.5%)", ZakatBelow: "Your wealth is below the nisab, so no zakat is due.",
+		ZakatDisclaimer: "Estimate based on live gold and silver prices. Consult a scholar for your situation.",
+		ZakatUpdated:    "Prices as of {date}",
 	},
 	"ar": {
 		Save: "حفظ التغييرات", Saved: "تم الحفظ", Loading: "جارٍ تحميل مواقيت الصلاة…",
@@ -969,6 +983,12 @@ var miniCopy = map[string]miniAppCopy{
 		ShareSent: "تم إرسال البطاقة إلى محادثة البوت. افتح المحادثة لحفظها أو إعادة توجيهها.", ShareFailed: "تعذر إنشاء بطاقة الصلاة.",
 		ShareCardHeading: "مواقيت الصلاة اليومية", ShareCardFooter: "مواقيت الصلاة العالمية",
 		ShareMessage: "مواقيت الصلاة",
+		ZakatTitle:   "حاسبة الزكاة", ZakatHelp: "احسب زكاة مالك بنسبة 2.5% إذا بلغ النصاب.",
+		ZakatCurrency: "العملة", ZakatHoldings: "أموالك الخاضعة للزكاة",
+		ZakatNisab: "النصاب (الحد الأدنى)", ZakatNisabNote: "نصاب الذهب {gold} · نصاب الفضة {silver}",
+		ZakatDue: "الزكاة المستحقة (2.5%)", ZakatBelow: "مالك دون النصاب، فلا زكاة عليك.",
+		ZakatDisclaimer: "تقدير بناءً على أسعار الذهب والفضة الحالية. استشر أهل العلم لحالتك.",
+		ZakatUpdated:    "الأسعار بتاريخ {date}",
 	},
 	"es": {
 		Save: "Guardar cambios", Saved: "Guardado", Loading: "Cargando horarios de oración…",
@@ -994,6 +1014,12 @@ var miniCopy = map[string]miniAppCopy{
 		ShareSent: "La tarjeta se envió al chat del bot. Abre el chat para guardarla o reenviarla.", ShareFailed: "No se pudo crear la tarjeta.",
 		ShareCardHeading: "Horarios diarios de oración", ShareCardFooter: "Horarios de oración globales",
 		ShareMessage: "Horarios de oración",
+		ZakatTitle:   "Calculadora de zakat", ZakatHelp: "Calcula el zakat de tus ahorros al 2,5% por encima del nisab.",
+		ZakatCurrency: "Moneda", ZakatHoldings: "Tu patrimonio sujeto al zakat",
+		ZakatNisab: "Nisab (mínimo)", ZakatNisabNote: "Nisab de oro {gold} · Nisab de plata {silver}",
+		ZakatDue: "Zakat a pagar (2,5%)", ZakatBelow: "Tu patrimonio está por debajo del nisab, así que no debes zakat.",
+		ZakatDisclaimer: "Estimación basada en precios actuales del oro y la plata. Consulta a un experto para tu caso.",
+		ZakatUpdated:    "Precios al {date}",
 	},
 	"fr": {
 		Save: "Enregistrer", Saved: "Enregistré", Loading: "Chargement des horaires de prière…",
@@ -1019,6 +1045,12 @@ var miniCopy = map[string]miniAppCopy{
 		ShareSent: "La carte a été envoyée dans le chat du bot. Ouvrez le chat pour l’enregistrer ou la transférer.", ShareFailed: "Impossible de créer la carte.",
 		ShareCardHeading: "Horaires de prière du jour", ShareCardFooter: "Horaires de prière mondiaux",
 		ShareMessage: "Horaires de prière",
+		ZakatTitle:   "Calculateur de zakat", ZakatHelp: "Estimez la zakat sur votre épargne à 2,5% au-dessus du nisab.",
+		ZakatCurrency: "Devise", ZakatHoldings: "Votre patrimoine soumis à la zakat",
+		ZakatNisab: "Nisab (minimum)", ZakatNisabNote: "Nisab or {gold} · Nisab argent {silver}",
+		ZakatDue: "Zakat à verser (2,5%)", ZakatBelow: "Votre patrimoine est inférieur au nisab, aucune zakat n’est due.",
+		ZakatDisclaimer: "Estimation basée sur les cours actuels de l’or et de l’argent. Consultez un savant pour votre cas.",
+		ZakatUpdated:    "Cours au {date}",
 	},
 	"ru": {
 		Save: "Сохранить", Saved: "Сохранено", Loading: "Загружаем время намаза…",
@@ -1044,6 +1076,12 @@ var miniCopy = map[string]miniAppCopy{
 		ShareSent: "Карточка отправлена в чат с ботом. Откройте чат, чтобы сохранить или переслать её.", ShareFailed: "Не удалось создать карточку.",
 		ShareCardHeading: "Время намаза на день", ShareCardFooter: "Global Prayer Times",
 		ShareMessage: "Время намаза",
+		ZakatTitle:   "Калькулятор закята", ZakatHelp: "Рассчитайте закят с накоплений — 2,5% при достижении нисаба.",
+		ZakatCurrency: "Валюта", ZakatHoldings: "Ваше имущество, облагаемое закятом",
+		ZakatNisab: "Нисаб (минимум)", ZakatNisabNote: "Нисаб золота {gold} · Нисаб серебра {silver}",
+		ZakatDue: "Закят к выплате (2,5%)", ZakatBelow: "Ваше имущество ниже нисаба, поэтому закят не обязателен.",
+		ZakatDisclaimer: "Оценка на основе текущих цен на золото и серебро. Обратитесь к знающему для вашего случая.",
+		ZakatUpdated:    "Цены на {date}",
 	},
 	"tr": {
 		Save: "Değişiklikleri kaydet", Saved: "Kaydedildi", Loading: "Namaz vakitleri yükleniyor…",
@@ -1069,6 +1107,12 @@ var miniCopy = map[string]miniAppCopy{
 		ShareSent: "Kart bot sohbetine gönderildi. Kaydetmek veya iletmek için sohbeti açın.", ShareFailed: "Namaz kartı oluşturulamadı.",
 		ShareCardHeading: "Günlük namaz vakitleri", ShareCardFooter: "Global Namaz Vakitleri",
 		ShareMessage: "Namaz vakitleri",
+		ZakatTitle:   "Zekât hesaplayıcı", ZakatHelp: "Nisabı aşan birikiminiz için %2,5 zekâtı hesaplayın.",
+		ZakatCurrency: "Para birimi", ZakatHoldings: "Zekâta tabi malınız",
+		ZakatNisab: "Nisap (asgari)", ZakatNisabNote: "Altın nisabı {gold} · Gümüş nisabı {silver}",
+		ZakatDue: "Ödenecek zekât (%2,5)", ZakatBelow: "Malınız nisabın altında, bu yüzden zekât gerekmez.",
+		ZakatDisclaimer: "Güncel altın ve gümüş fiyatlarına dayalı tahmin. Durumunuz için bir âlime danışın.",
+		ZakatUpdated:    "{date} tarihli fiyatlar",
 	},
 	"uz": {
 		Save: "O‘zgarishlarni saqlash", Saved: "Saqlandi", Loading: "Namoz vaqtlari yuklanmoqda…",
@@ -1094,6 +1138,12 @@ var miniCopy = map[string]miniAppCopy{
 		ShareSent: "Karta bot chatiga yuborildi. Saqlash yoki ulashish uchun chatni oching.", ShareFailed: "Namoz kartasini yaratib bo‘lmadi.",
 		ShareCardHeading: "Kunlik namoz vaqtlari", ShareCardFooter: "Global Namoz Vaqtlari",
 		ShareMessage: "Namoz vaqtlari",
+		ZakatTitle:   "Zakot kalkulyatori", ZakatHelp: "Nisobdan oshgan jamg‘armangizdan 2,5% zakotni hisoblang.",
+		ZakatCurrency: "Valyuta", ZakatHoldings: "Zakotga tortiladigan mol-mulkingiz",
+		ZakatNisab: "Nisob (eng kam miqdor)", ZakatNisabNote: "Oltin nisobi {gold} · Kumush nisobi {silver}",
+		ZakatDue: "To‘lanadigan zakot (2,5%)", ZakatBelow: "Mol-mulkingiz nisobdan kam, shuning uchun zakot vojib emas.",
+		ZakatDisclaimer: "Joriy oltin va kumush narxlariga asoslangan taxmin. Holatingiz uchun olimga murojaat qiling.",
+		ZakatUpdated:    "{date} holatidagi narxlar",
 	},
 	"tt": {
 		Save: "Үзгәрешләрне саклау", Saved: "Сакланды", Loading: "Намаз вакытлары йөкләнә…",
@@ -1119,5 +1169,11 @@ var miniCopy = map[string]miniAppCopy{
 		ShareSent: "Карточка бот чатына җибәрелде. Саклау яки җибәрү өчен чатны ачыгыз.", ShareFailed: "Намаз карточкасын ясап булмады.",
 		ShareCardHeading: "Көнлек намаз вакытлары", ShareCardFooter: "Глобаль намаз вакытлары",
 		ShareMessage: "Намаз вакытлары",
+		ZakatTitle:   "Зәкят исәпләгече", ZakatHelp: "Нисабтан артык җыемыгыздан 2,5% зәкятне исәпләгез.",
+		ZakatCurrency: "Валюта", ZakatHoldings: "Зәкятка керә торган мал-мөлкәтегез",
+		ZakatNisab: "Нисаб (минимум)", ZakatNisabNote: "Алтын нисабы {gold} · Көмеш нисабы {silver}",
+		ZakatDue: "Түләнәсе зәкят (2,5%)", ZakatBelow: "Мал-мөлкәтегез нисабтан ким, шуңа зәкят фарыз түгел.",
+		ZakatDisclaimer: "Хәзерге алтын һәм көмеш бәяләренә нигезләнгән бәя. Хәлегез өчен галимгә мөрәҗәгать итегез.",
+		ZakatUpdated:    "{date} көненә бәяләр",
 	},
 }

--- a/global/internal/miniapp/handler_test.go
+++ b/global/internal/miniapp/handler_test.go
@@ -105,6 +105,39 @@ func TestOfflineAndSharingLabelsExistForEveryLocale(t *testing.T) {
 	}
 }
 
+func TestZakatCalculatorMarkupAndLabelsExist(t *testing.T) {
+	html, err := embeddedStatic.ReadFile("static/index.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"zakat-panel", "zakat-currency", "zakat-holdings", "zakat-nisab-value", "zakat-due-value"} {
+		if !strings.Contains(string(html), id) {
+			t.Errorf("index.html is missing Zakat calculator element %q", id)
+		}
+	}
+	script, err := embeddedStatic.ReadFile("static/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, hook := range []string{"renderZakat", "state.nisab", "Intl.DisplayNames", "* 0.025"} {
+		if !strings.Contains(string(script), hook) {
+			t.Errorf("app.js is missing Zakat calculator logic %q", hook)
+		}
+	}
+	keys := []string{
+		"zakat_title", "zakat_help", "zakat_currency", "zakat_holdings", "zakat_nisab",
+		"zakat_nisab_note", "zakat_due", "zakat_below", "zakat_disclaimer", "zakat_updated",
+	}
+	for _, locale := range i18n.Supported() {
+		localized := labels(locale)
+		for _, key := range keys {
+			if localized[key] == "" {
+				t.Errorf("locale %q has no %q label", locale.Code, key)
+			}
+		}
+	}
+}
+
 func TestMiniAppAPIRejectsUnsignedRequests(t *testing.T) {
 	handler := NewHandler("token", nil, nil, nil, nil, nil)
 	mux := http.NewServeMux()

--- a/global/internal/miniapp/static/app.css
+++ b/global/internal/miniapp/static/app.css
@@ -383,6 +383,18 @@ select:focus, input[type="number"]:focus { border-color: var(--accent); box-shad
 .adjustment-grid label { color: var(--app-muted); font-size: 11px; }
 .adjustment-grid input { margin-top: 5px; text-align: center; }
 
+.zakat-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
+.zakat-form { display: grid; gap: 13px; margin-top: 4px; }
+.zakat-form label { display: grid; gap: 7px; color: var(--app-muted); font-size: 12px; font-weight: 650; }
+.zakat-summary { margin-top: 15px; padding: 15px 16px; border: 1px solid var(--line); border-radius: 16px; background: color-mix(in srgb, var(--surface-alt) 55%, transparent); }
+.zakat-row { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; }
+.zakat-row span { color: var(--app-muted); font-size: 13px; font-weight: 650; }
+.zakat-amount { font-size: 17px; font-weight: 800; }
+.zakat-due-row { margin-top: 12px; padding-top: 12px; border-top: 1px solid var(--line); }
+.zakat-due-amount { color: var(--accent); font-size: 20px; }
+.zakat-status { margin: 8px 0 0; }
+.zakat-updated { margin: 10px 0 0; font-size: 10px; }
+
 .primary-button { width: 100%; min-height: 50px; padding: 0 18px; border: 0; border-radius: 16px; color: var(--accent-text); background: var(--accent); font-weight: 800; cursor: pointer; box-shadow: 0 10px 24px color-mix(in srgb, var(--accent) 24%, transparent); }
 .primary-button:disabled { opacity: .55; cursor: wait; }
 .primary-button.compact { min-height: 44px; border-radius: 14px; box-shadow: none; font-size: 13px; }
@@ -405,6 +417,7 @@ select:focus, input[type="number"]:focus { border-color: var(--accent); box-shad
 @media (min-width: 560px) {
   .app-shell { padding-inline: 24px; }
   .form-grid { grid-template-columns: 1fr 1fr; }
+  .zakat-form { grid-template-columns: 1fr 1fr; }
   .tool-grid { grid-template-columns: 1fr 1fr; }
 }
 

--- a/global/internal/miniapp/static/app.js
+++ b/global/internal/miniapp/static/app.js
@@ -11,6 +11,8 @@
   let calendarFeedURL = "";
   let offlineMode = false;
   let homeScreenStatus = "unknown";
+  let zakatCurrency = "";
+  const troyOunceGrams = 31.1035;
   const offlineCacheVersion = 2;
   const offlineCacheMaxAge = 48 * 60 * 60 * 1000;
 
@@ -223,6 +225,13 @@
     setText("share-card-title", labels.share_title);
     setText("share-card-help", labels.share_help);
     setText("share-prayer-card", labels.share_action);
+    setText("zakat-title", labels.zakat_title);
+    setText("zakat-help", labels.zakat_help);
+    setText("zakat-currency-label", labels.zakat_currency);
+    setText("zakat-holdings-label", labels.zakat_holdings);
+    setText("zakat-nisab-label", labels.zakat_nisab);
+    setText("zakat-due-label", labels.zakat_due);
+    setText("zakat-disclaimer", labels.zakat_disclaimer);
   }
 
   function fillSelect(id, options, selected) {
@@ -437,6 +446,82 @@
     byId("pre-prayer-minutes").disabled = !byId("prayer-reminders").checked;
   }
 
+  function zakatCurrencyKey() {
+    const userID = telegramUserID();
+    return userID ? `global-prayer-zakat-currency-${userID}` : "";
+  }
+
+  function currencyName(code) {
+    try {
+      const name = new Intl.DisplayNames([state.locale], { type: "currency" }).of(code);
+      return name && name !== code ? `${code} · ${name}` : code;
+    } catch (_) {
+      return code;
+    }
+  }
+
+  function formatMoney(amount, currency) {
+    try {
+      return new Intl.NumberFormat(state.locale, {
+        style: "currency", currency, maximumFractionDigits: 2,
+      }).format(amount);
+    } catch (_) {
+      return `${new Intl.NumberFormat(state.locale, { maximumFractionDigits: 2 }).format(amount)} ${currency}`;
+    }
+  }
+
+  function nisabValue(nisab, grams, usdPerOunce, currency) {
+    const rate = Number(nisab.rates[currency]) || 1;
+    return (grams / troyOunceGrams) * usdPerOunce * rate;
+  }
+
+  function renderZakat() {
+    const panel = byId("zakat-panel");
+    const nisab = state.nisab;
+    if (!nisab || !Array.isArray(nisab.currencies) || nisab.currencies.length === 0) {
+      panel.classList.add("hidden");
+      return;
+    }
+    panel.classList.remove("hidden");
+    if (!zakatCurrency || !nisab.rates[zakatCurrency]) zakatCurrency = nisab.default_currency;
+    const select = byId("zakat-currency");
+    select.replaceChildren();
+    nisab.currencies.forEach((code) => {
+      const option = document.createElement("option");
+      option.value = code;
+      option.textContent = currencyName(code);
+      option.selected = code === zakatCurrency;
+      select.append(option);
+    });
+    if (nisab.fetched_at) {
+      const date = new Intl.DateTimeFormat(state.locale, { dateStyle: "medium" }).format(new Date(nisab.fetched_at));
+      setText("zakat-updated", formatLabel(state.labels.zakat_updated, { date }));
+    } else {
+      setText("zakat-updated", "");
+    }
+    renderZakatResult();
+  }
+
+  function renderZakatResult() {
+    const nisab = state && state.nisab;
+    if (!nisab) return;
+    const currency = zakatCurrency;
+    const gold = nisabValue(nisab, nisab.gold_grams, nisab.gold_usd_per_ounce, currency);
+    const silver = nisabValue(nisab, nisab.silver_grams, nisab.silver_usd_per_ounce, currency);
+    // The lower (usually silver) threshold is the applicable niSab in the
+    // majority view, so more wealth qualifies for zakat.
+    const threshold = Math.min(gold, silver);
+    setText("zakat-nisab-value", formatMoney(threshold, currency));
+    setText("zakat-nisab-note", formatLabel(state.labels.zakat_nisab_note, {
+      gold: formatMoney(gold, currency), silver: formatMoney(silver, currency),
+    }));
+    const holdings = Number(byId("zakat-holdings").value);
+    const wealth = Number.isFinite(holdings) && holdings > 0 ? holdings : 0;
+    const due = wealth >= threshold ? wealth * 0.025 : 0;
+    setText("zakat-due-value", formatMoney(due, currency));
+    setText("zakat-status", wealth > 0 && wealth < threshold ? state.labels.zakat_below : "");
+  }
+
   function applyState(next) {
     state = next;
     loading.classList.add("hidden");
@@ -454,6 +539,7 @@
     renderSchedule();
     renderTools();
     renderOccasions();
+    renderZakat();
     renderReminders();
     renderSettings();
     setDirty(false);
@@ -930,6 +1016,7 @@
       return;
     }
     standalone.classList.add("hidden");
+    if (!zakatCurrency) zakatCurrency = await readStoredValue(zakatCurrencyKey());
     const cached = await cachedState();
     if (cached) {
       applyState(cached.state);
@@ -983,6 +1070,12 @@
     .forEach((id) => byId(id).addEventListener("change", () => setDirty(true)));
   byId("prayer-reminders").addEventListener("change", syncPreReminderAvailability);
   byId("adjustment-grid").addEventListener("input", () => setDirty(true));
+  byId("zakat-currency").addEventListener("change", () => {
+    zakatCurrency = byId("zakat-currency").value;
+    void writeStoredValue(zakatCurrencyKey(), zakatCurrency);
+    renderZakatResult();
+  });
+  byId("zakat-holdings").addEventListener("input", renderZakatResult);
   window.addEventListener("pageshow", (event) => {
     if (event.persisted) bootstrapApp();
   });

--- a/global/internal/miniapp/static/index.html
+++ b/global/internal/miniapp/static/index.html
@@ -165,6 +165,36 @@
         </div>
       </section>
 
+      <section id="zakat-panel" class="panel zakat-panel hidden">
+        <div class="panel-heading zakat-heading">
+          <div>
+            <h2 id="zakat-title">Zakat calculator</h2>
+            <p id="zakat-help" class="panel-help">Calculate zakat on your wealth.</p>
+          </div>
+          <span class="section-icon" aria-hidden="true">💰</span>
+        </div>
+        <div class="zakat-form">
+          <label><span id="zakat-currency-label">Currency</span>
+            <select id="zakat-currency"></select></label>
+          <label><span id="zakat-holdings-label">Your zakatable wealth</span>
+            <input id="zakat-holdings" type="number" min="0" step="any" inputmode="decimal" placeholder="0"></label>
+        </div>
+        <div class="zakat-summary">
+          <div class="zakat-row">
+            <span id="zakat-nisab-label">Niṣāb (minimum)</span>
+            <strong id="zakat-nisab-value" class="zakat-amount"></strong>
+          </div>
+          <p id="zakat-nisab-note" class="tool-note"></p>
+          <div class="zakat-row zakat-due-row">
+            <span id="zakat-due-label">Zakat due (2.5%)</span>
+            <strong id="zakat-due-value" class="zakat-amount zakat-due-amount"></strong>
+          </div>
+          <p id="zakat-status" class="tool-note zakat-status"></p>
+        </div>
+        <p id="zakat-disclaimer" class="occasion-disclaimer"></p>
+        <p id="zakat-updated" class="tool-note zakat-updated"></p>
+      </section>
+
       <section class="panel">
         <div class="panel-heading">
           <h2 id="reminders-title">Reminders</h2>

--- a/global/internal/miniapp/static/sw.js
+++ b/global/internal/miniapp/static/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const cacheName = "global-prayer-miniapp-shell-v3";
+const cacheName = "global-prayer-miniapp-shell-v4";
 const shellAssets = [
   "./",
   "./app.css",


### PR DESCRIPTION
## What & why

Makes the Zakat feature **visible in the app**. PR #55 shipped the niṣāb price/currency backend; this adds the Mini App UI that consumes it.

## What it does
A new **Zakat** panel in the Mini App:
- **Currency selector** populated from the bootstrap `nisab.currencies`, with names via `Intl.DisplayNames` and amounts via `Intl.NumberFormat` (both localized) — no backend currency-name table.
- **Niṣāb readout** computed client-side from the fixed **85 g gold / 595 g silver** thresholds and the cached spot prices; the **lower (silver)** threshold applies, per the majority view.
- **Holdings input** → **zakat due (2.5%)**, with a "below niṣāb" message when applicable.
- **Disclaimer** ("estimate; consult a scholar") and a "prices as of {date}" line.

## Design notes
- **Entirely client-side**: reads the `nisab` block from the existing bootstrap; no new endpoint, no server round-trip, works from the offline snapshot.
- **Currency override** is remembered per-user in Telegram Device Storage / localStorage, defaulting to the profile's country-derived currency (from #55). It **never marks settings dirty** and never calls the server.
- **`sw.js` cache bumped to v4** so clients actually fetch the new shell.
- i18n: `zakat_*` labels added for all 8 locales.

## Tests
Added coverage for the calculator markup, the app.js logic hooks (`renderZakat`, `state.nisab`, `Intl.DisplayNames`, `* 0.025`), and per-locale label completeness. `gofmt` / `go vet` / `go test ./...` clean on Go 1.26.

## Deploy note
The panel only appears once the daily `/maintenance` job has populated `metal_prices` (force it with `gcloud scheduler jobs run global-prayer-<env>-maintenance --location=europe-west1`), and the currency defaults to the user's country after they set/re-set location.

## Follow-ups
The pure-math calculators (Zakat al-Fiṭr, fidya/kaffāra, mīrāth) can be added to this panel later — they need no backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)