### PR TITLE
Fix Mini App update lag + single-gear Settings icon

### DIFF
--- a/global/docs/request-flows.md
+++ b/global/docs/request-flows.md
@@ -79,6 +79,12 @@ the newly selected language.
 
 ### Cached startup and offline behavior
 
+The service worker serves the application shell (HTML, CSS, JavaScript)
+**network-first**: when online it always fetches the latest, so a new deploy is
+visible on the next launch without any manual cache clearing, and it falls back
+to the cached shell only when the network is unavailable. The Telegram SDK, a
+stable versioned URL, stays cache-first.
+
 On a returning launch, the Mini App reads a device-local snapshot scoped to the
 Telegram user and renders it immediately while requesting a fresh bootstrap.
 Snapshots older than 48 hours or missing a complete today/tomorrow schedule are

--- a/global/internal/miniapp/handler_test.go
+++ b/global/internal/miniapp/handler_test.go
@@ -215,6 +215,26 @@ func TestLookupReturnsScheduleWithoutChangingProfile(t *testing.T) {
 	}
 }
 
+func TestSettingsIconIsSingleGearAndShellIsNetworkFirst(t *testing.T) {
+	html, err := embeddedStatic.ReadFile("static/index.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(html), `class="tab-gear"`) {
+		t.Error("Settings tab is missing the single-gear SVG icon")
+	}
+	if strings.Contains(string(html), "🎛️") || strings.Contains(string(html), "⚙️") {
+		t.Error("Settings tab still uses a gear/knobs emoji instead of the single-gear SVG")
+	}
+	sw, err := embeddedStatic.ReadFile("static/sw.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(sw), "network-first") {
+		t.Error("service worker no longer documents its network-first shell strategy")
+	}
+}
+
 func TestMiniAppAPIRejectsUnsignedRequests(t *testing.T) {
 	handler := NewHandler("token", nil, nil, nil, nil, nil)
 	mux := http.NewServeMux()

--- a/global/internal/miniapp/static/app.css
+++ b/global/internal/miniapp/static/app.css
@@ -440,6 +440,7 @@ select:focus, input[type="number"]:focus { border-color: var(--accent); box-shad
 }
 .tab.active { color: var(--accent); background: color-mix(in srgb, var(--accent) 9%, transparent); }
 .tab-icon { font-size: 19px; line-height: 1; }
+.tab-icon .tab-gear { display: block; width: 21px; height: 21px; }
 .tab-label { font-size: 10px; letter-spacing: .01em; }
 #zakat-nisab-note { white-space: pre-line; }
 

--- a/global/internal/miniapp/static/index.html
+++ b/global/internal/miniapp/static/index.html
@@ -325,7 +325,7 @@
           <span class="tab-icon" aria-hidden="true">🧭</span><span id="tab-tools" class="tab-label">Tools</span>
         </button>
         <button class="tab" type="button" data-view="settings">
-          <span class="tab-icon" aria-hidden="true">🎛️</span><span id="tab-settings" class="tab-label">Settings</span>
+          <span class="tab-icon" aria-hidden="true"><svg class="tab-gear" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 0 0 .12-.61l-1.92-3.32a.488.488 0 0 0-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.484.484 0 0 0-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58a.49.49 0 0 0-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.21.08-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"/></svg></span><span id="tab-settings" class="tab-label">Settings</span>
         </button>
       </nav>
     </div>

--- a/global/internal/miniapp/static/sw.js
+++ b/global/internal/miniapp/static/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const cacheName = "global-prayer-miniapp-shell-v6";
+const cacheName = "global-prayer-miniapp-shell-v7";
 const shellAssets = [
   "./",
   "./app.css",
@@ -36,19 +36,38 @@ self.addEventListener("fetch", (event) => {
     url.pathname === "/js/telegram-web-app.js";
   if (!isAppShell && !isTelegramSDK) return;
 
-  event.respondWith((async () => {
-    const cached = await caches.match(event.request, { ignoreSearch: isTelegramSDK });
-    const network = fetch(event.request).then(async (response) => {
+  // The Telegram SDK is a stable, versioned URL, so cache-first avoids a network
+  // round-trip and never goes stale.
+  if (isTelegramSDK) {
+    event.respondWith((async () => {
+      const cached = await caches.match(event.request, { ignoreSearch: true });
+      if (cached) return cached;
+      const response = await fetch(event.request);
       if (response.ok || response.type === "opaque") {
         const cache = await caches.open(cacheName);
         await cache.put(event.request, response.clone());
       }
       return response;
-    });
-    if (cached) {
-      void network.catch(() => undefined);
-      return cached;
+    })());
+    return;
+  }
+
+  // The app shell (HTML, CSS, JS) is network-first: a fresh deploy is visible on
+  // the next launch without any manual cache clearing, while the cached copy is
+  // still used as an offline fallback so a previously opened Mini App can start
+  // during a network interruption.
+  event.respondWith((async () => {
+    try {
+      const response = await fetch(event.request);
+      if (response.ok) {
+        const cache = await caches.open(cacheName);
+        await cache.put(event.request, response.clone());
+      }
+      return response;
+    } catch (error) {
+      const cached = await caches.match(event.request);
+      if (cached) return cached;
+      throw error;
     }
-    return network;
   })());
 });


### PR DESCRIPTION
## What & why

Two related fixes for one root cause: users (on some devices) kept seeing the **old cached UI** — including the old double-gear Settings icon — so shipped changes didn't appear.

### 1. Service worker: network-first shell (the real fix)
`sw.js` served the whole app shell (`index.html`, `app.js`, `app.css`) **cache-first** (stale-while-revalidate), so every launch showed the previous version and updates lagged at least one launch — inconsistently across devices depending on when Telegram re-fetched `sw.js`.

Now the shell is **network-first**: fetch the latest when online, fall back to cache only when offline. A deploy is visible on the **next launch, on every device, with no manual cache clearing**. Offline start still works (cache fallback). The Telegram SDK (stable versioned URL) stays cache-first. Cache bumped to `v7`.

### 2. Settings icon: single-gear SVG
Apple renders the `⚙️` emoji as a **large gear + small gear** (the "two gears" you saw). Since there's no single-gear emoji, the Settings tab now uses an **inline SVG gear** with `currentColor`, sized to match the emoji tabs — guaranteed exactly one gear on every platform. Verified in the browser (screenshot during dev): one clean gear, accent-colored when active.

## Tests
- New: asserts the single-gear SVG is present (and no gear/knobs emoji remains) and that the SW documents its network-first strategy.
- `gofmt` / `go vet` / `go test ./...` clean on Go 1.26.

## Note for existing installs
There's a **one-time** lag to roll onto the new `v7` service worker (the current `v6` is still cache-first, so it serves itself once before `v7` installs). After that, all future updates appear immediately. To see it right now without waiting: Telegram → Settings → Data and Storage → Clear Cache, then reopen the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)