### PR TITLE
Reorganize Mini App nav: Zakat into Tools, share card on home

### DIFF
--- a/global/internal/miniapp/handler_test.go
+++ b/global/internal/miniapp/handler_test.go
@@ -115,10 +115,14 @@ func TestZakatCalculatorMarkupAndLabelsExist(t *testing.T) {
 			t.Errorf("index.html is missing Zakat calculator element %q", id)
 		}
 	}
-	for _, marker := range []string{"tab-bar", "view-prayer", "view-zakat", "data-view=\"prayer\""} {
+	for _, marker := range []string{"tab-bar", "view-prayer", "view-tools", "data-view=\"prayer\""} {
 		if !strings.Contains(string(html), marker) {
 			t.Errorf("index.html is missing section navigation marker %q", marker)
 		}
+	}
+	// The Zakat calculator now lives inside the Tools view; there is no Zakat tab.
+	if strings.Contains(string(html), `data-view="zakat"`) {
+		t.Error("Zakat should no longer be a top-level tab")
 	}
 	script, err := embeddedStatic.ReadFile("static/app.js")
 	if err != nil {

--- a/global/internal/miniapp/static/app.js
+++ b/global/internal/miniapp/static/app.js
@@ -238,7 +238,6 @@
     setText("zakat-disclaimer", labels.zakat_disclaimer);
     setText("tab-prayer", labels.nav_prayer);
     setText("tab-dates", labels.nav_dates);
-    setText("tab-zakat", labels.nav_zakat);
     setText("tab-places", labels.nav_places);
     setText("tab-tools", labels.tools);
     setText("tab-settings", labels.settings);
@@ -492,15 +491,11 @@
 
   function renderZakat() {
     const panel = byId("zakat-panel");
-    const tab = byId("tab-zakat-btn");
     const nisab = state.nisab;
     if (!nisab || !Array.isArray(nisab.currencies) || nisab.currencies.length === 0) {
       panel.classList.add("hidden");
-      if (tab) tab.classList.add("hidden");
-      if (activeView === "zakat") selectView("prayer");
       return;
     }
-    if (tab) tab.classList.remove("hidden");
     panel.classList.remove("hidden");
     if (!zakatCurrency || !nisab.rates[zakatCurrency]) zakatCurrency = nisab.default_currency;
     const select = byId("zakat-currency");
@@ -1062,7 +1057,7 @@
   }
 
   function selectView(view) {
-    const known = ["prayer", "dates", "zakat", "places", "tools", "settings"];
+    const known = ["prayer", "dates", "places", "tools", "settings"];
     if (!known.includes(view)) view = "prayer";
     activeView = view;
     known.forEach((name) => {

--- a/global/internal/miniapp/static/index.html
+++ b/global/internal/miniapp/static/index.html
@@ -67,6 +67,26 @@
               <p id="calculation-note" class="card-note"></p>
             </article>
           </section>
+
+          <section class="panel tools-panel">
+            <div class="tool-grid">
+              <article class="tool-card share-card">
+                <div class="tool-heading">
+                  <span class="tool-icon" aria-hidden="true">✨</span>
+                  <div>
+                    <h3 id="share-card-title">Share prayer card</h3>
+                    <p id="share-card-help">Create a beautiful image with the selected day’s prayer times.</p>
+                  </div>
+                </div>
+                <div class="share-card-preview" aria-hidden="true">
+                  <span class="share-preview-moon">☾</span>
+                  <strong id="share-preview-date"></strong>
+                  <span id="share-preview-time"></span>
+                </div>
+                <button id="share-prayer-card" class="primary-button compact" type="button">Create &amp; share</button>
+              </article>
+            </div>
+          </section>
         </div>
 
         <div class="view hidden" id="view-dates">
@@ -80,38 +100,6 @@
             </div>
             <div id="occasion-list" class="occasion-list"></div>
             <p id="occasions-disclaimer" class="occasion-disclaimer"></p>
-          </section>
-        </div>
-
-        <div class="view hidden" id="view-zakat">
-          <section id="zakat-panel" class="panel zakat-panel hidden">
-            <div class="panel-heading zakat-heading">
-              <div>
-                <h2 id="zakat-title">Zakat calculator</h2>
-                <p id="zakat-help" class="panel-help">Calculate zakat on your wealth.</p>
-              </div>
-              <span class="section-icon" aria-hidden="true">💰</span>
-            </div>
-            <div class="zakat-form">
-              <label><span id="zakat-currency-label">Currency</span>
-                <select id="zakat-currency"></select></label>
-              <label><span id="zakat-holdings-label">Your zakatable wealth</span>
-                <input id="zakat-holdings" type="number" min="0" step="any" inputmode="decimal" placeholder="0"></label>
-            </div>
-            <div class="zakat-summary">
-              <div class="zakat-row">
-                <span id="zakat-nisab-label">Niṣāb (minimum)</span>
-                <strong id="zakat-nisab-value" class="zakat-amount"></strong>
-              </div>
-              <p id="zakat-nisab-note" class="tool-note"></p>
-              <div class="zakat-row zakat-due-row">
-                <span id="zakat-due-label">Zakat due (2.5%)</span>
-                <strong id="zakat-due-value" class="zakat-amount zakat-due-amount"></strong>
-              </div>
-              <p id="zakat-status" class="tool-note zakat-status"></p>
-            </div>
-            <p id="zakat-disclaimer" class="occasion-disclaimer"></p>
-            <p id="zakat-updated" class="tool-note zakat-updated"></p>
           </section>
         </div>
 
@@ -221,23 +209,37 @@
                 <button id="add-home-screen" class="secondary-button" type="button">Add to home screen</button>
                 <p id="home-screen-status" class="tool-note hidden" role="status"></p>
               </article>
-
-              <article class="tool-card share-card">
-                <div class="tool-heading">
-                  <span class="tool-icon" aria-hidden="true">✨</span>
-                  <div>
-                    <h3 id="share-card-title">Share prayer card</h3>
-                    <p id="share-card-help">Create a beautiful image with the selected day’s prayer times.</p>
-                  </div>
-                </div>
-                <div class="share-card-preview" aria-hidden="true">
-                  <span class="share-preview-moon">☾</span>
-                  <strong id="share-preview-date"></strong>
-                  <span id="share-preview-time"></span>
-                </div>
-                <button id="share-prayer-card" class="primary-button compact" type="button">Create &amp; share</button>
-              </article>
             </div>
+          </section>
+
+          <section id="zakat-panel" class="panel zakat-panel hidden">
+            <div class="panel-heading zakat-heading">
+              <div>
+                <h2 id="zakat-title">Zakat calculator</h2>
+                <p id="zakat-help" class="panel-help">Calculate zakat on your wealth.</p>
+              </div>
+              <span class="section-icon" aria-hidden="true">💰</span>
+            </div>
+            <div class="zakat-form">
+              <label><span id="zakat-currency-label">Currency</span>
+                <select id="zakat-currency"></select></label>
+              <label><span id="zakat-holdings-label">Your zakatable wealth</span>
+                <input id="zakat-holdings" type="number" min="0" step="any" inputmode="decimal" placeholder="0"></label>
+            </div>
+            <div class="zakat-summary">
+              <div class="zakat-row">
+                <span id="zakat-nisab-label">Niṣāb (minimum)</span>
+                <strong id="zakat-nisab-value" class="zakat-amount"></strong>
+              </div>
+              <p id="zakat-nisab-note" class="tool-note"></p>
+              <div class="zakat-row zakat-due-row">
+                <span id="zakat-due-label">Zakat due (2.5%)</span>
+                <strong id="zakat-due-value" class="zakat-amount zakat-due-amount"></strong>
+              </div>
+              <p id="zakat-status" class="tool-note zakat-status"></p>
+            </div>
+            <p id="zakat-disclaimer" class="occasion-disclaimer"></p>
+            <p id="zakat-updated" class="tool-note zakat-updated"></p>
           </section>
         </div>
 
@@ -314,9 +316,6 @@
         </button>
         <button class="tab" type="button" data-view="dates">
           <span class="tab-icon" aria-hidden="true">🌙</span><span id="tab-dates" class="tab-label">Dates</span>
-        </button>
-        <button id="tab-zakat-btn" class="tab" type="button" data-view="zakat">
-          <span class="tab-icon" aria-hidden="true">💰</span><span id="tab-zakat" class="tab-label">Zakat</span>
         </button>
         <button class="tab" type="button" data-view="places">
           <span class="tab-icon" aria-hidden="true">🗺️</span><span id="tab-places" class="tab-label">Places</span>

--- a/global/internal/miniapp/static/sw.js
+++ b/global/internal/miniapp/static/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const cacheName = "global-prayer-miniapp-shell-v7";
+const cacheName = "global-prayer-miniapp-shell-v8";
 const shellAssets = [
   "./",
   "./app.css",


### PR DESCRIPTION
## What & why

Two navigation cleanups you requested, plus a note on the settings icon.

### 1. Zakat calculator → Tools (6 tabs → 5)
The Zakat calculator moves from its own top-level tab into the **Tools** section (below Qibla/Calendar). The tab bar is now **Prayer · Dates · Places · Tools · Settings** — less crowded. `renderZakat` still shows/hides the panel based on whether niṣāb prices are cached.

### 2. Share prayer card → Prayer home view
"Create & share prayer card" moves from Tools to the **Prayer home view**, right under the today/tomorrow schedule it shares — which is where the selected day lives.

`sw.js` cache bumped to **v8** so the new layout propagates on next launch.

## Settings icon (your 3rd point) — no code change needed
I verified the **bytes the testing deployment is actually serving**: `index.html` has a single inline SVG gear and **zero** gear/knob emoji, and `sw.js` is `v7` network-first. The two gears you saw are your **Telegram client's cached copy** of the old shell (the one-time v6→v7 transition). A full Telegram *Clear Cache* + reopen resolves it; it won't recur after that.

## Verified
Browser check at mobile width: 5 tabs, Share-card on home, Zakat under Tools (screenshots during dev). `gofmt` / `go vet` / `go test ./...` clean on Go 1.26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)