### PR TITLE
Fix second gear in Settings tab label

### DIFF
--- a/global/internal/miniapp/handler.go
+++ b/global/internal/miniapp/handler.go
@@ -978,7 +978,8 @@ func labels(locale i18n.Locale) map[string]string {
 		"zakat_due": copy.ZakatDue, "zakat_below": copy.ZakatBelow,
 		"zakat_disclaimer": copy.ZakatDisclaimer, "zakat_updated": copy.ZakatUpdated,
 		"nav_prayer": copy.NavPrayer, "nav_dates": copy.NavDates, "nav_zakat": copy.NavZakat,
-		"nav_places": copy.NavPlaces, "places_title": copy.PlacesTitle, "places_help": copy.PlacesHelp,
+		"nav_places": copy.NavPlaces, "nav_settings": copy.NavSettings,
+		"places_title": copy.PlacesTitle, "places_help": copy.PlacesHelp,
 	}
 }
 
@@ -1001,7 +1002,7 @@ type miniAppCopy struct {
 	ZakatTitle, ZakatHelp, ZakatCurrency, ZakatHoldings   string
 	ZakatNisab, ZakatNisabNote, ZakatDue, ZakatBelow      string
 	ZakatDisclaimer, ZakatUpdated                         string
-	NavPrayer, NavDates, NavZakat, NavPlaces              string
+	NavPrayer, NavDates, NavZakat, NavPlaces, NavSettings string
 	PlacesTitle, PlacesHelp                               string
 }
 
@@ -1036,7 +1037,7 @@ var miniCopy = map[string]miniAppCopy{
 		ZakatDue: "Zakat due (2.5%)", ZakatBelow: "Your wealth is below the nisab, so no zakat is due.",
 		ZakatDisclaimer: "Estimate based on live gold and silver prices. Consult a scholar for your situation.",
 		ZakatUpdated:    "Prices as of {date}",
-		NavPrayer:       "Prayer", NavDates: "Dates", NavZakat: "Zakat", NavPlaces: "Places",
+		NavPrayer:       "Prayer", NavDates: "Dates", NavZakat: "Zakat", NavPlaces: "Places", NavSettings: "Settings",
 		PlacesTitle: "Prayer times anywhere",
 		PlacesHelp:  "Drag the map to any place to see its prayer times.",
 	},
@@ -1070,7 +1071,7 @@ var miniCopy = map[string]miniAppCopy{
 		ZakatDue: "الزكاة المستحقة (2.5%)", ZakatBelow: "مالك دون النصاب، فلا زكاة عليك.",
 		ZakatDisclaimer: "تقدير بناءً على أسعار الذهب والفضة الحالية. استشر أهل العلم لحالتك.",
 		ZakatUpdated:    "الأسعار بتاريخ {date}",
-		NavPrayer:       "الصلاة", NavDates: "المناسبات", NavZakat: "الزكاة", NavPlaces: "أماكن",
+		NavPrayer:       "الصلاة", NavDates: "المناسبات", NavZakat: "الزكاة", NavPlaces: "أماكن", NavSettings: "الإعدادات",
 		PlacesTitle: "مواقيت الصلاة في أي مكان",
 		PlacesHelp:  "حرّك الخريطة إلى أي مكان لعرض مواقيت الصلاة فيه.",
 	},
@@ -1104,7 +1105,7 @@ var miniCopy = map[string]miniAppCopy{
 		ZakatDue: "Zakat a pagar (2,5%)", ZakatBelow: "Tu patrimonio está por debajo del nisab, así que no debes zakat.",
 		ZakatDisclaimer: "Estimación basada en precios actuales del oro y la plata. Consulta a un experto para tu caso.",
 		ZakatUpdated:    "Precios al {date}",
-		NavPrayer:       "Oración", NavDates: "Fechas", NavZakat: "Zakat", NavPlaces: "Lugares",
+		NavPrayer:       "Oración", NavDates: "Fechas", NavZakat: "Zakat", NavPlaces: "Lugares", NavSettings: "Ajustes",
 		PlacesTitle: "Horarios en cualquier lugar",
 		PlacesHelp:  "Arrastra el mapa a cualquier lugar para ver sus horarios de oración.",
 	},
@@ -1138,7 +1139,7 @@ var miniCopy = map[string]miniAppCopy{
 		ZakatDue: "Zakat à verser (2,5%)", ZakatBelow: "Votre patrimoine est inférieur au nisab, aucune zakat n’est due.",
 		ZakatDisclaimer: "Estimation basée sur les cours actuels de l’or et de l’argent. Consultez un savant pour votre cas.",
 		ZakatUpdated:    "Cours au {date}",
-		NavPrayer:       "Prière", NavDates: "Dates", NavZakat: "Zakat", NavPlaces: "Lieux",
+		NavPrayer:       "Prière", NavDates: "Dates", NavZakat: "Zakat", NavPlaces: "Lieux", NavSettings: "Réglages",
 		PlacesTitle: "Horaires n’importe où",
 		PlacesHelp:  "Faites glisser la carte vers n’importe quel lieu pour voir ses horaires de prière.",
 	},
@@ -1172,7 +1173,7 @@ var miniCopy = map[string]miniAppCopy{
 		ZakatDue: "Закят к выплате (2,5%)", ZakatBelow: "Ваше имущество ниже нисаба, поэтому закят не обязателен.",
 		ZakatDisclaimer: "Оценка на основе текущих цен на золото и серебро. Обратитесь к знающему для вашего случая.",
 		ZakatUpdated:    "Цены на {date}",
-		NavPrayer:       "Намаз", NavDates: "Даты", NavZakat: "Закят", NavPlaces: "Места",
+		NavPrayer:       "Намаз", NavDates: "Даты", NavZakat: "Закят", NavPlaces: "Места", NavSettings: "Настройки",
 		PlacesTitle: "Время намаза где угодно",
 		PlacesHelp:  "Перетащите карту на любое место, чтобы увидеть время намаза.",
 	},
@@ -1206,7 +1207,7 @@ var miniCopy = map[string]miniAppCopy{
 		ZakatDue: "Ödenecek zekât (%2,5)", ZakatBelow: "Malınız nisabın altında, bu yüzden zekât gerekmez.",
 		ZakatDisclaimer: "Güncel altın ve gümüş fiyatlarına dayalı tahmin. Durumunuz için bir âlime danışın.",
 		ZakatUpdated:    "{date} tarihli fiyatlar",
-		NavPrayer:       "Namaz", NavDates: "Günler", NavZakat: "Zekât", NavPlaces: "Yerler",
+		NavPrayer:       "Namaz", NavDates: "Günler", NavZakat: "Zekât", NavPlaces: "Yerler", NavSettings: "Ayarlar",
 		PlacesTitle: "Her yerde namaz vakitleri",
 		PlacesHelp:  "Namaz vakitlerini görmek için haritayı istediğiniz yere sürükleyin.",
 	},
@@ -1240,7 +1241,7 @@ var miniCopy = map[string]miniAppCopy{
 		ZakatDue: "To‘lanadigan zakot (2,5%)", ZakatBelow: "Mol-mulkingiz nisobdan kam, shuning uchun zakot vojib emas.",
 		ZakatDisclaimer: "Joriy oltin va kumush narxlariga asoslangan taxmin. Holatingiz uchun olimga murojaat qiling.",
 		ZakatUpdated:    "{date} holatidagi narxlar",
-		NavPrayer:       "Namoz", NavDates: "Sanalar", NavZakat: "Zakot", NavPlaces: "Joylar",
+		NavPrayer:       "Namoz", NavDates: "Sanalar", NavZakat: "Zakot", NavPlaces: "Joylar", NavSettings: "Sozlamalar",
 		PlacesTitle: "Istalgan joyda namoz vaqtlari",
 		PlacesHelp:  "Namoz vaqtlarini ko‘rish uchun xaritani istalgan joyga suring.",
 	},
@@ -1274,7 +1275,7 @@ var miniCopy = map[string]miniAppCopy{
 		ZakatDue: "Түләнәсе зәкят (2,5%)", ZakatBelow: "Мал-мөлкәтегез нисабтан ким, шуңа зәкят фарыз түгел.",
 		ZakatDisclaimer: "Хәзерге алтын һәм көмеш бәяләренә нигезләнгән бәя. Хәлегез өчен галимгә мөрәҗәгать итегез.",
 		ZakatUpdated:    "{date} көненә бәяләр",
-		NavPrayer:       "Намаз", NavDates: "Даталар", NavZakat: "Зәкят", NavPlaces: "Урыннар",
+		NavPrayer:       "Намаз", NavDates: "Даталар", NavZakat: "Зәкят", NavPlaces: "Урыннар", NavSettings: "Көйләүләр",
 		PlacesTitle: "Теләсә кайда намаз вакытлары",
 		PlacesHelp:  "Намаз вакытларын күрер өчен картаны теләсә кайсы урынга күчерегез.",
 	},

--- a/global/internal/miniapp/handler_test.go
+++ b/global/internal/miniapp/handler_test.go
@@ -239,6 +239,27 @@ func TestSettingsIconIsSingleGearAndShellIsNetworkFirst(t *testing.T) {
 	}
 }
 
+func TestSettingsTabLabelHasNoGearEmoji(t *testing.T) {
+	// The Settings tab already renders an SVG gear icon; its text label must be
+	// plain so the tab does not show a second (emoji) gear beside the word.
+	for _, locale := range i18n.Supported() {
+		label := labels(locale)["nav_settings"]
+		if label == "" {
+			t.Errorf("locale %q has no nav_settings label", locale.Code)
+		}
+		if strings.ContainsAny(label, "⚙🎛🛠") {
+			t.Errorf("locale %q settings tab label %q must not contain a gear emoji", locale.Code, label)
+		}
+	}
+	script, err := embeddedStatic.ReadFile("static/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(script), `setText("tab-settings", labels.nav_settings)`) {
+		t.Error("settings tab must use the emoji-free nav_settings label, not the button text")
+	}
+}
+
 func TestMiniAppAPIRejectsUnsignedRequests(t *testing.T) {
 	handler := NewHandler("token", nil, nil, nil, nil, nil)
 	mux := http.NewServeMux()

--- a/global/internal/miniapp/static/app.js
+++ b/global/internal/miniapp/static/app.js
@@ -240,7 +240,7 @@
     setText("tab-dates", labels.nav_dates);
     setText("tab-places", labels.nav_places);
     setText("tab-tools", labels.tools);
-    setText("tab-settings", labels.settings);
+    setText("tab-settings", labels.nav_settings);
     setText("places-title", labels.places_title);
     setText("places-help", labels.places_help);
     setText("places-today-tab", labels.today);

--- a/global/internal/miniapp/static/sw.js
+++ b/global/internal/miniapp/static/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const cacheName = "global-prayer-miniapp-shell-v8";
+const cacheName = "global-prayer-miniapp-shell-v9";
 const shellAssets = [
   "./",
   "./app.css",


### PR DESCRIPTION
## What & why — this was a real bug, not caching

The Settings tab renders an SVG gear **icon**, but its **text label** was pulled from the bot's keyboard button string — which is `"⚙️ Настройки"` (and `"⚙️ Settings"`, `"⚙️ Ajustes"`, …). That leading gear **emoji** showed up beside the label, so the tab displayed **two gears**: the SVG icon *and* an emoji next to the word.

I missed this earlier because the emoji is injected at **runtime from i18n** (`locale.Button(ActionSettings)`), not present in the static HTML I was grepping — and my browser screenshots manually typed "Settings" into the label instead of using the real translation. Thanks to @escalopa for insisting it wasn't caching.

## Fix
Add a plain, emoji-free `nav_settings` label (all 8 locales) and use it for the tab instead of the button text. The tab now shows just the single SVG gear above a clean "Настройки" / "Settings" / etc.

- `sw.js` cache → v9.
- **Test:** asserts `nav_settings` contains no gear/tool emoji in any locale and that the tab uses `labels.nav_settings`.

## Verified
Rendered the tab with the **real** Russian label this time (no manual override): single gear icon + plain "Настройки", no emoji. `gofmt` / `go vet` / `go test ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)