### PR TITLE
Fix doubled Settings tab icon

### DIFF
--- a/global/internal/miniapp/static/index.html
+++ b/global/internal/miniapp/static/index.html
@@ -285,7 +285,7 @@
           <span class="tab-icon" aria-hidden="true">🧭</span><span id="tab-tools" class="tab-label">Tools</span>
         </button>
         <button class="tab" type="button" data-view="settings">
-          <span class="tab-icon" aria-hidden="true">⚙️</span><span id="tab-settings" class="tab-label">Settings</span>
+          <span class="tab-icon" aria-hidden="true">🎛️</span><span id="tab-settings" class="tab-label">Settings</span>
         </button>
       </nav>
     </div>


### PR DESCRIPTION
## What & why

The Settings tab in the Mini App bottom nav used the ⚙️ gear emoji, which Apple renders as a **large gear with a smaller gear behind it** — reading as a duplicated/sub-icon. Replaced it with a single clean control-panel glyph (🎛️).

One-character change to `index.html`; verified in the browser at mobile width that the Settings tab now shows a single clean icon consistent with the other tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)