### PR TITLE
Add "prayer times anywhere" map lookup to the Mini App

### DIFF
--- a/global/docs/request-flows.md
+++ b/global/docs/request-flows.md
@@ -35,7 +35,8 @@ Full Telegram update bodies are never persisted.
 
 ## Location onboarding or change
 
-Location writes are the only normal user flow that calls Google APIs.
+Location writes and the "prayer times anywhere" lookup are the normal user
+flows that call Google APIs (timezone and reverse geocoding).
 
 1. Telegram supplies latitude and longitude from a location message or the Mini
    App location manager.
@@ -93,6 +94,25 @@ WebViews ignore browser download links, so an unavailable or rejected file
 share falls back to an authenticated multipart upload. The webhook validates a
 PNG of the expected 1080×1350 dimensions and immediately sends it to the user's
 private bot chat. The bot does not retain the image.
+
+## Prayer times anywhere (ad-hoc lookup)
+
+The Mini App "Places" section lets a user check prayer times for **any** place
+and day without changing their saved location. An OpenStreetMap slippy map (raw
+raster tiles loaded as images — allowed by the existing `img-src https:` policy,
+so no CSP change and no Maps key on the client) provides a draggable pin.
+
+1. On drag/zoom end (debounced), the app posts the pin's coordinates and the
+   selected day to `POST /api/miniapp/lookup`.
+2. The server resolves the timezone and place name via Google (same resolver as
+   a location change).
+3. It builds a **transient** profile — never persisted — reusing the caller's
+   saved calculation preferences when present, or country defaults otherwise.
+4. It calculates the requested local day and returns a localized schedule plus
+   the place name.
+
+No profile is written, no version is bumped, and no reminders are rebuilt. The
+saved location and reminders are untouched.
 
 ## Prayer schedule display
 

--- a/global/docs/runtime-and-deployment.md
+++ b/global/docs/runtime-and-deployment.md
@@ -45,6 +45,15 @@ HTTP APIs and caches them in one PostgreSQL row. Both calls use default Cloud
 Run egress and run at most once a day regardless of user volume. The refresh is
 best-effort and never blocks retention cleanup.
 
+The "prayer times anywhere" Mini App map loads OpenStreetMap raster tiles
+directly in the browser (allowed by the existing `img-src https:` policy — no
+CSP change, no Maps key). **Caveat:** the public `tile.openstreetmap.org`
+service is intended for light use and its usage policy discourages heavy or
+commercial traffic. Before this feature scales, switch the tile source to a
+provider that permits application traffic (self-hosted tiles or a keyed provider
+such as MapTiler/Carto). The ad-hoc lookup endpoint itself calls the same Google
+timezone/geocoding APIs as a location change.
+
 ## Secrets
 
 Runtime services read environment-specific Secret Manager values:

--- a/global/internal/miniapp/handler.go
+++ b/global/internal/miniapp/handler.go
@@ -106,6 +106,7 @@ func (h *Handler) Register(mux *http.ServeMux) {
 		http.Redirect(w, r, "/app/", http.StatusPermanentRedirect)
 	})
 	mux.HandleFunc("POST /api/miniapp/bootstrap", h.api(h.bootstrap))
+	mux.HandleFunc("POST /api/miniapp/lookup", h.api(h.lookup))
 	mux.HandleFunc("PUT /api/miniapp/location", h.api(h.updateLocation))
 	mux.HandleFunc("PUT /api/miniapp/preferences", h.api(h.updatePreferences))
 	mux.HandleFunc("PUT /api/miniapp/settings", h.api(h.updateSettings))
@@ -208,6 +209,79 @@ func (h *Handler) updateLocation(w http.ResponseWriter, r *http.Request, identit
 	}
 	data.LocationName = resolved.City
 	return writeJSON(w, data)
+}
+
+type lookupRequest struct {
+	Latitude  *float64 `json:"latitude"`
+	Longitude *float64 `json:"longitude"`
+	Day       string   `json:"day"`
+}
+
+type lookupResponse struct {
+	LocationName string           `json:"location_name"`
+	Schedule     scheduleResponse `json:"schedule"`
+}
+
+// lookup returns prayer times for an arbitrary place and day without changing
+// the caller's saved location. The computed profile is transient (never
+// persisted), reuses the caller's calculation preferences when available, and
+// falls back to sensible defaults for the looked-up country.
+func (h *Handler) lookup(w http.ResponseWriter, r *http.Request, identity Identity) error {
+	var request lookupRequest
+	if err := decodeJSON(w, r, &request); err != nil {
+		return badRequest("invalid_request")
+	}
+	if request.Latitude == nil || request.Longitude == nil ||
+		*request.Latitude < -90 || *request.Latitude > 90 ||
+		*request.Longitude < -180 || *request.Longitude > 180 {
+		return badRequest("invalid_location")
+	}
+	resolved, err := h.resolver.Resolve(r.Context(), *request.Latitude, *request.Longitude)
+	if err != nil {
+		return fmt.Errorf("resolve lookup location: %w", err)
+	}
+	latitude, longitude := domain.RoundedCoordinates(*request.Latitude, *request.Longitude)
+	profile := domain.PrayerProfile{
+		Latitude: latitude, Longitude: longitude, Timezone: resolved.Timezone,
+		Method:           location.RecommendedMethod(resolved.CountryCode),
+		Madhab:           domain.MadhabShafii,
+		HighLatitudeRule: domain.HighLatitudeAngleBased,
+	}
+	current, err := h.store.Profile(r.Context(), identity.UserID)
+	if err == nil {
+		profile.Method = current.Method
+		profile.Madhab = current.Madhab
+		profile.HighLatitudeRule = current.HighLatitudeRule
+		profile.Adjustments = current.Adjustments
+		profile.HijriAdjustment = current.HijriAdjustment
+	} else if !store.IsNotFound(err) {
+		return fmt.Errorf("load profile: %w", err)
+	}
+	locale := i18n.Resolve(identity.LanguageCode)
+	if chat, err := h.store.Chat(r.Context(), identity.UserID); err == nil {
+		locale = i18n.Resolve(chat.LanguageCode)
+	} else if !store.IsNotFound(err) {
+		return fmt.Errorf("load chat: %w", err)
+	}
+	now := h.now()
+	schedule, err := h.calculator.Day(r.Context(), now, profile)
+	if err != nil {
+		return fmt.Errorf("calculate lookup schedule: %w", err)
+	}
+	if request.Day == "tomorrow" {
+		schedule, err = h.calculator.Day(r.Context(), now.In(schedule.Date.Location()).AddDate(0, 0, 1), profile)
+		if err != nil {
+			return fmt.Errorf("calculate lookup schedule: %w", err)
+		}
+	}
+	name := resolved.City
+	if name == "" {
+		name = resolved.Timezone
+	}
+	return writeJSON(w, lookupResponse{
+		LocationName: name,
+		Schedule:     formatSchedule(schedule, profile, locale),
+	})
 }
 
 func (h *Handler) sendPrayerCard(w http.ResponseWriter, r *http.Request, identity Identity) error {
@@ -904,6 +978,7 @@ func labels(locale i18n.Locale) map[string]string {
 		"zakat_due": copy.ZakatDue, "zakat_below": copy.ZakatBelow,
 		"zakat_disclaimer": copy.ZakatDisclaimer, "zakat_updated": copy.ZakatUpdated,
 		"nav_prayer": copy.NavPrayer, "nav_dates": copy.NavDates, "nav_zakat": copy.NavZakat,
+		"nav_places": copy.NavPlaces, "places_title": copy.PlacesTitle, "places_help": copy.PlacesHelp,
 	}
 }
 
@@ -926,7 +1001,8 @@ type miniAppCopy struct {
 	ZakatTitle, ZakatHelp, ZakatCurrency, ZakatHoldings   string
 	ZakatNisab, ZakatNisabNote, ZakatDue, ZakatBelow      string
 	ZakatDisclaimer, ZakatUpdated                         string
-	NavPrayer, NavDates, NavZakat                         string
+	NavPrayer, NavDates, NavZakat, NavPlaces              string
+	PlacesTitle, PlacesHelp                               string
 }
 
 var miniCopy = map[string]miniAppCopy{
@@ -960,7 +1036,9 @@ var miniCopy = map[string]miniAppCopy{
 		ZakatDue: "Zakat due (2.5%)", ZakatBelow: "Your wealth is below the nisab, so no zakat is due.",
 		ZakatDisclaimer: "Estimate based on live gold and silver prices. Consult a scholar for your situation.",
 		ZakatUpdated:    "Prices as of {date}",
-		NavPrayer:       "Prayer", NavDates: "Dates", NavZakat: "Zakat",
+		NavPrayer:       "Prayer", NavDates: "Dates", NavZakat: "Zakat", NavPlaces: "Places",
+		PlacesTitle: "Prayer times anywhere",
+		PlacesHelp:  "Drag the map to any place to see its prayer times.",
 	},
 	"ar": {
 		Save: "حفظ التغييرات", Saved: "تم الحفظ", Loading: "جارٍ تحميل مواقيت الصلاة…",
@@ -992,7 +1070,9 @@ var miniCopy = map[string]miniAppCopy{
 		ZakatDue: "الزكاة المستحقة (2.5%)", ZakatBelow: "مالك دون النصاب، فلا زكاة عليك.",
 		ZakatDisclaimer: "تقدير بناءً على أسعار الذهب والفضة الحالية. استشر أهل العلم لحالتك.",
 		ZakatUpdated:    "الأسعار بتاريخ {date}",
-		NavPrayer:       "الصلاة", NavDates: "المناسبات", NavZakat: "الزكاة",
+		NavPrayer:       "الصلاة", NavDates: "المناسبات", NavZakat: "الزكاة", NavPlaces: "أماكن",
+		PlacesTitle: "مواقيت الصلاة في أي مكان",
+		PlacesHelp:  "حرّك الخريطة إلى أي مكان لعرض مواقيت الصلاة فيه.",
 	},
 	"es": {
 		Save: "Guardar cambios", Saved: "Guardado", Loading: "Cargando horarios de oración…",
@@ -1024,7 +1104,9 @@ var miniCopy = map[string]miniAppCopy{
 		ZakatDue: "Zakat a pagar (2,5%)", ZakatBelow: "Tu patrimonio está por debajo del nisab, así que no debes zakat.",
 		ZakatDisclaimer: "Estimación basada en precios actuales del oro y la plata. Consulta a un experto para tu caso.",
 		ZakatUpdated:    "Precios al {date}",
-		NavPrayer:       "Oración", NavDates: "Fechas", NavZakat: "Zakat",
+		NavPrayer:       "Oración", NavDates: "Fechas", NavZakat: "Zakat", NavPlaces: "Lugares",
+		PlacesTitle: "Horarios en cualquier lugar",
+		PlacesHelp:  "Arrastra el mapa a cualquier lugar para ver sus horarios de oración.",
 	},
 	"fr": {
 		Save: "Enregistrer", Saved: "Enregistré", Loading: "Chargement des horaires de prière…",
@@ -1056,7 +1138,9 @@ var miniCopy = map[string]miniAppCopy{
 		ZakatDue: "Zakat à verser (2,5%)", ZakatBelow: "Votre patrimoine est inférieur au nisab, aucune zakat n’est due.",
 		ZakatDisclaimer: "Estimation basée sur les cours actuels de l’or et de l’argent. Consultez un savant pour votre cas.",
 		ZakatUpdated:    "Cours au {date}",
-		NavPrayer:       "Prière", NavDates: "Dates", NavZakat: "Zakat",
+		NavPrayer:       "Prière", NavDates: "Dates", NavZakat: "Zakat", NavPlaces: "Lieux",
+		PlacesTitle: "Horaires n’importe où",
+		PlacesHelp:  "Faites glisser la carte vers n’importe quel lieu pour voir ses horaires de prière.",
 	},
 	"ru": {
 		Save: "Сохранить", Saved: "Сохранено", Loading: "Загружаем время намаза…",
@@ -1088,7 +1172,9 @@ var miniCopy = map[string]miniAppCopy{
 		ZakatDue: "Закят к выплате (2,5%)", ZakatBelow: "Ваше имущество ниже нисаба, поэтому закят не обязателен.",
 		ZakatDisclaimer: "Оценка на основе текущих цен на золото и серебро. Обратитесь к знающему для вашего случая.",
 		ZakatUpdated:    "Цены на {date}",
-		NavPrayer:       "Намаз", NavDates: "Даты", NavZakat: "Закят",
+		NavPrayer:       "Намаз", NavDates: "Даты", NavZakat: "Закят", NavPlaces: "Места",
+		PlacesTitle: "Время намаза где угодно",
+		PlacesHelp:  "Перетащите карту на любое место, чтобы увидеть время намаза.",
 	},
 	"tr": {
 		Save: "Değişiklikleri kaydet", Saved: "Kaydedildi", Loading: "Namaz vakitleri yükleniyor…",
@@ -1120,7 +1206,9 @@ var miniCopy = map[string]miniAppCopy{
 		ZakatDue: "Ödenecek zekât (%2,5)", ZakatBelow: "Malınız nisabın altında, bu yüzden zekât gerekmez.",
 		ZakatDisclaimer: "Güncel altın ve gümüş fiyatlarına dayalı tahmin. Durumunuz için bir âlime danışın.",
 		ZakatUpdated:    "{date} tarihli fiyatlar",
-		NavPrayer:       "Namaz", NavDates: "Günler", NavZakat: "Zekât",
+		NavPrayer:       "Namaz", NavDates: "Günler", NavZakat: "Zekât", NavPlaces: "Yerler",
+		PlacesTitle: "Her yerde namaz vakitleri",
+		PlacesHelp:  "Namaz vakitlerini görmek için haritayı istediğiniz yere sürükleyin.",
 	},
 	"uz": {
 		Save: "O‘zgarishlarni saqlash", Saved: "Saqlandi", Loading: "Namoz vaqtlari yuklanmoqda…",
@@ -1152,7 +1240,9 @@ var miniCopy = map[string]miniAppCopy{
 		ZakatDue: "To‘lanadigan zakot (2,5%)", ZakatBelow: "Mol-mulkingiz nisobdan kam, shuning uchun zakot vojib emas.",
 		ZakatDisclaimer: "Joriy oltin va kumush narxlariga asoslangan taxmin. Holatingiz uchun olimga murojaat qiling.",
 		ZakatUpdated:    "{date} holatidagi narxlar",
-		NavPrayer:       "Namoz", NavDates: "Sanalar", NavZakat: "Zakot",
+		NavPrayer:       "Namoz", NavDates: "Sanalar", NavZakat: "Zakot", NavPlaces: "Joylar",
+		PlacesTitle: "Istalgan joyda namoz vaqtlari",
+		PlacesHelp:  "Namoz vaqtlarini ko‘rish uchun xaritani istalgan joyga suring.",
 	},
 	"tt": {
 		Save: "Үзгәрешләрне саклау", Saved: "Сакланды", Loading: "Намаз вакытлары йөкләнә…",
@@ -1184,6 +1274,8 @@ var miniCopy = map[string]miniAppCopy{
 		ZakatDue: "Түләнәсе зәкят (2,5%)", ZakatBelow: "Мал-мөлкәтегез нисабтан ким, шуңа зәкят фарыз түгел.",
 		ZakatDisclaimer: "Хәзерге алтын һәм көмеш бәяләренә нигезләнгән бәя. Хәлегез өчен галимгә мөрәҗәгать итегез.",
 		ZakatUpdated:    "{date} көненә бәяләр",
-		NavPrayer:       "Намаз", NavDates: "Даталар", NavZakat: "Зәкят",
+		NavPrayer:       "Намаз", NavDates: "Даталар", NavZakat: "Зәкят", NavPlaces: "Урыннар",
+		PlacesTitle: "Теләсә кайда намаз вакытлары",
+		PlacesHelp:  "Намаз вакытларын күрер өчен картаны теләсә кайсы урынга күчерегез.",
 	},
 }

--- a/global/internal/miniapp/handler_test.go
+++ b/global/internal/miniapp/handler_test.go
@@ -144,6 +144,77 @@ func TestZakatCalculatorMarkupAndLabelsExist(t *testing.T) {
 	}
 }
 
+func TestPlacesLookupMarkupAndLabels(t *testing.T) {
+	html, err := embeddedStatic.ReadFile("static/index.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, marker := range []string{"view-places", "places-map", "places-tiles", "places-grid", "data-view=\"places\""} {
+		if !strings.Contains(string(html), marker) {
+			t.Errorf("index.html is missing places marker %q", marker)
+		}
+	}
+	script, err := embeddedStatic.ReadFile("static/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, hook := range []string{"runPlacesLookup", "tile.openstreetmap.org", "/api/miniapp/lookup", "bindPlacesMap"} {
+		if !strings.Contains(string(script), hook) {
+			t.Errorf("app.js is missing places lookup logic %q", hook)
+		}
+	}
+	for _, locale := range i18n.Supported() {
+		localized := labels(locale)
+		for _, key := range []string{"nav_places", "places_title", "places_help"} {
+			if localized[key] == "" {
+				t.Errorf("locale %q has no %q label", locale.Code, key)
+			}
+		}
+	}
+}
+
+func TestLookupReturnsScheduleWithoutChangingProfile(t *testing.T) {
+	now := time.Date(2026, time.July, 26, 12, 0, 0, 0, time.UTC)
+	storage := newFakeStorage()
+	storage.chats[42] = domain.Chat{TelegramChatID: 42, Type: "private", LanguageCode: "en"}
+	storage.profiles[42] = domain.PrayerProfile{
+		ChatID: 42, Latitude: 55.75, Longitude: 37.62, Timezone: "Europe/Moscow",
+		CountryCode: "RU", Method: domain.MethodMWL, Madhab: domain.MadhabHanafi,
+		HighLatitudeRule: domain.HighLatitudeAngleBased, Version: 3,
+	}
+	resolver := &fakeResolver{resolved: location.Resolved{Timezone: "Africa/Cairo", City: "Cairo", CountryCode: "EG"}}
+	planner := &fakePlanner{}
+	handler := NewHandler("test-token", storage, resolver, prayertime.New(), planner, nil)
+	handler.now = func() time.Time { return now }
+	mux := http.NewServeMux()
+	handler.Register(mux)
+
+	request := httptest.NewRequest(http.MethodPost, "/api/miniapp/lookup", strings.NewReader(`{"latitude":30.0444,"longitude":31.2357,"day":"today"}`))
+	request.Header.Set("X-Telegram-Init-Data", signedInitData(t, "test-token", now, initDataUser{ID: 42, FirstName: "Amina", LanguageCode: "en"}))
+	response := httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	var data lookupResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &data); err != nil {
+		t.Fatal(err)
+	}
+	if data.LocationName != "Cairo" {
+		t.Fatalf("location name = %q, want Cairo", data.LocationName)
+	}
+	if data.Schedule.Timezone != "Africa/Cairo" || len(data.Schedule.Prayers) == 0 {
+		t.Fatalf("unexpected schedule: %+v", data.Schedule)
+	}
+	if saved := storage.profiles[42]; saved.Timezone != "Europe/Moscow" || saved.Version != 3 {
+		t.Fatalf("saved profile must be untouched by a lookup, got %+v", saved)
+	}
+	if planner.rebuilds != 0 {
+		t.Fatalf("lookup must not rebuild reminders, rebuilds = %d", planner.rebuilds)
+	}
+}
+
 func TestMiniAppAPIRejectsUnsignedRequests(t *testing.T) {
 	handler := NewHandler("token", nil, nil, nil, nil, nil)
 	mux := http.NewServeMux()

--- a/global/internal/miniapp/static/app.css
+++ b/global/internal/miniapp/static/app.css
@@ -443,6 +443,18 @@ select:focus, input[type="number"]:focus { border-color: var(--accent); box-shad
 .tab-label { font-size: 10px; letter-spacing: .01em; }
 #zakat-nisab-note { white-space: pre-line; }
 
+.places-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
+.places-map { position: relative; height: 260px; margin-top: 6px; overflow: hidden; border-radius: 16px; border: 1px solid var(--line); background: var(--surface-alt); touch-action: none; cursor: grab; }
+.places-map:active { cursor: grabbing; }
+.places-tiles { position: absolute; inset: 0; will-change: transform; }
+.places-tiles img { position: absolute; width: 256px; height: 256px; user-select: none; -webkit-user-drag: none; pointer-events: none; }
+.places-pin { position: absolute; top: 50%; left: 50%; z-index: 2; transform: translate(-50%, -100%); font-size: 30px; pointer-events: none; filter: drop-shadow(0 2px 3px rgba(0,0,0,.4)); }
+.places-zoom { position: absolute; right: 10px; bottom: 10px; z-index: 3; display: flex; flex-direction: column; gap: 6px; }
+.places-zoom button { width: 34px; height: 34px; border: 1px solid var(--line); border-radius: 10px; background: color-mix(in srgb, var(--surface) 92%, transparent); color: var(--app-text); font-size: 20px; font-weight: 700; line-height: 1; cursor: pointer; -webkit-backdrop-filter: blur(6px); backdrop-filter: blur(6px); }
+.places-attribution { position: absolute; left: 8px; bottom: 6px; z-index: 2; padding: 1px 6px; border-radius: 6px; color: var(--app-muted); background: color-mix(in srgb, var(--surface) 75%, transparent); font-size: 9px; }
+.places-location { margin: 12px 0 8px; min-height: 20px; font-size: 15px; font-weight: 750; text-align: center; }
+.places-schedule { margin-top: 10px; }
+
 .toast { position: fixed; z-index: 10; right: 16px; bottom: calc(18px + env(safe-area-inset-bottom)); left: 16px; max-width: 520px; margin: auto; padding: 14px 16px; border-radius: 15px; color: var(--accent-text); background: var(--accent); box-shadow: 0 12px 34px rgba(0,0,0,.2); font-size: 13px; font-weight: 700; text-align: center; }
 .toast.error { color: white; background: #a84040; }
 

--- a/global/internal/miniapp/static/app.js
+++ b/global/internal/miniapp/static/app.js
@@ -13,6 +13,9 @@
   let homeScreenStatus = "unknown";
   let zakatCurrency = "";
   let activeView = "prayer";
+  let placesDay = "today";
+  let placesLookupTimer = null;
+  const places = { z: 5, lat: 21.4225, lng: 39.8262, initialized: false, lastKey: "" };
   const troyOunceGrams = 31.1035;
   const offlineCacheVersion = 2;
   const offlineCacheMaxAge = 48 * 60 * 60 * 1000;
@@ -236,8 +239,14 @@
     setText("tab-prayer", labels.nav_prayer);
     setText("tab-dates", labels.nav_dates);
     setText("tab-zakat", labels.nav_zakat);
+    setText("tab-places", labels.nav_places);
     setText("tab-tools", labels.tools);
     setText("tab-settings", labels.settings);
+    setText("places-title", labels.places_title);
+    setText("places-help", labels.places_help);
+    setText("places-today-tab", labels.today);
+    setText("places-tomorrow-tab", labels.tomorrow);
+    setText("places-note", labels.calculated_locally);
   }
 
   function fillSelect(id, options, selected) {
@@ -1053,7 +1062,7 @@
   }
 
   function selectView(view) {
-    const known = ["prayer", "dates", "zakat", "tools", "settings"];
+    const known = ["prayer", "dates", "zakat", "places", "tools", "settings"];
     if (!known.includes(view)) view = "prayer";
     activeView = view;
     known.forEach((name) => {
@@ -1066,6 +1075,154 @@
       tab.setAttribute("aria-current", active ? "page" : "false");
     });
     window.scrollTo({ top: 0, behavior: "auto" });
+    if (view === "places") ensurePlacesMap();
+  }
+
+  // --- "Prayer times anywhere" map lookup (dependency-free OSM slippy map) ---
+
+  function lngToTileX(lng, z) { return (lng + 180) / 360 * Math.pow(2, z); }
+  function latToTileY(lat, z) {
+    const r = lat * Math.PI / 180;
+    return (1 - Math.log(Math.tan(r) + 1 / Math.cos(r)) / Math.PI) / 2 * Math.pow(2, z);
+  }
+  function tileXToLng(x, z) { return x / Math.pow(2, z) * 360 - 180; }
+  function tileYToLat(y, z) {
+    const n = Math.PI - 2 * Math.PI * y / Math.pow(2, z);
+    return 180 / Math.PI * Math.atan(0.5 * (Math.exp(n) - Math.exp(-n)));
+  }
+  function clampLat(lat) { return Math.max(-85.05, Math.min(85.05, lat)); }
+  function wrapLng(lng) { return ((lng + 180) % 360 + 360) % 360 - 180; }
+
+  function renderPlacesTiles() {
+    const map = byId("places-map");
+    const layer = byId("places-tiles");
+    const w = map.clientWidth, h = map.clientHeight;
+    if (!w || !h) return;
+    layer.style.transform = "";
+    layer.replaceChildren();
+    const z = places.z;
+    const world = Math.pow(2, z);
+    const originX = lngToTileX(places.lng, z) * 256 - w / 2;
+    const originY = latToTileY(places.lat, z) * 256 - h / 2;
+    const firstCol = Math.floor(originX / 256), lastCol = Math.floor((originX + w) / 256);
+    const firstRow = Math.floor(originY / 256), lastRow = Math.floor((originY + h) / 256);
+    for (let ty = firstRow; ty <= lastRow; ty += 1) {
+      if (ty < 0 || ty >= world) continue;
+      for (let tx = firstCol; tx <= lastCol; tx += 1) {
+        const wx = ((tx % world) + world) % world;
+        const img = document.createElement("img");
+        img.src = `https://tile.openstreetmap.org/${z}/${wx}/${ty}.png`;
+        img.alt = "";
+        img.style.left = `${tx * 256 - originX}px`;
+        img.style.top = `${ty * 256 - originY}px`;
+        layer.append(img);
+      }
+    }
+  }
+
+  function finishPan(dx, dy) {
+    const z = places.z;
+    places.lng = wrapLng(tileXToLng((lngToTileX(places.lng, z) * 256 - dx) / 256, z));
+    places.lat = clampLat(tileYToLat((latToTileY(places.lat, z) * 256 - dy) / 256, z));
+    renderPlacesTiles();
+    schedulePlacesLookup();
+  }
+
+  function setPlacesZoom(delta) {
+    places.z = Math.max(2, Math.min(18, places.z + delta));
+    renderPlacesTiles();
+    schedulePlacesLookup();
+  }
+
+  function ensurePlacesMap() {
+    places.initialized = true;
+    renderPlacesTiles();
+    if (!places.lastKey) schedulePlacesLookup();
+  }
+
+  function schedulePlacesLookup() {
+    clearTimeout(placesLookupTimer);
+    setText("places-location", "…");
+    placesLookupTimer = setTimeout(runPlacesLookup, 450);
+  }
+
+  async function runPlacesLookup() {
+    const lat = Number(places.lat.toFixed(4));
+    const lng = Number(places.lng.toFixed(4));
+    const key = `${lat},${lng},${placesDay}`;
+    if (key === places.lastKey) return;
+    places.lastKey = key;
+    try {
+      const data = await request("/api/miniapp/lookup", "POST", { latitude: lat, longitude: lng, day: placesDay });
+      setText("places-location", data.location_name || "");
+      renderPlacesSchedule(data.schedule);
+    } catch (_) {
+      places.lastKey = "";
+      setText("places-location", state ? state.labels.temporary_failure : "");
+    }
+  }
+
+  function renderPlacesSchedule(schedule) {
+    if (!schedule) return;
+    setText("places-gregorian", schedule.gregorian);
+    setText("places-hijri", `☾ ${schedule.hijri}`);
+    setText("places-timezone", schedule.timezone);
+    const grid = byId("places-grid");
+    grid.replaceChildren();
+    schedule.prayers.forEach((prayer) => {
+      const item = document.createElement("div");
+      item.className = "prayer";
+      const emoji = document.createElement("span");
+      emoji.className = "prayer-emoji";
+      emoji.textContent = prayer.emoji;
+      const name = document.createElement("span");
+      name.className = "prayer-name";
+      name.textContent = prayer.name;
+      const time = document.createElement("strong");
+      time.className = "prayer-time";
+      time.textContent = prayer.time;
+      item.append(emoji, name, time);
+      grid.append(item);
+    });
+  }
+
+  function selectPlacesDay(day) {
+    placesDay = day;
+    ["today", "tomorrow"].forEach((name) => {
+      const tab = byId(`places-${name}-tab`);
+      const active = name === day;
+      tab.classList.toggle("active", active);
+      tab.setAttribute("aria-selected", String(active));
+    });
+    places.lastKey = "";
+    runPlacesLookup();
+  }
+
+  function bindPlacesMap() {
+    const map = byId("places-map");
+    if (!map) return;
+    let dragging = false, startX = 0, startY = 0, dx = 0, dy = 0;
+    map.addEventListener("pointerdown", (event) => {
+      dragging = true; startX = event.clientX; startY = event.clientY; dx = 0; dy = 0;
+      try { map.setPointerCapture(event.pointerId); } catch (_) { /* capture is best-effort */ }
+    });
+    map.addEventListener("pointermove", (event) => {
+      if (!dragging) return;
+      dx = event.clientX - startX; dy = event.clientY - startY;
+      byId("places-tiles").style.transform = `translate(${dx}px, ${dy}px)`;
+    });
+    const end = (event) => {
+      if (!dragging) return;
+      dragging = false;
+      try { map.releasePointerCapture(event.pointerId); } catch (_) { /* best-effort */ }
+      if (dx || dy) finishPan(dx, dy); else renderPlacesTiles();
+    };
+    map.addEventListener("pointerup", end);
+    map.addEventListener("pointercancel", () => { dragging = false; renderPlacesTiles(); });
+    byId("places-zoom-in").addEventListener("click", () => setPlacesZoom(1));
+    byId("places-zoom-out").addEventListener("click", () => setPlacesZoom(-1));
+    byId("places-today-tab").addEventListener("click", () => selectPlacesDay("today"));
+    byId("places-tomorrow-tab").addEventListener("click", () => selectPlacesDay("tomorrow"));
   }
 
   function selectDay(day) {
@@ -1084,6 +1241,7 @@
   document.querySelectorAll(".tab").forEach((tab) => {
     tab.addEventListener("click", () => selectView(tab.dataset.view));
   });
+  bindPlacesMap();
   byId("location-primary").addEventListener("click", (event) => updateLocation(event.currentTarget));
   byId("location-secondary").addEventListener("click", (event) => updateLocation(event.currentTarget));
   byId("start-compass").addEventListener("click", startCompass);

--- a/global/internal/miniapp/static/index.html
+++ b/global/internal/miniapp/static/index.html
@@ -115,6 +115,43 @@
           </section>
         </div>
 
+        <div class="view hidden" id="view-places">
+          <section class="panel places-panel">
+            <div class="panel-heading places-heading">
+              <div>
+                <h2 id="places-title">Prayer times anywhere</h2>
+                <p id="places-help" class="panel-help">Drag the map to any place to see its prayer times.</p>
+              </div>
+              <span class="section-icon" aria-hidden="true">🗺️</span>
+            </div>
+            <div id="places-map" class="places-map">
+              <div id="places-tiles" class="places-tiles"></div>
+              <div class="places-pin" aria-hidden="true">📍</div>
+              <div class="places-zoom">
+                <button id="places-zoom-in" type="button" aria-label="Zoom in">+</button>
+                <button id="places-zoom-out" type="button" aria-label="Zoom out">−</button>
+              </div>
+              <span class="places-attribution">© OpenStreetMap</span>
+            </div>
+            <p id="places-location" class="places-location"></p>
+            <div class="segmented" role="tablist" aria-label="Lookup day">
+              <button id="places-today-tab" class="segment active" type="button" role="tab" aria-selected="true">Today</button>
+              <button id="places-tomorrow-tab" class="segment" type="button" role="tab" aria-selected="false">Tomorrow</button>
+            </div>
+            <article class="schedule-card places-schedule">
+              <div class="schedule-heading">
+                <div>
+                  <p id="places-gregorian" class="date-primary"></p>
+                  <p id="places-hijri" class="date-secondary"></p>
+                </div>
+                <span id="places-timezone" class="timezone-pill"></span>
+              </div>
+              <div id="places-grid" class="prayer-grid"></div>
+              <p id="places-note" class="card-note"></p>
+            </article>
+          </section>
+        </div>
+
         <div class="view hidden" id="view-tools">
           <section class="panel tools-panel">
             <div class="panel-heading">
@@ -280,6 +317,9 @@
         </button>
         <button id="tab-zakat-btn" class="tab" type="button" data-view="zakat">
           <span class="tab-icon" aria-hidden="true">💰</span><span id="tab-zakat" class="tab-label">Zakat</span>
+        </button>
+        <button class="tab" type="button" data-view="places">
+          <span class="tab-icon" aria-hidden="true">🗺️</span><span id="tab-places" class="tab-label">Places</span>
         </button>
         <button class="tab" type="button" data-view="tools">
           <span class="tab-icon" aria-hidden="true">🧭</span><span id="tab-tools" class="tab-label">Tools</span>

--- a/global/internal/miniapp/static/sw.js
+++ b/global/internal/miniapp/static/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const cacheName = "global-prayer-miniapp-shell-v5";
+const cacheName = "global-prayer-miniapp-shell-v6";
 const shellAssets = [
   "./",
   "./app.css",


### PR DESCRIPTION
## What & why

The long-planned **"prayer times anywhere, any day"** feature — check prayer times for any place by dragging a pin on a map, **without changing your saved location**. Fully in the Mini App, as requested.

## How it works
New **Places** tab with a **draggable OpenStreetMap map** + center pin:
- Drag/zoom (debounced) → `POST /api/miniapp/lookup` with the pin coordinates and day.
- Server resolves timezone + place name (same Google resolver as a location change), builds a **transient profile** (never persisted; reuses your saved method/madhab/high-lat, or country defaults), and returns a localized schedule for **today or tomorrow**.
- **No profile write, no version bump, no reminder rebuild** — your saved location and reminders are untouched (covered by a test).

## Design decisions
- **Dependency-free map**: a small vanilla-JS slippy map using OSM **raster tiles as `<img>`** — allowed by the existing `img-src https:` CSP, so **no CSP change and no Maps key on the client**. Keeps the "dependency-free Mini App" principle.
- Default center is Makkah; Today/Tomorrow toggle; place name + `© OpenStreetMap` attribution shown.
- `sw.js` cache → v6; `nav_places` / `places_title` / `places_help` added for all 8 locales.

## ⚠️ Follow-up before scaling (documented in `runtime-and-deployment.md`)
The public `tile.openstreetmap.org` service is for **light use**; its usage policy discourages heavy/commercial traffic. Before this scales, switch the tile source to a policy-compliant provider (self-hosted or keyed, e.g. MapTiler/Carto). Functional now; not a long-term tile source.

## Verified
- Browser check at mobile width: OSM tiles load under the CSP, pin/zoom/attribution render, 6-tab bar fits (Places active), schedule displays (screenshots taken during dev).
- New tests: lookup returns a schedule and leaves the saved profile + planner untouched; Places markup, JS hooks, and per-locale labels present.
- `gofmt` / `go vet` / `go test ./...` clean on Go 1.26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)