### PR TITLE
Bump global workflow actions to Node 24 majors

### DIFF
--- a/.github/workflows/global-ci.yaml
+++ b/.github/workflows/global-ci.yaml
@@ -22,8 +22,8 @@ jobs:
       run:
         working-directory: global
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: '1.26.x'
           cache-dependency-path: global/go.sum
@@ -39,8 +39,8 @@ jobs:
       run:
         working-directory: global/infra/gcp
     steps:
-      - uses: actions/checkout@v4
-      - uses: hashicorp/setup-terraform@v3
+      - uses: actions/checkout@v7
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: '1.13.3'
       - run: terraform fmt -check -recursive

--- a/.github/workflows/global-deploy.yaml
+++ b/.github/workflows/global-deploy.yaml
@@ -30,22 +30,22 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment == 'testing' && 'dev' || 'prod' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: '1.26.x'
           cache-dependency-path: global/go.sum
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: '1.13.3'
 
-      - uses: google-github-actions/auth@v2
+      - uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@v3
 
       - name: Test global module
         id: tests


### PR DESCRIPTION
## What & why
Every global deploy run carries a "Node.js 20 is deprecated" annotation because the workflow actions target Node 20. Bumps `global-ci.yaml` and `global-deploy.yaml` to the current Node-24-native majors:

| Action | From | To |
| --- | --- | --- |
| actions/checkout | v4 | **v7** |
| actions/setup-go | v5 | **v7** |
| hashicorp/setup-terraform | v3 | **v4** |
| google-github-actions/auth | v2 | **v3** |
| google-github-actions/setup-gcloud | v2 | **v3** |

Workflow inputs are unchanged (all existing parameters remain valid in the new majors). `global-ci` on this PR exercises checkout/setup-go/setup-terraform directly; auth/setup-gcloud get exercised on the next manual deploy. Legacy `deploy.yaml` untouched per the global-only doctrine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)