### PR TITLE
Serve /health for external checks; GFE intercepts /healthz

### DIFF
--- a/global/docs/operations.md
+++ b/global/docs/operations.md
@@ -2,7 +2,12 @@
 
 ## Health and logs
 
-All services expose `GET /healthz`. Application logs include update IDs or delivery keys, never full Telegram updates, coordinates, database URLs, bot tokens, webhook secrets, or Maps keys.
+All services expose `GET /health` (use this for external checks) and
+`GET /healthz` (container-internal only: Google Front End intercepts `/healthz`
+on `run.app` domains and returns its own 404 before the request reaches the
+service). Application logs include update IDs or delivery keys, never full
+Telegram updates, coordinates, database URLs, bot tokens, webhook secrets, or
+Maps keys.
 
 Useful alerts are Cloud Run 5xx rate, Cloud Tasks oldest task age, queue retry count, Scheduler failures, PostgreSQL connection errors, and Google Time Zone/Geocoding non-`OK` statuses.
 

--- a/global/docs/runtime-and-deployment.md
+++ b/global/docs/runtime-and-deployment.md
@@ -130,7 +130,8 @@ so infrastructure deployment is not rolled back by a cosmetic operation.
 
 1. Confirm the workflow summary shows successful tests, migration, Terraform,
    and webhook configuration.
-2. Check `GET /healthz` for all three services.
+2. Check `GET /health` for all three services (`/healthz` is intercepted by
+   Google Front End on `run.app` domains and never reaches the container).
 3. Run `/start`, `/today`, and one settings save in the selected bot.
 4. Open the Mini App from Telegram and verify bootstrap, location state, and
    today/tomorrow switching.

--- a/global/internal/httpx/server.go
+++ b/global/internal/httpx/server.go
@@ -40,8 +40,14 @@ func Serve(port string, handler http.Handler) error {
 	}
 }
 
+// HealthMux registers the health endpoints. Google Front End intercepts
+// "/healthz" at the edge on run.app domains and answers 404 before the request
+// reaches the container, so "/health" is the route external checks must use;
+// "/healthz" is kept for container-internal probes and local runs.
 func HealthMux(mux *http.ServeMux) {
-	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
+	health := func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
-	})
+	}
+	mux.HandleFunc("GET /health", health)
+	mux.HandleFunc("GET /healthz", health)
 }

--- a/global/internal/httpx/server_test.go
+++ b/global/internal/httpx/server_test.go
@@ -1,0 +1,21 @@
+package httpx
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Google Front End intercepts /healthz on run.app domains, so the externally
+// reachable route is /health; /healthz stays for container-internal probes.
+func TestHealthMuxServesBothRoutes(t *testing.T) {
+	mux := http.NewServeMux()
+	HealthMux(mux)
+	for _, path := range []string{"/health", "/healthz"} {
+		response := httptest.NewRecorder()
+		mux.ServeHTTP(response, httptest.NewRequest(http.MethodGet, path, nil))
+		if response.Code != http.StatusNoContent {
+			t.Errorf("GET %s = %d, want %d", path, response.Code, http.StatusNoContent)
+		}
+	}
+}


### PR DESCRIPTION
## What & why

Found during a stability sweep: the documented post-deploy check `GET /healthz` **can never succeed** on the public `run.app` URLs — Google Front End reserves `/healthz` at the edge and answers its own HTML 404 before the request reaches the container.

**Proof (live testing service):**
- `GET /healthz` → HTTP 404, `content-type: text/html`, Google's "Error 404 (Not Found)!!1" page, **no** `x-cloud-trace-context` header (never reached Cloud Run)
- `GET /healthz2` and `GET /nonexistent` → plain-text Go-mux 404 **with** a trace header (reached the container fine)

## Fix
- `httpx.HealthMux` now registers `GET /health` (externally reachable) alongside `GET /healthz` (kept for container-internal probes/local runs) — both return 204.
- `operations.md` and `runtime-and-deployment.md` post-deploy checks now point at `/health` and explain the GFE interception.
- New test asserts both routes return 204.

No Terraform probes referenced `/healthz`, so nothing else changes. `gofmt` / `go vet` / `go test ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)