### PR TITLE
Improve Mini App layout: section nav & niṣāb readability

### DIFF
--- a/global/internal/miniapp/handler.go
+++ b/global/internal/miniapp/handler.go
@@ -903,6 +903,7 @@ func labels(locale i18n.Locale) map[string]string {
 		"zakat_nisab": copy.ZakatNisab, "zakat_nisab_note": copy.ZakatNisabNote,
 		"zakat_due": copy.ZakatDue, "zakat_below": copy.ZakatBelow,
 		"zakat_disclaimer": copy.ZakatDisclaimer, "zakat_updated": copy.ZakatUpdated,
+		"nav_prayer": copy.NavPrayer, "nav_dates": copy.NavDates, "nav_zakat": copy.NavZakat,
 	}
 }
 
@@ -925,6 +926,7 @@ type miniAppCopy struct {
 	ZakatTitle, ZakatHelp, ZakatCurrency, ZakatHoldings   string
 	ZakatNisab, ZakatNisabNote, ZakatDue, ZakatBelow      string
 	ZakatDisclaimer, ZakatUpdated                         string
+	NavPrayer, NavDates, NavZakat                         string
 }
 
 var miniCopy = map[string]miniAppCopy{
@@ -954,10 +956,11 @@ var miniCopy = map[string]miniAppCopy{
 		ShareMessage: "Prayer times",
 		ZakatTitle:   "Zakat calculator", ZakatHelp: "Estimate zakat on your savings at 2.5% above the nisab.",
 		ZakatCurrency: "Currency", ZakatHoldings: "Your zakatable wealth",
-		ZakatNisab: "Nisab (minimum)", ZakatNisabNote: "Gold nisab {gold} · Silver nisab {silver}",
+		ZakatNisab: "Nisab (minimum)", ZakatNisabNote: "Gold nisab {gold}\nSilver nisab {silver}",
 		ZakatDue: "Zakat due (2.5%)", ZakatBelow: "Your wealth is below the nisab, so no zakat is due.",
 		ZakatDisclaimer: "Estimate based on live gold and silver prices. Consult a scholar for your situation.",
 		ZakatUpdated:    "Prices as of {date}",
+		NavPrayer:       "Prayer", NavDates: "Dates", NavZakat: "Zakat",
 	},
 	"ar": {
 		Save: "حفظ التغييرات", Saved: "تم الحفظ", Loading: "جارٍ تحميل مواقيت الصلاة…",
@@ -985,10 +988,11 @@ var miniCopy = map[string]miniAppCopy{
 		ShareMessage: "مواقيت الصلاة",
 		ZakatTitle:   "حاسبة الزكاة", ZakatHelp: "احسب زكاة مالك بنسبة 2.5% إذا بلغ النصاب.",
 		ZakatCurrency: "العملة", ZakatHoldings: "أموالك الخاضعة للزكاة",
-		ZakatNisab: "النصاب (الحد الأدنى)", ZakatNisabNote: "نصاب الذهب {gold} · نصاب الفضة {silver}",
+		ZakatNisab: "النصاب (الحد الأدنى)", ZakatNisabNote: "نصاب الذهب {gold}\nنصاب الفضة {silver}",
 		ZakatDue: "الزكاة المستحقة (2.5%)", ZakatBelow: "مالك دون النصاب، فلا زكاة عليك.",
 		ZakatDisclaimer: "تقدير بناءً على أسعار الذهب والفضة الحالية. استشر أهل العلم لحالتك.",
 		ZakatUpdated:    "الأسعار بتاريخ {date}",
+		NavPrayer:       "الصلاة", NavDates: "المناسبات", NavZakat: "الزكاة",
 	},
 	"es": {
 		Save: "Guardar cambios", Saved: "Guardado", Loading: "Cargando horarios de oración…",
@@ -1016,10 +1020,11 @@ var miniCopy = map[string]miniAppCopy{
 		ShareMessage: "Horarios de oración",
 		ZakatTitle:   "Calculadora de zakat", ZakatHelp: "Calcula el zakat de tus ahorros al 2,5% por encima del nisab.",
 		ZakatCurrency: "Moneda", ZakatHoldings: "Tu patrimonio sujeto al zakat",
-		ZakatNisab: "Nisab (mínimo)", ZakatNisabNote: "Nisab de oro {gold} · Nisab de plata {silver}",
+		ZakatNisab: "Nisab (mínimo)", ZakatNisabNote: "Nisab de oro {gold}\nNisab de plata {silver}",
 		ZakatDue: "Zakat a pagar (2,5%)", ZakatBelow: "Tu patrimonio está por debajo del nisab, así que no debes zakat.",
 		ZakatDisclaimer: "Estimación basada en precios actuales del oro y la plata. Consulta a un experto para tu caso.",
 		ZakatUpdated:    "Precios al {date}",
+		NavPrayer:       "Oración", NavDates: "Fechas", NavZakat: "Zakat",
 	},
 	"fr": {
 		Save: "Enregistrer", Saved: "Enregistré", Loading: "Chargement des horaires de prière…",
@@ -1047,10 +1052,11 @@ var miniCopy = map[string]miniAppCopy{
 		ShareMessage: "Horaires de prière",
 		ZakatTitle:   "Calculateur de zakat", ZakatHelp: "Estimez la zakat sur votre épargne à 2,5% au-dessus du nisab.",
 		ZakatCurrency: "Devise", ZakatHoldings: "Votre patrimoine soumis à la zakat",
-		ZakatNisab: "Nisab (minimum)", ZakatNisabNote: "Nisab or {gold} · Nisab argent {silver}",
+		ZakatNisab: "Nisab (minimum)", ZakatNisabNote: "Nisab or {gold}\nNisab argent {silver}",
 		ZakatDue: "Zakat à verser (2,5%)", ZakatBelow: "Votre patrimoine est inférieur au nisab, aucune zakat n’est due.",
 		ZakatDisclaimer: "Estimation basée sur les cours actuels de l’or et de l’argent. Consultez un savant pour votre cas.",
 		ZakatUpdated:    "Cours au {date}",
+		NavPrayer:       "Prière", NavDates: "Dates", NavZakat: "Zakat",
 	},
 	"ru": {
 		Save: "Сохранить", Saved: "Сохранено", Loading: "Загружаем время намаза…",
@@ -1078,10 +1084,11 @@ var miniCopy = map[string]miniAppCopy{
 		ShareMessage: "Время намаза",
 		ZakatTitle:   "Калькулятор закята", ZakatHelp: "Рассчитайте закят с накоплений — 2,5% при достижении нисаба.",
 		ZakatCurrency: "Валюта", ZakatHoldings: "Ваше имущество, облагаемое закятом",
-		ZakatNisab: "Нисаб (минимум)", ZakatNisabNote: "Нисаб золота {gold} · Нисаб серебра {silver}",
+		ZakatNisab: "Нисаб (минимум)", ZakatNisabNote: "Нисаб золота {gold}\nНисаб серебра {silver}",
 		ZakatDue: "Закят к выплате (2,5%)", ZakatBelow: "Ваше имущество ниже нисаба, поэтому закят не обязателен.",
 		ZakatDisclaimer: "Оценка на основе текущих цен на золото и серебро. Обратитесь к знающему для вашего случая.",
 		ZakatUpdated:    "Цены на {date}",
+		NavPrayer:       "Намаз", NavDates: "Даты", NavZakat: "Закят",
 	},
 	"tr": {
 		Save: "Değişiklikleri kaydet", Saved: "Kaydedildi", Loading: "Namaz vakitleri yükleniyor…",
@@ -1109,10 +1116,11 @@ var miniCopy = map[string]miniAppCopy{
 		ShareMessage: "Namaz vakitleri",
 		ZakatTitle:   "Zekât hesaplayıcı", ZakatHelp: "Nisabı aşan birikiminiz için %2,5 zekâtı hesaplayın.",
 		ZakatCurrency: "Para birimi", ZakatHoldings: "Zekâta tabi malınız",
-		ZakatNisab: "Nisap (asgari)", ZakatNisabNote: "Altın nisabı {gold} · Gümüş nisabı {silver}",
+		ZakatNisab: "Nisap (asgari)", ZakatNisabNote: "Altın nisabı {gold}\nGümüş nisabı {silver}",
 		ZakatDue: "Ödenecek zekât (%2,5)", ZakatBelow: "Malınız nisabın altında, bu yüzden zekât gerekmez.",
 		ZakatDisclaimer: "Güncel altın ve gümüş fiyatlarına dayalı tahmin. Durumunuz için bir âlime danışın.",
 		ZakatUpdated:    "{date} tarihli fiyatlar",
+		NavPrayer:       "Namaz", NavDates: "Günler", NavZakat: "Zekât",
 	},
 	"uz": {
 		Save: "O‘zgarishlarni saqlash", Saved: "Saqlandi", Loading: "Namoz vaqtlari yuklanmoqda…",
@@ -1140,10 +1148,11 @@ var miniCopy = map[string]miniAppCopy{
 		ShareMessage: "Namoz vaqtlari",
 		ZakatTitle:   "Zakot kalkulyatori", ZakatHelp: "Nisobdan oshgan jamg‘armangizdan 2,5% zakotni hisoblang.",
 		ZakatCurrency: "Valyuta", ZakatHoldings: "Zakotga tortiladigan mol-mulkingiz",
-		ZakatNisab: "Nisob (eng kam miqdor)", ZakatNisabNote: "Oltin nisobi {gold} · Kumush nisobi {silver}",
+		ZakatNisab: "Nisob (eng kam miqdor)", ZakatNisabNote: "Oltin nisobi {gold}\nKumush nisobi {silver}",
 		ZakatDue: "To‘lanadigan zakot (2,5%)", ZakatBelow: "Mol-mulkingiz nisobdan kam, shuning uchun zakot vojib emas.",
 		ZakatDisclaimer: "Joriy oltin va kumush narxlariga asoslangan taxmin. Holatingiz uchun olimga murojaat qiling.",
 		ZakatUpdated:    "{date} holatidagi narxlar",
+		NavPrayer:       "Namoz", NavDates: "Sanalar", NavZakat: "Zakot",
 	},
 	"tt": {
 		Save: "Үзгәрешләрне саклау", Saved: "Сакланды", Loading: "Намаз вакытлары йөкләнә…",
@@ -1171,9 +1180,10 @@ var miniCopy = map[string]miniAppCopy{
 		ShareMessage: "Намаз вакытлары",
 		ZakatTitle:   "Зәкят исәпләгече", ZakatHelp: "Нисабтан артык җыемыгыздан 2,5% зәкятне исәпләгез.",
 		ZakatCurrency: "Валюта", ZakatHoldings: "Зәкятка керә торган мал-мөлкәтегез",
-		ZakatNisab: "Нисаб (минимум)", ZakatNisabNote: "Алтын нисабы {gold} · Көмеш нисабы {silver}",
+		ZakatNisab: "Нисаб (минимум)", ZakatNisabNote: "Алтын нисабы {gold}\nКөмеш нисабы {silver}",
 		ZakatDue: "Түләнәсе зәкят (2,5%)", ZakatBelow: "Мал-мөлкәтегез нисабтан ким, шуңа зәкят фарыз түгел.",
 		ZakatDisclaimer: "Хәзерге алтын һәм көмеш бәяләренә нигезләнгән бәя. Хәлегез өчен галимгә мөрәҗәгать итегез.",
 		ZakatUpdated:    "{date} көненә бәяләр",
+		NavPrayer:       "Намаз", NavDates: "Даталар", NavZakat: "Зәкят",
 	},
 }

--- a/global/internal/miniapp/handler_test.go
+++ b/global/internal/miniapp/handler_test.go
@@ -115,18 +115,24 @@ func TestZakatCalculatorMarkupAndLabelsExist(t *testing.T) {
 			t.Errorf("index.html is missing Zakat calculator element %q", id)
 		}
 	}
+	for _, marker := range []string{"tab-bar", "view-prayer", "view-zakat", "data-view=\"prayer\""} {
+		if !strings.Contains(string(html), marker) {
+			t.Errorf("index.html is missing section navigation marker %q", marker)
+		}
+	}
 	script, err := embeddedStatic.ReadFile("static/app.js")
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, hook := range []string{"renderZakat", "state.nisab", "Intl.DisplayNames", "* 0.025"} {
+	for _, hook := range []string{"renderZakat", "state.nisab", "Intl.DisplayNames", "* 0.025", "function selectView"} {
 		if !strings.Contains(string(script), hook) {
-			t.Errorf("app.js is missing Zakat calculator logic %q", hook)
+			t.Errorf("app.js is missing Zakat calculator or navigation logic %q", hook)
 		}
 	}
 	keys := []string{
 		"zakat_title", "zakat_help", "zakat_currency", "zakat_holdings", "zakat_nisab",
 		"zakat_nisab_note", "zakat_due", "zakat_below", "zakat_disclaimer", "zakat_updated",
+		"nav_prayer", "nav_dates", "nav_zakat",
 	}
 	for _, locale := range i18n.Supported() {
 		localized := labels(locale)

--- a/global/internal/miniapp/static/app.css
+++ b/global/internal/miniapp/static/app.css
@@ -30,7 +30,7 @@ button { -webkit-tap-highlight-color: transparent; }
 .app-shell {
   width: min(100%, 720px);
   margin: 0 auto;
-  padding: max(20px, env(safe-area-inset-top)) 16px calc(32px + env(safe-area-inset-bottom));
+  padding: max(20px, env(safe-area-inset-top)) 16px calc(90px + env(safe-area-inset-bottom));
 }
 
 .hero {
@@ -404,12 +404,44 @@ select:focus, input[type="number"]:focus { border-color: var(--accent); box-shad
 
 .save-bar {
   position: sticky;
-  z-index: 5;
-  bottom: 0;
-  margin: 14px -8px -16px;
-  padding: 12px 8px calc(12px + env(safe-area-inset-bottom));
-  background: linear-gradient(transparent, var(--app-bg) 24%);
+  z-index: 7;
+  bottom: calc(70px + env(safe-area-inset-bottom));
+  margin: 14px 0 0;
 }
+
+.tab-bar {
+  position: fixed;
+  z-index: 6;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  gap: 4px;
+  width: min(100%, 720px);
+  margin: 0 auto;
+  padding: 6px 8px calc(6px + env(safe-area-inset-bottom));
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  backdrop-filter: blur(12px);
+  border-top: 1px solid var(--line);
+}
+.tab {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  padding: 7px 2px;
+  border: 0;
+  border-radius: 13px;
+  color: var(--app-muted);
+  background: transparent;
+  font-weight: 700;
+  cursor: pointer;
+}
+.tab.active { color: var(--accent); background: color-mix(in srgb, var(--accent) 9%, transparent); }
+.tab-icon { font-size: 19px; line-height: 1; }
+.tab-label { font-size: 10px; letter-spacing: .01em; }
+#zakat-nisab-note { white-space: pre-line; }
 
 .toast { position: fixed; z-index: 10; right: 16px; bottom: calc(18px + env(safe-area-inset-bottom)); left: 16px; max-width: 520px; margin: auto; padding: 14px 16px; border-radius: 15px; color: var(--accent-text); background: var(--accent); box-shadow: 0 12px 34px rgba(0,0,0,.2); font-size: 13px; font-weight: 700; text-align: center; }
 .toast.error { color: white; background: #a84040; }

--- a/global/internal/miniapp/static/app.js
+++ b/global/internal/miniapp/static/app.js
@@ -12,6 +12,7 @@
   let offlineMode = false;
   let homeScreenStatus = "unknown";
   let zakatCurrency = "";
+  let activeView = "prayer";
   const troyOunceGrams = 31.1035;
   const offlineCacheVersion = 2;
   const offlineCacheMaxAge = 48 * 60 * 60 * 1000;
@@ -232,6 +233,11 @@
     setText("zakat-nisab-label", labels.zakat_nisab);
     setText("zakat-due-label", labels.zakat_due);
     setText("zakat-disclaimer", labels.zakat_disclaimer);
+    setText("tab-prayer", labels.nav_prayer);
+    setText("tab-dates", labels.nav_dates);
+    setText("tab-zakat", labels.nav_zakat);
+    setText("tab-tools", labels.tools);
+    setText("tab-settings", labels.settings);
   }
 
   function fillSelect(id, options, selected) {
@@ -477,11 +483,15 @@
 
   function renderZakat() {
     const panel = byId("zakat-panel");
+    const tab = byId("tab-zakat-btn");
     const nisab = state.nisab;
     if (!nisab || !Array.isArray(nisab.currencies) || nisab.currencies.length === 0) {
       panel.classList.add("hidden");
+      if (tab) tab.classList.add("hidden");
+      if (activeView === "zakat") selectView("prayer");
       return;
     }
+    if (tab) tab.classList.remove("hidden");
     panel.classList.remove("hidden");
     if (!zakatCurrency || !nisab.rates[zakatCurrency]) zakatCurrency = nisab.default_currency;
     const select = byId("zakat-currency");
@@ -542,6 +552,7 @@
     renderZakat();
     renderReminders();
     renderSettings();
+    selectView(activeView);
     setDirty(false);
   }
 
@@ -1041,6 +1052,22 @@
     }
   }
 
+  function selectView(view) {
+    const known = ["prayer", "dates", "zakat", "tools", "settings"];
+    if (!known.includes(view)) view = "prayer";
+    activeView = view;
+    known.forEach((name) => {
+      const panel = byId(`view-${name}`);
+      if (panel) panel.classList.toggle("hidden", name !== view);
+    });
+    document.querySelectorAll(".tab").forEach((tab) => {
+      const active = tab.dataset.view === view;
+      tab.classList.toggle("active", active);
+      tab.setAttribute("aria-current", active ? "page" : "false");
+    });
+    window.scrollTo({ top: 0, behavior: "auto" });
+  }
+
   function selectDay(day) {
     activeDay = day;
     ["today", "tomorrow"].forEach((name) => {
@@ -1054,6 +1081,9 @@
 
   byId("today-tab").addEventListener("click", () => selectDay("today"));
   byId("tomorrow-tab").addEventListener("click", () => selectDay("tomorrow"));
+  document.querySelectorAll(".tab").forEach((tab) => {
+    tab.addEventListener("click", () => selectView(tab.dataset.view));
+  });
   byId("location-primary").addEventListener("click", (event) => updateLocation(event.currentTarget));
   byId("location-secondary").addEventListener("click", (event) => updateLocation(event.currentTarget));
   byId("start-compass").addEventListener("click", startCompass);

--- a/global/internal/miniapp/static/index.html
+++ b/global/internal/miniapp/static/index.html
@@ -47,217 +47,247 @@
         </div>
       </aside>
 
-      <section class="schedule-section">
-        <div class="segmented" role="tablist" aria-label="Prayer schedule date">
-          <button id="today-tab" class="segment active" type="button" role="tab" aria-selected="true">Today</button>
-          <button id="tomorrow-tab" class="segment" type="button" role="tab" aria-selected="false">Tomorrow</button>
-        </div>
-
-        <article class="schedule-card">
-          <div class="schedule-heading">
-            <div>
-              <p id="gregorian-date" class="date-primary"></p>
-              <p id="hijri-date" class="date-secondary"></p>
+      <div class="views">
+        <div class="view" id="view-prayer">
+          <section class="schedule-section">
+            <div class="segmented" role="tablist" aria-label="Prayer schedule date">
+              <button id="today-tab" class="segment active" type="button" role="tab" aria-selected="true">Today</button>
+              <button id="tomorrow-tab" class="segment" type="button" role="tab" aria-selected="false">Tomorrow</button>
             </div>
-            <span id="timezone" class="timezone-pill"></span>
-          </div>
-          <div id="prayer-grid" class="prayer-grid"></div>
-          <p id="calculation-note" class="card-note"></p>
-        </article>
-      </section>
 
-      <section class="panel occasions-panel">
-        <div class="panel-heading occasions-heading">
-          <div>
-            <h2 id="occasions-title">Upcoming Islamic dates</h2>
-            <p id="occasions-help" class="panel-help">Calculated from your corrected Hijri calendar.</p>
-          </div>
-          <span class="section-icon" aria-hidden="true">🌙</span>
-        </div>
-        <div id="occasion-list" class="occasion-list"></div>
-        <p id="occasions-disclaimer" class="occasion-disclaimer"></p>
-      </section>
-
-      <section class="panel tools-panel">
-        <div class="panel-heading">
-          <h2 id="tools-title">Tools</h2>
+            <article class="schedule-card">
+              <div class="schedule-heading">
+                <div>
+                  <p id="gregorian-date" class="date-primary"></p>
+                  <p id="hijri-date" class="date-secondary"></p>
+                </div>
+                <span id="timezone" class="timezone-pill"></span>
+              </div>
+              <div id="prayer-grid" class="prayer-grid"></div>
+              <p id="calculation-note" class="card-note"></p>
+            </article>
+          </section>
         </div>
 
-        <div class="tool-grid">
-          <article class="tool-card qibla-card">
-            <div class="tool-heading">
-              <span class="tool-icon" aria-hidden="true">🕋</span>
+        <div class="view hidden" id="view-dates">
+          <section class="panel occasions-panel">
+            <div class="panel-heading occasions-heading">
               <div>
-                <h3 id="qibla-title">Qibla direction</h3>
-                <p id="qibla-help">The arrow points from north toward the Kaaba.</p>
+                <h2 id="occasions-title">Upcoming Islamic dates</h2>
+                <p id="occasions-help" class="panel-help">Calculated from your corrected Hijri calendar.</p>
               </div>
+              <span class="section-icon" aria-hidden="true">🌙</span>
             </div>
+            <div id="occasion-list" class="occasion-list"></div>
+            <p id="occasions-disclaimer" class="occasion-disclaimer"></p>
+          </section>
+        </div>
 
-            <div id="qibla-compass" class="qibla-compass" role="img" aria-labelledby="qibla-bearing">
-              <span class="cardinal cardinal-north">N</span>
-              <span class="cardinal cardinal-east">E</span>
-              <span class="cardinal cardinal-south">S</span>
-              <span class="cardinal cardinal-west">W</span>
-              <div id="qibla-needle" class="qibla-needle" aria-hidden="true">
-                <span class="needle-arrow">▲</span>
-                <span class="needle-kaaba">🕋</span>
-              </div>
-              <span class="compass-center" aria-hidden="true"></span>
-            </div>
-
-            <p id="qibla-bearing" class="tool-value"></p>
-            <p id="qibla-distance" class="tool-note"></p>
-            <button id="start-compass" class="secondary-button" type="button">Use live compass</button>
-            <p id="compass-status" class="tool-note hidden" role="status"></p>
-          </article>
-
-          <article class="tool-card calendar-card">
-            <div class="tool-heading">
-              <span class="tool-icon" aria-hidden="true">📅</span>
+        <div class="view hidden" id="view-zakat">
+          <section id="zakat-panel" class="panel zakat-panel hidden">
+            <div class="panel-heading zakat-heading">
               <div>
-                <h3 id="calendar-title">Prayer calendar</h3>
-                <p id="calendar-help">Connect an automatically updated rolling 30-day calendar.</p>
+                <h2 id="zakat-title">Zakat calculator</h2>
+                <p id="zakat-help" class="panel-help">Calculate zakat on your wealth.</p>
               </div>
+              <span class="section-icon" aria-hidden="true">💰</span>
             </div>
-            <div class="calendar-illustration" aria-hidden="true">
-              <span>☾</span>
-              <strong id="calendar-day">30</strong>
+            <div class="zakat-form">
+              <label><span id="zakat-currency-label">Currency</span>
+                <select id="zakat-currency"></select></label>
+              <label><span id="zakat-holdings-label">Your zakatable wealth</span>
+                <input id="zakat-holdings" type="number" min="0" step="any" inputmode="decimal" placeholder="0"></label>
             </div>
-            <p id="calendar-private" class="tool-note calendar-private">Keep the private calendar link secret.</p>
-            <div class="calendar-actions">
-              <button id="connect-calendar" class="primary-button compact" type="button">Connect Google Calendar</button>
-              <button id="copy-calendar-link" class="secondary-button" type="button">Copy private link</button>
-              <button id="disconnect-calendar" class="text-button calendar-disconnect hidden" type="button">Disconnect calendar</button>
-            </div>
-            <p id="calendar-status" class="tool-note hidden" role="status"></p>
-          </article>
-
-          <article id="home-screen-card" class="tool-card quick-access-card hidden">
-            <div class="tool-heading">
-              <span class="tool-icon" aria-hidden="true">📲</span>
-              <div>
-                <h3 id="home-screen-title">Quick access</h3>
-                <p id="home-screen-help">Add prayer times to your Telegram home screen.</p>
+            <div class="zakat-summary">
+              <div class="zakat-row">
+                <span id="zakat-nisab-label">Niṣāb (minimum)</span>
+                <strong id="zakat-nisab-value" class="zakat-amount"></strong>
               </div>
-            </div>
-            <div class="quick-access-illustration" aria-hidden="true">
-              <span>☾</span>
-            </div>
-            <button id="add-home-screen" class="secondary-button" type="button">Add to home screen</button>
-            <p id="home-screen-status" class="tool-note hidden" role="status"></p>
-          </article>
-
-          <article class="tool-card share-card">
-            <div class="tool-heading">
-              <span class="tool-icon" aria-hidden="true">✨</span>
-              <div>
-                <h3 id="share-card-title">Share prayer card</h3>
-                <p id="share-card-help">Create a beautiful image with the selected day’s prayer times.</p>
+              <p id="zakat-nisab-note" class="tool-note"></p>
+              <div class="zakat-row zakat-due-row">
+                <span id="zakat-due-label">Zakat due (2.5%)</span>
+                <strong id="zakat-due-value" class="zakat-amount zakat-due-amount"></strong>
               </div>
+              <p id="zakat-status" class="tool-note zakat-status"></p>
             </div>
-            <div class="share-card-preview" aria-hidden="true">
-              <span class="share-preview-moon">☾</span>
-              <strong id="share-preview-date"></strong>
-              <span id="share-preview-time"></span>
+            <p id="zakat-disclaimer" class="occasion-disclaimer"></p>
+            <p id="zakat-updated" class="tool-note zakat-updated"></p>
+          </section>
+        </div>
+
+        <div class="view hidden" id="view-tools">
+          <section class="panel tools-panel">
+            <div class="panel-heading">
+              <h2 id="tools-title">Tools</h2>
             </div>
-            <button id="share-prayer-card" class="primary-button compact" type="button">Create &amp; share</button>
-          </article>
-        </div>
-      </section>
 
-      <section id="zakat-panel" class="panel zakat-panel hidden">
-        <div class="panel-heading zakat-heading">
-          <div>
-            <h2 id="zakat-title">Zakat calculator</h2>
-            <p id="zakat-help" class="panel-help">Calculate zakat on your wealth.</p>
-          </div>
-          <span class="section-icon" aria-hidden="true">💰</span>
-        </div>
-        <div class="zakat-form">
-          <label><span id="zakat-currency-label">Currency</span>
-            <select id="zakat-currency"></select></label>
-          <label><span id="zakat-holdings-label">Your zakatable wealth</span>
-            <input id="zakat-holdings" type="number" min="0" step="any" inputmode="decimal" placeholder="0"></label>
-        </div>
-        <div class="zakat-summary">
-          <div class="zakat-row">
-            <span id="zakat-nisab-label">Niṣāb (minimum)</span>
-            <strong id="zakat-nisab-value" class="zakat-amount"></strong>
-          </div>
-          <p id="zakat-nisab-note" class="tool-note"></p>
-          <div class="zakat-row zakat-due-row">
-            <span id="zakat-due-label">Zakat due (2.5%)</span>
-            <strong id="zakat-due-value" class="zakat-amount zakat-due-amount"></strong>
-          </div>
-          <p id="zakat-status" class="tool-note zakat-status"></p>
-        </div>
-        <p id="zakat-disclaimer" class="occasion-disclaimer"></p>
-        <p id="zakat-updated" class="tool-note zakat-updated"></p>
-      </section>
+            <div class="tool-grid">
+              <article class="tool-card qibla-card">
+                <div class="tool-heading">
+                  <span class="tool-icon" aria-hidden="true">🕋</span>
+                  <div>
+                    <h3 id="qibla-title">Qibla direction</h3>
+                    <p id="qibla-help">The arrow points from north toward the Kaaba.</p>
+                  </div>
+                </div>
 
-      <section class="panel">
-        <div class="panel-heading">
-          <h2 id="reminders-title">Reminders</h2>
-        </div>
-        <label class="toggle-row">
-          <span><strong id="prayer-reminders-label">Prayer times</strong></span>
-          <input id="prayer-reminders" type="checkbox">
-          <span class="toggle" aria-hidden="true"></span>
-        </label>
-        <label id="pre-reminder-row" class="reminder-option">
-          <span id="pre-prayer-reminder-label">Pre-prayer reminder</span>
-          <select id="pre-prayer-minutes"></select>
-        </label>
-        <label class="toggle-row">
-          <span><strong id="fasting-reminders-label">Monday &amp; Thursday fasting</strong><small id="fasting-schedule"></small></span>
-          <input id="fasting-reminders" type="checkbox">
-          <span class="toggle" aria-hidden="true"></span>
-        </label>
-        <label class="toggle-row">
-          <span><strong id="kahf-reminders-label">Friday Al-Kahf</strong><small id="kahf-schedule"></small></span>
-          <input id="kahf-reminders" type="checkbox">
-          <span class="toggle" aria-hidden="true"></span>
-        </label>
-        <label class="toggle-row">
-          <span><strong id="occasion-major-reminders-label">Major Islamic occasions</strong><small id="occasion-major-schedule"></small></span>
-          <input id="occasion-major-reminders" type="checkbox">
-          <span class="toggle" aria-hidden="true"></span>
-        </label>
-        <label class="toggle-row">
-          <span><strong id="occasion-fasting-reminders-label">Special fasting days</strong><small id="occasion-fasting-schedule"></small></span>
-          <input id="occasion-fasting-reminders" type="checkbox">
-          <span class="toggle" aria-hidden="true"></span>
-        </label>
-        <label class="toggle-row">
-          <span><strong id="occasion-observed-reminders-label">Commonly observed dates</strong><small id="occasion-observed-schedule"></small></span>
-          <input id="occasion-observed-reminders" type="checkbox">
-          <span class="toggle" aria-hidden="true"></span>
-        </label>
-      </section>
+                <div id="qibla-compass" class="qibla-compass" role="img" aria-labelledby="qibla-bearing">
+                  <span class="cardinal cardinal-north">N</span>
+                  <span class="cardinal cardinal-east">E</span>
+                  <span class="cardinal cardinal-south">S</span>
+                  <span class="cardinal cardinal-west">W</span>
+                  <div id="qibla-needle" class="qibla-needle" aria-hidden="true">
+                    <span class="needle-arrow">▲</span>
+                    <span class="needle-kaaba">🕋</span>
+                  </div>
+                  <span class="compass-center" aria-hidden="true"></span>
+                </div>
 
-      <section class="panel settings-panel">
-        <div class="panel-heading">
-          <h2 id="settings-title">Settings</h2>
-          <button id="location-secondary" class="text-button" type="button">Update location</button>
-        </div>
+                <p id="qibla-bearing" class="tool-value"></p>
+                <p id="qibla-distance" class="tool-note"></p>
+                <button id="start-compass" class="secondary-button" type="button">Use live compass</button>
+                <p id="compass-status" class="tool-note hidden" role="status"></p>
+              </article>
 
-        <div class="form-grid">
-          <label><span id="language-label">Language</span><select id="language"></select></label>
-          <label><span id="method-label">Calculation method</span><select id="method"></select></label>
-          <label><span id="madhab-label">Madhab</span><select id="madhab"></select></label>
-          <label><span id="highlat-label">High latitude rule</span><select id="highlat"></select></label>
-          <label><span id="hijri-label">Hijri date correction</span><select id="hijri-adjustment"></select></label>
+              <article class="tool-card calendar-card">
+                <div class="tool-heading">
+                  <span class="tool-icon" aria-hidden="true">📅</span>
+                  <div>
+                    <h3 id="calendar-title">Prayer calendar</h3>
+                    <p id="calendar-help">Connect an automatically updated rolling 30-day calendar.</p>
+                  </div>
+                </div>
+                <div class="calendar-illustration" aria-hidden="true">
+                  <span>☾</span>
+                  <strong id="calendar-day">30</strong>
+                </div>
+                <p id="calendar-private" class="tool-note calendar-private">Keep the private calendar link secret.</p>
+                <div class="calendar-actions">
+                  <button id="connect-calendar" class="primary-button compact" type="button">Connect Google Calendar</button>
+                  <button id="copy-calendar-link" class="secondary-button" type="button">Copy private link</button>
+                  <button id="disconnect-calendar" class="text-button calendar-disconnect hidden" type="button">Disconnect calendar</button>
+                </div>
+                <p id="calendar-status" class="tool-note hidden" role="status"></p>
+              </article>
+
+              <article id="home-screen-card" class="tool-card quick-access-card hidden">
+                <div class="tool-heading">
+                  <span class="tool-icon" aria-hidden="true">📲</span>
+                  <div>
+                    <h3 id="home-screen-title">Quick access</h3>
+                    <p id="home-screen-help">Add prayer times to your Telegram home screen.</p>
+                  </div>
+                </div>
+                <div class="quick-access-illustration" aria-hidden="true">
+                  <span>☾</span>
+                </div>
+                <button id="add-home-screen" class="secondary-button" type="button">Add to home screen</button>
+                <p id="home-screen-status" class="tool-note hidden" role="status"></p>
+              </article>
+
+              <article class="tool-card share-card">
+                <div class="tool-heading">
+                  <span class="tool-icon" aria-hidden="true">✨</span>
+                  <div>
+                    <h3 id="share-card-title">Share prayer card</h3>
+                    <p id="share-card-help">Create a beautiful image with the selected day’s prayer times.</p>
+                  </div>
+                </div>
+                <div class="share-card-preview" aria-hidden="true">
+                  <span class="share-preview-moon">☾</span>
+                  <strong id="share-preview-date"></strong>
+                  <span id="share-preview-time"></span>
+                </div>
+                <button id="share-prayer-card" class="primary-button compact" type="button">Create &amp; share</button>
+              </article>
+            </div>
+          </section>
         </div>
 
-        <details class="adjustments">
-          <summary id="adjustments-label">Prayer adjustments</summary>
-          <div id="adjustment-grid" class="adjustment-grid"></div>
-        </details>
-      </section>
+        <div class="view hidden" id="view-settings">
+          <section class="panel">
+            <div class="panel-heading">
+              <h2 id="reminders-title">Reminders</h2>
+            </div>
+            <label class="toggle-row">
+              <span><strong id="prayer-reminders-label">Prayer times</strong></span>
+              <input id="prayer-reminders" type="checkbox">
+              <span class="toggle" aria-hidden="true"></span>
+            </label>
+            <label id="pre-reminder-row" class="reminder-option">
+              <span id="pre-prayer-reminder-label">Pre-prayer reminder</span>
+              <select id="pre-prayer-minutes"></select>
+            </label>
+            <label class="toggle-row">
+              <span><strong id="fasting-reminders-label">Monday &amp; Thursday fasting</strong><small id="fasting-schedule"></small></span>
+              <input id="fasting-reminders" type="checkbox">
+              <span class="toggle" aria-hidden="true"></span>
+            </label>
+            <label class="toggle-row">
+              <span><strong id="kahf-reminders-label">Friday Al-Kahf</strong><small id="kahf-schedule"></small></span>
+              <input id="kahf-reminders" type="checkbox">
+              <span class="toggle" aria-hidden="true"></span>
+            </label>
+            <label class="toggle-row">
+              <span><strong id="occasion-major-reminders-label">Major Islamic occasions</strong><small id="occasion-major-schedule"></small></span>
+              <input id="occasion-major-reminders" type="checkbox">
+              <span class="toggle" aria-hidden="true"></span>
+            </label>
+            <label class="toggle-row">
+              <span><strong id="occasion-fasting-reminders-label">Special fasting days</strong><small id="occasion-fasting-schedule"></small></span>
+              <input id="occasion-fasting-reminders" type="checkbox">
+              <span class="toggle" aria-hidden="true"></span>
+            </label>
+            <label class="toggle-row">
+              <span><strong id="occasion-observed-reminders-label">Commonly observed dates</strong><small id="occasion-observed-schedule"></small></span>
+              <input id="occasion-observed-reminders" type="checkbox">
+              <span class="toggle" aria-hidden="true"></span>
+            </label>
+          </section>
+
+          <section class="panel settings-panel">
+            <div class="panel-heading">
+              <h2 id="settings-title">Settings</h2>
+              <button id="location-secondary" class="text-button" type="button">Update location</button>
+            </div>
+
+            <div class="form-grid">
+              <label><span id="language-label">Language</span><select id="language"></select></label>
+              <label><span id="method-label">Calculation method</span><select id="method"></select></label>
+              <label><span id="madhab-label">Madhab</span><select id="madhab"></select></label>
+              <label><span id="highlat-label">High latitude rule</span><select id="highlat"></select></label>
+              <label><span id="hijri-label">Hijri date correction</span><select id="hijri-adjustment"></select></label>
+            </div>
+
+            <details class="adjustments">
+              <summary id="adjustments-label">Prayer adjustments</summary>
+              <div id="adjustment-grid" class="adjustment-grid"></div>
+            </details>
+          </section>
+        </div>
+      </div>
 
       <div id="save-bar" class="save-bar hidden">
         <button id="save-preferences" class="primary-button" type="button">Save changes</button>
       </div>
+
+      <nav id="tab-bar" class="tab-bar" aria-label="Sections">
+        <button class="tab active" type="button" data-view="prayer">
+          <span class="tab-icon" aria-hidden="true">🕌</span><span id="tab-prayer" class="tab-label">Prayer</span>
+        </button>
+        <button class="tab" type="button" data-view="dates">
+          <span class="tab-icon" aria-hidden="true">🌙</span><span id="tab-dates" class="tab-label">Dates</span>
+        </button>
+        <button id="tab-zakat-btn" class="tab" type="button" data-view="zakat">
+          <span class="tab-icon" aria-hidden="true">💰</span><span id="tab-zakat" class="tab-label">Zakat</span>
+        </button>
+        <button class="tab" type="button" data-view="tools">
+          <span class="tab-icon" aria-hidden="true">🧭</span><span id="tab-tools" class="tab-label">Tools</span>
+        </button>
+        <button class="tab" type="button" data-view="settings">
+          <span class="tab-icon" aria-hidden="true">⚙️</span><span id="tab-settings" class="tab-label">Settings</span>
+        </button>
+      </nav>
     </div>
   </main>
 

--- a/global/internal/miniapp/static/sw.js
+++ b/global/internal/miniapp/static/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const cacheName = "global-prayer-miniapp-shell-v4";
+const cacheName = "global-prayer-miniapp-shell-v5";
 const shellAssets = [
   "./",
   "./app.css",


### PR DESCRIPTION
## What & why

Two UX refinements from feedback on the live Zakat feature.

### 1. Section navigation (page was getting too long)
Split the single long-scroll dashboard into **sections behind a fixed bottom tab bar**:

| Tab | Contents |
| --- | --- |
| 🕌 **Prayer** (default) | Today / Tomorrow schedule — unchanged, shown on open |
| 🌙 Dates | Islamic occasions |
| 💰 Zakat | Calculator |
| 🧭 Tools | Qibla, calendar, prayer card, home screen |
| ⚙️ Settings | Reminders + calculation settings + location |

- Prayer is the **default view**. Reminders and calculation settings are grouped under **Settings** since they share the save bar.
- The Zakat tab **hides itself** when prices aren't available yet (keeps the existing empty-state logic), falling back to Prayer.
- The save bar floats above the tab bar; content has bottom clearance so nothing is obscured.

### 2. Niṣāb readability
Gold and silver niṣāb now render on **separate lines** instead of one crowded line (`white-space: pre-line` + a newline separator across all 8 locales).

## Notes
- All `app.js` render functions target the same element IDs, now nested inside per-section `view` containers — no rendering logic changed, just structure + a `selectView()` switcher.
- `nav_*` labels added for all 8 locales; `sw.js` cache bumped to **v5** so clients fetch the new shell.
- Verified visually at mobile width (screenshots taken during development): Prayer default view + bottom nav, and the Zakat view with gold/silver on separate lines.
- `gofmt` / `go vet` / `go test ./...` clean on Go 1.26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)