### PR TITLE
Add white days (Ayyām al-Bīḍ) fasting reminders

### DIFF
--- a/global/docs/data-model.md
+++ b/global/docs/data-model.md
@@ -150,7 +150,9 @@ category:
 - `islamic_occasion`
 
 Before-prayer and at-prayer messages deliberately share `prayer`. All three
-Islamic occasion rule kinds deliberately share `islamic_occasion`.
+Islamic occasion rule kinds deliberately share `islamic_occasion`, and the
+`white_days` rule kind deliberately shares `weekly_fasting` because both are
+"fasting tomorrow" notices where only the latest matters.
 
 ### `calendar_subscriptions`
 

--- a/global/docs/reminder-delivery.md
+++ b/global/docs/reminder-delivery.md
@@ -62,11 +62,18 @@ same task twice returns `AlreadyExists` and is treated as success.
 | Prayer time | `prayer` | Replaces its pre-reminder, or the preceding prayer |
 | Tomorrow reminder | `tomorrow` | Replaces the prior tomorrow reminder |
 | Monday/Thursday fasting | `weekly_fasting` | Replaces only the prior fasting reminder |
+| White days fasting (Hijri 13–15) | `weekly_fasting` | Shares the fasting slot: only the latest "fasting tomorrow" notice remains |
 | Friday Al-Kahf | `weekly_kahf` | Replaces only the prior Al-Kahf reminder |
 | Major, fasting, or commonly observed Islamic occasion | `islamic_occasion` | Replaces the prior Islamic occasion reminder |
 
 Every message also expires after 36 hours because Telegram cannot delete bot
 messages once they are older than 48 hours.
+
+White days (Ayyam al-Bid) recurrence is calculated from the Hijri calendar with
+the profile's -2 to +2 day correction: the planner scans forward for the next
+Gregorian day whose corrected Hijri day is 13, 14, or 15 and schedules the
+reminder for 20:00 on the preceding local evening, mirroring the weekly fasting
+reminder.
 
 Islamic occasion recurrence is calculated, not stored as a list of Gregorian
 dates. The planner scans the curated Hijri catalog with the profile's -2 to +2

--- a/global/internal/domain/domain.go
+++ b/global/internal/domain/domain.go
@@ -185,6 +185,9 @@ const (
 	ReminderOccasionMajor    ReminderKind = "occasion_major"
 	ReminderOccasionFasting  ReminderKind = "occasion_fasting"
 	ReminderOccasionObserved ReminderKind = "occasion_observed"
+	// ReminderWhiteDays reminds on the evening before each of the 13th, 14th,
+	// and 15th Hijri days (Ayyam al-Bid), when voluntary fasting is recommended.
+	ReminderWhiteDays ReminderKind = "white_days"
 )
 
 func (kind ReminderKind) Weekly() bool {

--- a/global/internal/i18n/catalog_extensions.go
+++ b/global/internal/i18n/catalog_extensions.go
@@ -12,9 +12,12 @@ func init() {
 			buttons: map[string]string{
 				"hijri": "🌙 Hijri date correction", "prayer_reminders": "Prayer times",
 				"fasting_reminders": "Monday & Thursday fasting", "kahf_reminders": "Friday Al-Kahf",
+				"white_days_reminders": "White days fasting (13–15)",
 			},
 			text: map[string]string{
-				"reminders_title": "<b>Reminders</b> 🔔", "enabled": "enabled", "disabled": "disabled",
+				"white_days_schedule": "Evening before the 13th–15th Hijri days · 20:00",
+				"reminder_white_days": "<b>White days reminder</b> 🌕\nTomorrow is %d %s, one of the white days (Ayyām al-Bīḍ). Fasting it is a beloved Sunnah.",
+				"reminders_title":     "<b>Reminders</b> 🔔", "enabled": "enabled", "disabled": "disabled",
 				"pre_prayer_reminder": "Pre-prayer reminder", "pre_reminder_off": "At prayer time only", "minutes_before": "%d minutes before",
 				"choose_pre_reminder": "<b>Choose a pre-prayer reminder</b> ⏳\n\nYou will receive one message before every obligatory prayer, followed by the prayer-time notification.",
 				"fasting_schedule":    "Evening before · 20:00", "kahf_schedule": "Friday · 09:00",
@@ -26,9 +29,11 @@ func init() {
 			hijriMonths: []string{"Muharram", "Safar", "Rabi' al-Awwal", "Rabi' al-Thani", "Jumada al-Awwal", "Jumada al-Thani", "Rajab", "Sha'ban", "Ramadan", "Shawwal", "Dhu al-Qi'dah", "Dhu al-Hijjah"},
 		},
 		"ar": {
-			buttons: map[string]string{"hijri": "🌙 تصحيح التاريخ الهجري", "prayer_reminders": "مواقيت الصلاة", "fasting_reminders": "صيام الاثنين والخميس", "kahf_reminders": "سورة الكهف يوم الجمعة"},
+			buttons: map[string]string{"hijri": "🌙 تصحيح التاريخ الهجري", "prayer_reminders": "مواقيت الصلاة", "fasting_reminders": "صيام الاثنين والخميس", "kahf_reminders": "سورة الكهف يوم الجمعة", "white_days_reminders": "صيام الأيام البيض (13–15)"},
 			text: map[string]string{
-				"reminders_title": "<b>التنبيهات</b> 🔔", "enabled": "مفعّل", "disabled": "متوقف", "fasting_schedule": "مساء اليوم السابق · 20:00", "kahf_schedule": "الجمعة · 09:00",
+				"white_days_schedule": "مساء ما قبل 13–15 هجريًا · 20:00",
+				"reminder_white_days": "<b>تذكير الأيام البيض</b> 🌕\nغدًا %d %s، أحد الأيام البيض. صيامها سنة مستحبة، تقبل الله منك.",
+				"reminders_title":     "<b>التنبيهات</b> 🔔", "enabled": "مفعّل", "disabled": "متوقف", "fasting_schedule": "مساء اليوم السابق · 20:00", "kahf_schedule": "الجمعة · 09:00",
 				"pre_prayer_reminder": "تنبيه قبل الصلاة", "pre_reminder_off": "عند دخول وقت الصلاة فقط", "minutes_before": "قبل الصلاة بـ %d دقيقة",
 				"choose_pre_reminder": "<b>اختر موعد التنبيه قبل الصلاة</b> ⏳\n\nسيصلك تنبيه قبل كل صلاة مفروضة، ثم تنبيه عند دخول وقت الصلاة.",
 				"hijri_date":          "التاريخ الهجري", "hijri_era": "هـ", "hijri_setting": "تصحيح أم القرى: %+d يوم", "hijri_note": "أم القرى · محسوب", "choose_hijri": "<b>تصحيح التاريخ الهجري المحسوب</b> 🌙\n\nقد يختلف ثبوت الهلال محليًا. اختر تصحيحًا من −2 إلى +2 يوم، والقيمة الحالية مميزة بعلامة ✓.",
@@ -37,9 +42,11 @@ func init() {
 			hijriMonths: []string{"محرم", "صفر", "ربيع الأول", "ربيع الآخر", "جمادى الأولى", "جمادى الآخرة", "رجب", "شعبان", "رمضان", "شوال", "ذو القعدة", "ذو الحجة"},
 		},
 		"es": {
-			buttons: map[string]string{"hijri": "🌙 Corrección de fecha hiyri", "prayer_reminders": "Horarios de oración", "fasting_reminders": "Ayuno lunes y jueves", "kahf_reminders": "Al-Kahf del viernes"},
+			buttons: map[string]string{"hijri": "🌙 Corrección de fecha hiyri", "prayer_reminders": "Horarios de oración", "fasting_reminders": "Ayuno lunes y jueves", "kahf_reminders": "Al-Kahf del viernes", "white_days_reminders": "Ayuno de los días blancos (13–15)"},
 			text: map[string]string{
-				"reminders_title": "<b>Recordatorios</b> 🔔", "enabled": "activado", "disabled": "desactivado", "fasting_schedule": "Víspera · 20:00", "kahf_schedule": "Viernes · 09:00",
+				"white_days_schedule": "Víspera de los días 13–15 hiyri · 20:00",
+				"reminder_white_days": "<b>Recordatorio de los días blancos</b> 🌕\nMañana es %d de %s, uno de los días blancos. Ayunarlos es una sunna recomendada.",
+				"reminders_title":     "<b>Recordatorios</b> 🔔", "enabled": "activado", "disabled": "desactivado", "fasting_schedule": "Víspera · 20:00", "kahf_schedule": "Viernes · 09:00",
 				"pre_prayer_reminder": "Aviso antes de la oración", "pre_reminder_off": "Solo al comenzar la oración", "minutes_before": "%d minutos antes",
 				"choose_pre_reminder": "<b>Elige el aviso previo</b> ⏳\n\nRecibirás un mensaje antes de cada oración obligatoria y otro cuando llegue su hora.",
 				"hijri_date":          "Fecha hiyri", "hijri_era": "AH", "hijri_setting": "Corrección Umm al-Qura: %+d día(s)", "hijri_note": "Umm al-Qura · calculada", "choose_hijri": "<b>Corrige la fecha hiyri calculada</b> 🌙\n\nLa observación lunar local puede variar. Elige una corrección de −2 a +2 días; el valor actual está marcado ✓.",
@@ -48,9 +55,11 @@ func init() {
 			hijriMonths: []string{"Muharram", "Safar", "Rabi al-Awwal", "Rabi al-Thani", "Yumada al-Awwal", "Yumada al-Thani", "Rayab", "Sha'ban", "Ramadán", "Shawwal", "Dhu al-Qi'dah", "Dhu al-Hiyyah"},
 		},
 		"fr": {
-			buttons: map[string]string{"hijri": "🌙 Correction de date hégirienne", "prayer_reminders": "Horaires de prière", "fasting_reminders": "Jeûne lundi et jeudi", "kahf_reminders": "Al-Kahf du vendredi"},
+			buttons: map[string]string{"hijri": "🌙 Correction de date hégirienne", "prayer_reminders": "Horaires de prière", "fasting_reminders": "Jeûne lundi et jeudi", "kahf_reminders": "Al-Kahf du vendredi", "white_days_reminders": "Jeûne des jours blancs (13–15)"},
 			text: map[string]string{
-				"reminders_title": "<b>Rappels</b> 🔔", "enabled": "activé", "disabled": "désactivé", "fasting_schedule": "La veille · 20:00", "kahf_schedule": "Vendredi · 09:00",
+				"white_days_schedule": "La veille des 13–15 hégiriens · 20:00",
+				"reminder_white_days": "<b>Rappel des jours blancs</b> 🌕\nDemain est le %d %s, l'un des jours blancs. Les jeûner est une sunna recommandée.",
+				"reminders_title":     "<b>Rappels</b> 🔔", "enabled": "activé", "disabled": "désactivé", "fasting_schedule": "La veille · 20:00", "kahf_schedule": "Vendredi · 09:00",
 				"pre_prayer_reminder": "Rappel avant la prière", "pre_reminder_off": "À l’heure de la prière uniquement", "minutes_before": "%d minutes avant",
 				"choose_pre_reminder": "<b>Choisissez le rappel préalable</b> ⏳\n\nVous recevrez un message avant chaque prière obligatoire, puis un autre à l’heure de la prière.",
 				"hijri_date":          "Date hégirienne", "hijri_era": "AH", "hijri_setting": "Correction Umm al-Qura : %+d jour(s)", "hijri_note": "Umm al-Qura · calculée", "choose_hijri": "<b>Corrigez la date hégirienne calculée</b> 🌙\n\nL'observation locale de la lune peut différer. Choisissez de −2 à +2 jours ; la valeur actuelle est marquée ✓.",
@@ -59,9 +68,11 @@ func init() {
 			hijriMonths: []string{"Mouharram", "Safar", "Rabi al-Awwal", "Rabi al-Thani", "Joumada al-Awwal", "Joumada al-Thani", "Rajab", "Chaabane", "Ramadan", "Chawwal", "Dhou al-Qi'dah", "Dhou al-Hijjah"},
 		},
 		"ru": {
-			buttons: map[string]string{"hijri": "🌙 Поправка даты Хиджры", "prayer_reminders": "Время намаза", "fasting_reminders": "Пост в понедельник и четверг", "kahf_reminders": "Аль-Кахф в пятницу"},
+			buttons: map[string]string{"hijri": "🌙 Поправка даты Хиджры", "prayer_reminders": "Время намаза", "fasting_reminders": "Пост в понедельник и четверг", "kahf_reminders": "Аль-Кахф в пятницу", "white_days_reminders": "Пост в белые дни (13–15)"},
 			text: map[string]string{
-				"reminders_title": "<b>Напоминания</b> 🔔", "enabled": "включено", "disabled": "выключено", "fasting_schedule": "Накануне · 20:00", "kahf_schedule": "Пятница · 09:00",
+				"white_days_schedule": "Накануне 13–15 чисел Хиджры · 20:00",
+				"reminder_white_days": "<b>Напоминание о белых днях</b> 🌕\nЗавтра %d %s — один из белых дней (айям аль-бид). Пост в эти дни — желательная сунна.",
+				"reminders_title":     "<b>Напоминания</b> 🔔", "enabled": "включено", "disabled": "выключено", "fasting_schedule": "Накануне · 20:00", "kahf_schedule": "Пятница · 09:00",
 				"pre_prayer_reminder": "Напоминание перед намазом", "pre_reminder_off": "Только при наступлении намаза", "minutes_before": "За %d мин.",
 				"choose_pre_reminder": "<b>Выберите предварительное напоминание</b> ⏳\n\nВы получите сообщение перед каждым обязательным намазом, а затем — при наступлении его времени.",
 				"hijri_date":          "Дата Хиджры", "hijri_era": "г. х.", "hijri_setting": "Поправка Умм аль-Кура: %+d дн.", "hijri_note": "Умм аль-Кура · расчёт", "choose_hijri": "<b>Поправка расчётной даты Хиджры</b> 🌙\n\nМестное наблюдение луны может отличаться. Выберите от −2 до +2 дней; текущее значение отмечено ✓.",
@@ -70,9 +81,11 @@ func init() {
 			hijriMonths: []string{"Мухаррам", "Сафар", "Раби аль-авваль", "Раби ас-сани", "Джумада аль-уля", "Джумада ас-сания", "Раджаб", "Шаабан", "Рамадан", "Шавваль", "Зуль-када", "Зуль-хиджа"},
 		},
 		"tr": {
-			buttons: map[string]string{"hijri": "🌙 Hicri tarih düzeltmesi", "prayer_reminders": "Namaz vakitleri", "fasting_reminders": "Pazartesi ve Perşembe orucu", "kahf_reminders": "Cuma Kehf Suresi"},
+			buttons: map[string]string{"hijri": "🌙 Hicri tarih düzeltmesi", "prayer_reminders": "Namaz vakitleri", "fasting_reminders": "Pazartesi ve Perşembe orucu", "kahf_reminders": "Cuma Kehf Suresi", "white_days_reminders": "Beyaz günler orucu (13–15)"},
 			text: map[string]string{
-				"reminders_title": "<b>Hatırlatıcılar</b> 🔔", "enabled": "açık", "disabled": "kapalı", "fasting_schedule": "Önceki akşam · 20:00", "kahf_schedule": "Cuma · 09:00",
+				"white_days_schedule": "Hicri 13–15 öncesi akşam · 20:00",
+				"reminder_white_days": "<b>Beyaz günler hatırlatıcısı</b> 🌕\nYarın %d %s — beyaz günlerden (Eyyâm-ı Bîd) biridir. Bu günlerde oruç tutmak müstehap bir sünnettir.",
+				"reminders_title":     "<b>Hatırlatıcılar</b> 🔔", "enabled": "açık", "disabled": "kapalı", "fasting_schedule": "Önceki akşam · 20:00", "kahf_schedule": "Cuma · 09:00",
 				"pre_prayer_reminder": "Namaz öncesi hatırlatma", "pre_reminder_off": "Yalnızca namaz vaktinde", "minutes_before": "%d dakika önce",
 				"choose_pre_reminder": "<b>Namaz öncesi hatırlatmayı seçin</b> ⏳\n\nHer farz namazdan önce bir mesaj, vakit geldiğinde de ikinci bir bildirim alırsınız.",
 				"hijri_date":          "Hicri tarih", "hijri_era": "H", "hijri_setting": "Ümmü'l-Kurâ düzeltmesi: %+d gün", "hijri_note": "Ümmü'l-Kurâ · hesaplandı", "choose_hijri": "<b>Hesaplanan Hicri tarihi düzeltin</b> 🌙\n\nYerel hilal gözlemi farklı olabilir. −2 ile +2 gün arasında seçim yapın; geçerli değer ✓ ile işaretlidir.",
@@ -81,9 +94,11 @@ func init() {
 			hijriMonths: []string{"Muharrem", "Safer", "Rebiülevvel", "Rebiülahir", "Cemaziyelevvel", "Cemaziyelahir", "Recep", "Şaban", "Ramazan", "Şevval", "Zilkade", "Zilhicce"},
 		},
 		"uz": {
-			buttons: map[string]string{"hijri": "🌙 Hijriy sana tuzatishi", "prayer_reminders": "Namoz vaqtlari", "fasting_reminders": "Dushanba va payshanba ro‘zasi", "kahf_reminders": "Juma kuni Kahf surasi"},
+			buttons: map[string]string{"hijri": "🌙 Hijriy sana tuzatishi", "prayer_reminders": "Namoz vaqtlari", "fasting_reminders": "Dushanba va payshanba ro‘zasi", "kahf_reminders": "Juma kuni Kahf surasi", "white_days_reminders": "Oq kunlar ro‘zasi (13–15)"},
 			text: map[string]string{
-				"reminders_title": "<b>Eslatmalar</b> 🔔", "enabled": "yoqilgan", "disabled": "o‘chirilgan", "fasting_schedule": "Oldingi oqshom · 20:00", "kahf_schedule": "Juma · 09:00",
+				"white_days_schedule": "Hijriy 13–15 oldidan oqshom · 20:00",
+				"reminder_white_days": "<b>Oq kunlar eslatmasi</b> 🌕\nErtaga %d %s — oq kunlarning (ayyomul-biyz) biri. Bu kunlarda ro‘za tutish mustahab sunnatdir.",
+				"reminders_title":     "<b>Eslatmalar</b> 🔔", "enabled": "yoqilgan", "disabled": "o‘chirilgan", "fasting_schedule": "Oldingi oqshom · 20:00", "kahf_schedule": "Juma · 09:00",
 				"pre_prayer_reminder": "Namozdan oldingi eslatma", "pre_reminder_off": "Faqat namoz vaqtida", "minutes_before": "%d daqiqa oldin",
 				"choose_pre_reminder": "<b>Namozdan oldingi eslatmani tanlang</b> ⏳\n\nHar bir farz namozidan oldin va namoz vaqti kirganda alohida xabar olasiz.",
 				"hijri_date":          "Hijriy sana", "hijri_era": "h.", "hijri_setting": "Umm al-Qura tuzatishi: %+d kun", "hijri_note": "Umm al-Qura · hisoblangan", "choose_hijri": "<b>Hisoblangan hijriy sanani tuzating</b> 🌙\n\nMahalliy hilol kuzatuvi farq qilishi mumkin. −2 dan +2 kungacha tanlang; joriy qiymat ✓ bilan belgilangan.",
@@ -92,9 +107,11 @@ func init() {
 			hijriMonths: []string{"Muharram", "Safar", "Rabi’ ul-avval", "Rabi’ us-soniy", "Jumodul avval", "Jumodus soniy", "Rajab", "Sha’bon", "Ramazon", "Shavvol", "Zulqa’da", "Zulhijja"},
 		},
 		"tt": {
-			buttons: map[string]string{"hijri": "🌙 Һиҗри дата төзәтмәсе", "prayer_reminders": "Намаз вакытлары", "fasting_reminders": "Дүшәмбе һәм пәнҗешәмбе уразасы", "kahf_reminders": "Җомга Кәһф сүрәсе"},
+			buttons: map[string]string{"hijri": "🌙 Һиҗри дата төзәтмәсе", "prayer_reminders": "Намаз вакытлары", "fasting_reminders": "Дүшәмбе һәм пәнҗешәмбе уразасы", "kahf_reminders": "Җомга Кәһф сүрәсе", "white_days_reminders": "Ак көннәр уразасы (13–15)"},
 			text: map[string]string{
-				"reminders_title": "<b>Искәртүләр</b> 🔔", "enabled": "кабызылган", "disabled": "сүндерелгән", "fasting_schedule": "Алдагы кич · 20:00", "kahf_schedule": "Җомга · 09:00",
+				"white_days_schedule": "Һиҗри 13–15 алдагы кич · 20:00",
+				"reminder_white_days": "<b>Ак көннәр искәртүе</b> 🌕\nИртәгә %d %s — ак көннәрнең берсе. Бу көннәрдә ураза тоту — мөстәхәб сөннәт.",
+				"reminders_title":     "<b>Искәртүләр</b> 🔔", "enabled": "кабызылган", "disabled": "сүндерелгән", "fasting_schedule": "Алдагы кич · 20:00", "kahf_schedule": "Җомга · 09:00",
 				"pre_prayer_reminder": "Намаз алдыннан искәртү", "pre_reminder_off": "Намаз вакыты җиткәч кенә", "minutes_before": "%d минут алдан",
 				"choose_pre_reminder": "<b>Намаз алдыннан искәртүне сайлагыз</b> ⏳\n\nҺәр фарыз намаз алдыннан һәм намаз вакыты җиткәч аерым хәбәр алырсыз.",
 				"hijri_date":          "Һиҗри дата", "hijri_era": "һ.", "hijri_setting": "Умм әл-Кура төзәтмәсе: %+d көн", "hijri_note": "Умм әл-Кура · исәпләнгән", "choose_hijri": "<b>Исәпләнгән Һиҗри датаны төзәтегез</b> 🌙\n\nҖирле ай күренеше аерылырга мөмкин. −2 дән +2 көнгә кадәр сайлагыз; хәзерге кыйммәт ✓ белән билгеләнгән.",

--- a/global/internal/miniapp/handler.go
+++ b/global/internal/miniapp/handler.go
@@ -47,6 +47,7 @@ type Storage interface {
 	DisableRules(context.Context, int64) error
 	ConfigurePrayerRules(context.Context, int64, bool, int) error
 	SetWeeklyRule(context.Context, int64, domain.ReminderKind, bool) error
+	SetWhiteDaysRule(context.Context, int64, bool) error
 	SetOccasionRule(context.Context, int64, domain.ReminderKind, bool) error
 	CalendarSubscription(context.Context, int64) (domain.CalendarSubscription, error)
 	CalendarSubscriptionByToken(context.Context, string) (domain.CalendarSubscription, error)
@@ -367,6 +368,9 @@ type remindersRequest struct {
 	Prayer           *bool `json:"prayer"`
 	PrePrayerMinutes int   `json:"pre_prayer_minutes"`
 	Fasting          *bool `json:"fasting"`
+	// WhiteDays is optional so cached Mini App clients that predate the field
+	// keep saving successfully; nil preserves the current state.
+	WhiteDays        *bool `json:"white_days"`
 	Kahf             *bool `json:"kahf"`
 	OccasionMajor    *bool `json:"occasion_major"`
 	OccasionFasting  *bool `json:"occasion_fasting"`
@@ -469,7 +473,7 @@ func (h *Handler) updateReminders(w http.ResponseWriter, r *http.Request, identi
 	if err != nil {
 		return err
 	}
-	if changed && (desired.Prayer || desired.Fasting || desired.Kahf ||
+	if changed && (desired.Prayer || desired.Fasting || desired.WhiteDays || desired.Kahf ||
 		desired.OccasionMajor || desired.OccasionFasting || desired.OccasionObserved) {
 		if err := h.planner.RebuildChat(r.Context(), identity.UserID, h.now()); err != nil {
 			return fmt.Errorf("rebuild reminders: %w", err)
@@ -492,6 +496,10 @@ func (h *Handler) applyReminders(ctx context.Context, chatID int64, request remi
 		Fasting: *request.Fasting, Kahf: *request.Kahf,
 		OccasionMajor: *request.OccasionMajor, OccasionFasting: *request.OccasionFasting,
 		OccasionObserved: *request.OccasionObserved,
+		WhiteDays:        current.WhiteDays,
+	}
+	if request.WhiteDays != nil {
+		desired.WhiteDays = *request.WhiteDays
 	}
 	if !desired.Prayer {
 		desired.PrePrayerMinutes = 0
@@ -505,6 +513,11 @@ func (h *Handler) applyReminders(ctx context.Context, chatID int64, request remi
 	if current.Fasting != desired.Fasting {
 		if err := h.store.SetWeeklyRule(ctx, chatID, domain.ReminderWeeklyFasting, desired.Fasting); err != nil {
 			return false, reminderResponse{}, fmt.Errorf("update fasting reminders: %w", err)
+		}
+	}
+	if current.WhiteDays != desired.WhiteDays {
+		if err := h.store.SetWhiteDaysRule(ctx, chatID, desired.WhiteDays); err != nil {
+			return false, reminderResponse{}, fmt.Errorf("update white days reminders: %w", err)
 		}
 	}
 	if current.Kahf != desired.Kahf {
@@ -600,6 +613,7 @@ type reminderResponse struct {
 	Prayer           bool `json:"prayer"`
 	PrePrayerMinutes int  `json:"pre_prayer_minutes"`
 	Fasting          bool `json:"fasting"`
+	WhiteDays        bool `json:"white_days"`
 	Kahf             bool `json:"kahf"`
 	OccasionMajor    bool `json:"occasion_major"`
 	OccasionFasting  bool `json:"occasion_fasting"`
@@ -751,6 +765,8 @@ func (h *Handler) reminderState(ctx context.Context, chatID int64) (reminderResp
 		switch rule.Kind {
 		case domain.ReminderWeeklyFasting:
 			state.Fasting = true
+		case domain.ReminderWhiteDays:
+			state.WhiteDays = true
 		case domain.ReminderWeeklyKahf:
 			state.Kahf = true
 		case domain.ReminderOccasionMajor:
@@ -942,7 +958,9 @@ func labels(locale i18n.Locale) map[string]string {
 		"pre_prayer_reminder": locale.Message("pre_prayer_reminder"),
 		"fasting_reminders":   locale.Button("fasting_reminders"), "kahf_reminders": locale.Button("kahf_reminders"),
 		"fasting_schedule": locale.Message("fasting_schedule"), "kahf_schedule": locale.Message("kahf_schedule"),
-		"occasions_title": locale.OccasionUI("title"), "occasions_help": locale.OccasionUI("help"),
+		"white_days_reminders": locale.Button("white_days_reminders"),
+		"white_days_schedule":  locale.Message("white_days_schedule"),
+		"occasions_title":      locale.OccasionUI("title"), "occasions_help": locale.OccasionUI("help"),
 		"occasions_disclaimer": locale.OccasionUI("disclaimer"),
 		"occasion_recommended": locale.OccasionUI("recommended"), "occasion_sources": locale.OccasionUI("sources"),
 		"occasion_major_reminders":    locale.OccasionUI("major_reminders"),

--- a/global/internal/miniapp/handler_test.go
+++ b/global/internal/miniapp/handler_test.go
@@ -777,6 +777,54 @@ func TestPreferencesUpdateSavesSettingsAndRemindersTogether(t *testing.T) {
 	}
 }
 
+func TestWhiteDaysToggleAndStaleClientPreservation(t *testing.T) {
+	now := time.Date(2026, time.July, 17, 12, 0, 0, 0, time.UTC)
+	storage := newFakeStorage()
+	storage.chats[42] = domain.Chat{TelegramChatID: 42, Type: "private", LanguageCode: "en"}
+	storage.profiles[42] = domain.PrayerProfile{
+		ChatID: 42, Latitude: 30.044, Longitude: 31.236, Timezone: "UTC",
+		Method: domain.MethodEgyptian, Madhab: domain.MadhabShafii,
+		HighLatitudeRule: domain.HighLatitudeAngleBased,
+	}
+	planner := &fakePlanner{}
+	handler := NewHandler("test-token", storage, nil, prayertime.New(), planner, nil)
+	handler.now = func() time.Time { return now }
+	mux := http.NewServeMux()
+	handler.Register(mux)
+	send := func(body string) bootstrapResponse {
+		t.Helper()
+		request := httptest.NewRequest(http.MethodPut, "/api/miniapp/reminders", strings.NewReader(body))
+		request.Header.Set("X-Telegram-Init-Data", signedInitData(t, "test-token", now, initDataUser{ID: 42, FirstName: "Amina", LanguageCode: "en"}))
+		response := httptest.NewRecorder()
+		mux.ServeHTTP(response, request)
+		if response.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+		}
+		var data bootstrapResponse
+		if err := json.Unmarshal(response.Body.Bytes(), &data); err != nil {
+			t.Fatal(err)
+		}
+		return data
+	}
+
+	enabled := send(`{"prayer":false,"pre_prayer_minutes":0,"fasting":false,"white_days":true,"kahf":false,
+		"occasion_major":false,"occasion_fasting":false,"occasion_observed":false}`)
+	if !enabled.Reminders.WhiteDays {
+		t.Fatalf("white days reminder was not enabled: %+v", enabled.Reminders)
+	}
+
+	// A cached Mini App client that predates the field omits it entirely; the
+	// save must preserve the enabled white days rule instead of disabling it.
+	stale := send(`{"prayer":false,"pre_prayer_minutes":0,"fasting":true,"kahf":false,
+		"occasion_major":false,"occasion_fasting":false,"occasion_observed":false}`)
+	if !stale.Reminders.WhiteDays {
+		t.Fatalf("stale client save must not disable white days: %+v", stale.Reminders)
+	}
+	if !stale.Reminders.Fasting {
+		t.Fatalf("stale client save lost its own change: %+v", stale.Reminders)
+	}
+}
+
 func TestParseAdjustmentsRequiresCompleteSnapshot(t *testing.T) {
 	if _, err := parseAdjustments(map[string]int{"fajr": 1}); err == nil {
 		t.Fatal("expected an incomplete adjustment snapshot to fail")
@@ -944,6 +992,10 @@ func (s *fakeStorage) SetWeeklyRule(_ context.Context, chatID int64, kind domain
 	}
 	s.rules[chatID] = append(s.rules[chatID], domain.ReminderRule{ChatID: chatID, Kind: kind, Enabled: enabled})
 	return nil
+}
+
+func (s *fakeStorage) SetWhiteDaysRule(ctx context.Context, chatID int64, enabled bool) error {
+	return s.SetWeeklyRule(ctx, chatID, domain.ReminderWhiteDays, enabled)
 }
 
 func (s *fakeStorage) SetOccasionRule(_ context.Context, chatID int64, kind domain.ReminderKind, enabled bool) error {

--- a/global/internal/miniapp/static/app.js
+++ b/global/internal/miniapp/static/app.js
@@ -194,8 +194,10 @@
     setText("prayer-reminders-label", labels.prayer_reminders);
     setText("pre-prayer-reminder-label", labels.pre_prayer_reminder);
     setText("fasting-reminders-label", labels.fasting_reminders);
+    setText("white-days-reminders-label", labels.white_days_reminders);
     setText("kahf-reminders-label", labels.kahf_reminders);
     setText("fasting-schedule", labels.fasting_schedule);
+    setText("white-days-schedule", labels.white_days_schedule);
     setText("kahf-schedule", labels.kahf_schedule);
     setText("occasions-title", labels.occasions_title);
     setText("occasions-help", labels.occasions_help);
@@ -385,6 +387,7 @@
     byId("prayer-reminders").checked = state.reminders.prayer;
     fillSelect("pre-prayer-minutes", state.options.pre_reminders, state.reminders.pre_prayer_minutes);
     byId("fasting-reminders").checked = state.reminders.fasting;
+    byId("white-days-reminders").checked = Boolean(state.reminders.white_days);
     byId("kahf-reminders").checked = state.reminders.kahf;
     byId("occasion-major-reminders").checked = state.reminders.occasion_major;
     byId("occasion-fasting-reminders").checked = state.reminders.occasion_fasting;
@@ -676,6 +679,7 @@
       prayer: byId("prayer-reminders").checked,
       pre_prayer_minutes: Number(byId("pre-prayer-minutes").value),
       fasting: byId("fasting-reminders").checked,
+      white_days: byId("white-days-reminders").checked,
       kahf: byId("kahf-reminders").checked,
       occasion_major: byId("occasion-major-reminders").checked,
       occasion_fasting: byId("occasion-fasting-reminders").checked,
@@ -1247,7 +1251,7 @@
   byId("share-prayer-card").addEventListener("click", sharePrayerCard);
   byId("save-preferences").addEventListener("click", savePreferences);
   byId("retry-app").addEventListener("click", bootstrapApp);
-  ["prayer-reminders", "pre-prayer-minutes", "fasting-reminders", "kahf-reminders",
+  ["prayer-reminders", "pre-prayer-minutes", "fasting-reminders", "white-days-reminders", "kahf-reminders",
     "occasion-major-reminders", "occasion-fasting-reminders", "occasion-observed-reminders",
     "language", "method", "madhab", "highlat", "hijri-adjustment"]
     .forEach((id) => byId(id).addEventListener("change", () => setDirty(true)));

--- a/global/internal/miniapp/static/index.html
+++ b/global/internal/miniapp/static/index.html
@@ -263,6 +263,11 @@
               <span class="toggle" aria-hidden="true"></span>
             </label>
             <label class="toggle-row">
+              <span><strong id="white-days-reminders-label">White days fasting</strong><small id="white-days-schedule"></small></span>
+              <input id="white-days-reminders" type="checkbox">
+              <span class="toggle" aria-hidden="true"></span>
+            </label>
+            <label class="toggle-row">
               <span><strong id="kahf-reminders-label">Friday Al-Kahf</strong><small id="kahf-schedule"></small></span>
               <input id="kahf-reminders" type="checkbox">
               <span class="toggle" aria-hidden="true"></span>

--- a/global/internal/miniapp/static/sw.js
+++ b/global/internal/miniapp/static/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const cacheName = "global-prayer-miniapp-shell-v9";
+const cacheName = "global-prayer-miniapp-shell-v10";
 const shellAssets = [
   "./",
   "./app.css",

--- a/global/internal/reminders/planner.go
+++ b/global/internal/reminders/planner.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/escalopa/prayer-bot/global/internal/domain"
+	"github.com/escalopa/prayer-bot/global/internal/hijri"
 	"github.com/escalopa/prayer-bot/global/internal/occasions"
 	"github.com/escalopa/prayer-bot/global/internal/prayertime"
 )
@@ -55,6 +56,9 @@ func (p *Planner) Next(ctx context.Context, profile domain.PrayerProfile, rule d
 	}
 	if rule.Kind.Weekly() {
 		return nextWeekly(profile, rule, after, location)
+	}
+	if rule.Kind == domain.ReminderWhiteDays {
+		return nextWhiteDays(profile, rule, after, location)
 	}
 	if rule.Kind.Occasion() {
 		return nextOccasion(profile, rule, after, location)
@@ -184,6 +188,40 @@ func nextWeekly(profile domain.PrayerProfile, rule domain.ReminderRule, after ti
 		}, nil
 	}
 	return domain.ReminderSchedule{}, fmt.Errorf("no valid weekly occurrence found in the next fifteen days")
+}
+
+// nextWhiteDays finds the next 13th, 14th, or 15th Hijri day (Ayyam al-Bid)
+// using the profile's moon-sighting correction and schedules the reminder for
+// the rule's local time on the preceding evening, mirroring the weekly fasting
+// reminder. A 40-day scan safely covers any 29/30-day Hijri month plus margin.
+func nextWhiteDays(profile domain.PrayerProfile, rule domain.ReminderRule, after time.Time, location *time.Location) (domain.ReminderSchedule, error) {
+	hour, minute, err := parseLocalTime(rule.LocalTime)
+	if err != nil {
+		return domain.ReminderSchedule{}, err
+	}
+	localAfter := after.In(location)
+	for dayOffset := 0; dayOffset < 40; dayOffset++ {
+		candidate := localAfter.AddDate(0, 0, dayOffset)
+		target := time.Date(candidate.Year(), candidate.Month(), candidate.Day(), 0, 0, 0, 0, location)
+		date, err := hijri.FromGregorian(target, profile.HijriAdjustment)
+		if err != nil {
+			return domain.ReminderSchedule{}, err
+		}
+		if date.Day < 13 || date.Day > 15 {
+			continue
+		}
+		previous := target.AddDate(0, 0, -1)
+		nextRun := time.Date(previous.Year(), previous.Month(), previous.Day(), hour, minute, 0, 0, location)
+		if !nextRun.After(after) {
+			continue
+		}
+		return domain.ReminderSchedule{
+			RuleID: rule.ID, ChatID: rule.ChatID, ProfileVersion: profile.Version,
+			LocalDate: target.Format("2006-01-02"), PrayerAt: target,
+			NextRunAt: nextRun.UTC(), State: "pending",
+		}, nil
+	}
+	return domain.ReminderSchedule{}, fmt.Errorf("no white day found in the next forty days")
 }
 
 func parseLocalTime(value string) (int, int, error) {

--- a/global/internal/reminders/planner_test.go
+++ b/global/internal/reminders/planner_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/escalopa/prayer-bot/global/internal/domain"
+	"github.com/escalopa/prayer-bot/global/internal/hijri"
 	"github.com/escalopa/prayer-bot/global/internal/occasions"
 )
 
@@ -95,5 +96,76 @@ func TestNextIslamicOccasionUsesCorrectedHijriDateAndPreviousEvening(t *testing.
 	)
 	if !next.NextRunAt.Equal(expectedRun.UTC()) {
 		t.Fatalf("occasion run = %s, want %s", next.NextRunAt, expectedRun.UTC())
+	}
+}
+
+func TestNextWhiteDaysReminderUsesPreviousEveningOfHijri13to15(t *testing.T) {
+	location, _ := time.LoadLocation("Africa/Cairo")
+	after := time.Date(2026, 7, 17, 12, 0, 0, 0, location)
+	planner := &Planner{}
+	profile := domain.PrayerProfile{Timezone: "Africa/Cairo", Version: 5}
+	rule := domain.ReminderRule{ID: 9, ChatID: 10, Kind: domain.ReminderWhiteDays, LocalTime: "20:00"}
+
+	next, err := planner.Next(context.Background(), profile, rule, after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := time.ParseInLocation("2006-01-02", next.LocalDate, location)
+	if err != nil {
+		t.Fatal(err)
+	}
+	date, err := hijri.FromGregorian(target, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if date.Day < 13 || date.Day > 15 {
+		t.Fatalf("target %s is Hijri day %d, want 13-15", next.LocalDate, date.Day)
+	}
+	run := next.NextRunAt.In(location)
+	if got := run.Format("15:04"); got != "20:00" {
+		t.Fatalf("reminder time = %s, want 20:00", got)
+	}
+	if got := run.AddDate(0, 0, 1).Format("2006-01-02"); got != next.LocalDate {
+		t.Fatalf("reminder day %s is not the evening before %s", run.Format("2006-01-02"), next.LocalDate)
+	}
+	if !next.NextRunAt.After(after) {
+		t.Fatalf("reminder %s is not after %s", next.NextRunAt, after)
+	}
+
+	// Planning again from just after this reminder must find the next white day,
+	// never repeat the same occurrence.
+	following, err := planner.Next(context.Background(), profile, rule, next.NextRunAt.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if following.LocalDate <= next.LocalDate {
+		t.Fatalf("following white day %s does not advance past %s", following.LocalDate, next.LocalDate)
+	}
+}
+
+func TestNextWhiteDaysRespectsHijriAdjustment(t *testing.T) {
+	location, _ := time.LoadLocation("Africa/Cairo")
+	after := time.Date(2026, 7, 17, 12, 0, 0, 0, location)
+	planner := &Planner{}
+	rule := domain.ReminderRule{ID: 9, ChatID: 10, Kind: domain.ReminderWhiteDays, LocalTime: "20:00"}
+
+	base, err := planner.Next(context.Background(), domain.PrayerProfile{Timezone: "Africa/Cairo"}, rule, after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	shifted, err := planner.Next(context.Background(), domain.PrayerProfile{Timezone: "Africa/Cairo", HijriAdjustment: 2}, rule, after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if base.LocalDate == shifted.LocalDate {
+		t.Fatalf("a +2 day Hijri correction must shift the white day, both were %s", base.LocalDate)
+	}
+	target, _ := time.ParseInLocation("2006-01-02", shifted.LocalDate, location)
+	date, err := hijri.FromGregorian(target, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if date.Day < 13 || date.Day > 15 {
+		t.Fatalf("corrected target %s is Hijri day %d, want 13-15", shifted.LocalDate, date.Day)
 	}
 }

--- a/global/internal/reminders/sender.go
+++ b/global/internal/reminders/sender.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-telegram/bot/models"
 
 	"github.com/escalopa/prayer-bot/global/internal/domain"
+	"github.com/escalopa/prayer-bot/global/internal/hijri"
 	"github.com/escalopa/prayer-bot/global/internal/i18n"
 	"github.com/escalopa/prayer-bot/global/internal/occasions"
 	"github.com/escalopa/prayer-bot/global/internal/store"
@@ -157,7 +158,9 @@ func (s *Sender) Delete(ctx context.Context, task domain.MessageDeletionTask) er
 
 func notificationCategory(kind domain.ReminderKind) string {
 	switch kind {
-	case domain.ReminderWeeklyFasting:
+	case domain.ReminderWeeklyFasting, domain.ReminderWhiteDays:
+		// All fasting reminders share one slot: only the latest "fasting
+		// tomorrow" notice matters, whether weekly or a white day.
 		return "weekly_fasting"
 	case domain.ReminderWeeklyKahf:
 		return "weekly_kahf"
@@ -179,6 +182,8 @@ func reminderText(rule domain.ReminderRule, schedule domain.ReminderSchedule, pr
 	switch rule.Kind {
 	case domain.ReminderWeeklyFasting:
 		return locale.Message("reminder_fasting")
+	case domain.ReminderWhiteDays:
+		return whiteDaysReminderText(schedule, profile, locale)
 	case domain.ReminderWeeklyKahf:
 		return locale.Message("reminder_kahf")
 	case domain.ReminderBefore:
@@ -226,6 +231,22 @@ func occasionReminderText(rule domain.ReminderRule, schedule domain.ReminderSche
 		}
 	}
 	return builder.String()
+}
+
+// whiteDaysReminderText names the Hijri date being fasted so the user knows
+// which of the white days tomorrow is. It falls back to the generic template
+// values on a conversion error rather than failing the delivery.
+func whiteDaysReminderText(schedule domain.ReminderSchedule, profile domain.PrayerProfile, locale i18n.Locale) string {
+	location := mustLocation(profile.Timezone)
+	date, err := time.ParseInLocation("2006-01-02", schedule.LocalDate, location)
+	if err != nil {
+		return locale.Message("reminder_fasting")
+	}
+	hijriDate, err := hijri.FromGregorian(date, profile.HijriAdjustment)
+	if err != nil {
+		return locale.Message("reminder_fasting")
+	}
+	return fmt.Sprintf(locale.Message("reminder_white_days"), hijriDate.Day, locale.HijriMonth(hijriDate.Month))
 }
 
 func mustLocation(name string) *time.Location {

--- a/global/internal/store/postgres.go
+++ b/global/internal/store/postgres.go
@@ -283,6 +283,7 @@ func (s *Store) AdminMetrics(ctx context.Context) (AdminDashboard, error) {
 				WHEN kind IN ('before', 'at', 'tomorrow') THEN 'prayer'
 				WHEN kind = 'weekly_fasting' THEN 'fasting'
 				WHEN kind = 'weekly_kahf' THEN 'kahf'
+				WHEN kind = 'white_days' THEN 'white_days'
 				WHEN kind = 'occasion_major' THEN 'occasion_major'
 				WHEN kind = 'occasion_fasting' THEN 'occasion_fasting'
 				WHEN kind = 'occasion_observed' THEN 'occasion_observed'
@@ -436,6 +437,16 @@ func (s *Store) SetWeeklyRule(ctx context.Context, chatID int64, kind domain.Rem
 	if kind == domain.ReminderWeeklyKahf {
 		localTime = "09:00"
 	}
+	return s.setRecurringRule(ctx, chatID, kind, localTime, enabled)
+}
+
+// SetWhiteDaysRule toggles the Ayyam al-Bid fasting reminder, delivered at
+// 20:00 on the evening before each of the 13th-15th Hijri days.
+func (s *Store) SetWhiteDaysRule(ctx context.Context, chatID int64, enabled bool) error {
+	return s.setRecurringRule(ctx, chatID, domain.ReminderWhiteDays, "20:00", enabled)
+}
+
+func (s *Store) setRecurringRule(ctx context.Context, chatID int64, kind domain.ReminderKind, localTime string, enabled bool) error {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
 		return err

--- a/global/internal/telegram/admin.go
+++ b/global/internal/telegram/admin.go
@@ -204,6 +204,7 @@ func formatAdminReminders(metrics store.AdminDashboard) string {
 		"<b>Reminder adoption</b> 🔔\n\n"+
 			"🕌 Prayer times: <b>%d</b>\n"+
 			"🌙 Monday &amp; Thursday fasting: <b>%d</b>\n"+
+			"🌕 White days fasting: <b>%d</b>\n"+
 			"📖 Friday Al-Kahf: <b>%d</b>\n"+
 			"🕋 Major Islamic occasions: <b>%d</b>\n"+
 			"🤲 Special fasting days: <b>%d</b>\n"+
@@ -213,6 +214,7 @@ func formatAdminReminders(metrics store.AdminDashboard) string {
 			"Pending schedules: %d",
 		counts["prayer"],
 		counts["fasting"],
+		counts["white_days"],
 		counts["kahf"],
 		counts["occasion_major"],
 		counts["occasion_fasting"],

--- a/global/internal/telegram/callbacks.go
+++ b/global/internal/telegram/callbacks.go
@@ -219,6 +219,10 @@ func (h *Handler) handleReminderCallback(ctx context.Context, message *models.Me
 		if err := h.store.SetWeeklyRule(ctx, message.Chat.ID, domain.ReminderWeeklyFasting, enabled); err != nil {
 			return err
 		}
+	case "white_days":
+		if err := h.store.SetWhiteDaysRule(ctx, message.Chat.ID, enabled); err != nil {
+			return err
+		}
 	case "kahf":
 		if err := h.store.SetWeeklyRule(ctx, message.Chat.ID, domain.ReminderWeeklyKahf, enabled); err != nil {
 			return err

--- a/global/internal/telegram/commands.go
+++ b/global/internal/telegram/commands.go
@@ -304,6 +304,7 @@ type reminderState struct {
 	Prayer           bool
 	PrePrayerMinutes int
 	Fasting          bool
+	WhiteDays        bool
 	Kahf             bool
 	OccasionMajor    bool
 	OccasionFasting  bool
@@ -320,6 +321,8 @@ func (h *Handler) loadReminderState(ctx context.Context, chatID int64) (reminder
 		switch rule.Kind {
 		case domain.ReminderWeeklyFasting:
 			state.Fasting = true
+		case domain.ReminderWhiteDays:
+			state.WhiteDays = true
 		case domain.ReminderWeeklyKahf:
 			state.Kahf = true
 		case domain.ReminderOccasionMajor:
@@ -348,10 +351,11 @@ func formatReminders(state reminderState, locale i18n.Locale) string {
 	if state.PrePrayerMinutes > 0 {
 		preReminder = fmt.Sprintf(locale.Message("minutes_before"), state.PrePrayerMinutes)
 	}
-	return fmt.Sprintf("%s\n\n🔔 <b>%s</b> · %s\n   ⏳ %s\n\n🌙 <b>%s</b> · %s\n   %s\n\n📖 <b>%s</b> · %s\n   %s\n\n🕌 <b>%s</b> · %s\n   %s\n\n🤲 <b>%s</b> · %s\n   %s\n\n🌙 <b>%s</b> · %s\n   %s",
+	return fmt.Sprintf("%s\n\n🔔 <b>%s</b> · %s\n   ⏳ %s\n\n🌙 <b>%s</b> · %s\n   %s\n\n🌕 <b>%s</b> · %s\n   %s\n\n📖 <b>%s</b> · %s\n   %s\n\n🕌 <b>%s</b> · %s\n   %s\n\n🤲 <b>%s</b> · %s\n   %s\n\n🌙 <b>%s</b> · %s\n   %s",
 		locale.Message("reminders_title"), escape(locale.Button("prayer_reminders")), status(state.Prayer),
 		escape(preReminder),
 		escape(locale.Button("fasting_reminders")), status(state.Fasting), escape(locale.Message("fasting_schedule")),
+		escape(locale.Button("white_days_reminders")), status(state.WhiteDays), escape(locale.Message("white_days_schedule")),
 		escape(locale.Button("kahf_reminders")), status(state.Kahf), escape(locale.Message("kahf_schedule")),
 		escape(locale.OccasionUI("major_reminders")), status(state.OccasionMajor), escape(locale.OccasionUI("schedule")),
 		escape(locale.OccasionUI("fasting_reminders")), status(state.OccasionFasting), escape(locale.OccasionUI("schedule")),

--- a/global/internal/telegram/keyboards.go
+++ b/global/internal/telegram/keyboards.go
@@ -128,6 +128,7 @@ func remindersKeyboard(state reminderState, locale i18n.Locale) *models.InlineKe
 		[]models.InlineKeyboardButton{toggle(locale.Button("prayer_reminders"), "prayer", state.Prayer)},
 		[]models.InlineKeyboardButton{callbackButton("⏳ "+preReminder, "reminders:pre:choose")},
 		[]models.InlineKeyboardButton{toggle(locale.Button("fasting_reminders"), "fasting", state.Fasting)},
+		[]models.InlineKeyboardButton{toggle(locale.Button("white_days_reminders"), "white_days", state.WhiteDays)},
 		[]models.InlineKeyboardButton{toggle(locale.Button("kahf_reminders"), "kahf", state.Kahf)},
 		[]models.InlineKeyboardButton{toggle(locale.OccasionUI("major_reminders"), "occasion_major", state.OccasionMajor)},
 		[]models.InlineKeyboardButton{toggle(locale.OccasionUI("fasting_reminders"), "occasion_fasting", state.OccasionFasting)},

--- a/global/migrations/00007_white_days_reminders.sql
+++ b/global/migrations/00007_white_days_reminders.sql
@@ -1,0 +1,35 @@
+-- +goose Up
+-- +goose ENVSUB ON
+-- Ayyam al-Bid (white days) fasting reminders: one rule kind that reminds at
+-- 20:00 on the evening before each of the 13th, 14th, and 15th Hijri days.
+-- Delivered messages reuse the existing weekly_fasting cleanup slot, so no
+-- message-slot category change is needed.
+ALTER TABLE ${GLOBAL_DB_SCHEMA}.reminder_rules
+    DROP CONSTRAINT reminder_rules_kind_check;
+
+ALTER TABLE ${GLOBAL_DB_SCHEMA}.reminder_rules
+    ADD CONSTRAINT reminder_rules_kind_check
+    CHECK (kind IN (
+        'before', 'at', 'tomorrow', 'weekly_fasting', 'weekly_kahf',
+        'occasion_major', 'occasion_fasting', 'occasion_observed',
+        'white_days'
+    ));
+
+-- +goose Down
+DELETE FROM ${GLOBAL_DB_SCHEMA}.reminder_schedules s
+USING ${GLOBAL_DB_SCHEMA}.reminder_rules r
+WHERE s.rule_id = r.id AND r.kind = 'white_days';
+
+DELETE FROM ${GLOBAL_DB_SCHEMA}.reminder_rules
+WHERE kind = 'white_days';
+
+ALTER TABLE ${GLOBAL_DB_SCHEMA}.reminder_rules
+    DROP CONSTRAINT reminder_rules_kind_check;
+
+ALTER TABLE ${GLOBAL_DB_SCHEMA}.reminder_rules
+    ADD CONSTRAINT reminder_rules_kind_check
+    CHECK (kind IN (
+        'before', 'at', 'tomorrow', 'weekly_fasting', 'weekly_kahf',
+        'occasion_major', 'occasion_fasting', 'occasion_observed'
+    ));
+-- +goose ENVSUB OFF


### PR DESCRIPTION
## What & why

The quick-win feature from the roadmap: an opt-in reminder for fasting the **white days** — the 13th–15th of each Hijri month — delivered at **20:00 on the preceding local evening**, exactly mirroring the Monday/Thursday fasting reminder. Reuses the Hijri engine, reminder pipeline, and cleanup machinery end-to-end.

## How it works
- **Migration 00007** — allows the `white_days` rule kind (backward-compatible constraint extension; down removes the rules + schedules first).
- **Planner** — `nextWhiteDays` scans up to 40 days for the next Gregorian day whose **corrected** Hijri day is 13–15 (`hijri.FromGregorian` with the profile's −2..+2 adjustment), then schedules the previous evening. Three reminders per Hijri month.
- **Sender** — localized message that **names the Hijri date** ("Tomorrow is 14 Muharram…"); falls back to the generic fasting text on a conversion error rather than failing delivery. Shares the **`weekly_fasting` cleanup slot** — both are "fasting tomorrow" notices where only the latest matters (documented).
- **Store** — `SetWeeklyRule` body refactored into a shared `setRecurringRule`; new `SetWhiteDaysRule`; admin metrics category.
- **Bot** — toggle in the reminders keyboard, status row, callback, owner-dashboard adoption line.
- **Mini App** — toggle row between Mon/Thu fasting and Al-Kahf (browser-verified with real labels). **Backward compatible:** `white_days` is optional in the save payload — cached clients that predate the field keep saving, and `nil` preserves the current state (covered by a test).
- **i18n** — button/schedule/reminder strings for all 8 locales; `sw.js` → v10.

## Tests
- Planner: occurrence is Hijri 13–15, reminder is the previous evening at 20:00, planning after a send advances to the next white day, and a +2 Hijri correction shifts the target.
- Mini App: toggle round-trip + stale-client preservation.
- Full suite: `gofmt` / `go vet` / `go test ./...` clean (17 packages).

## Docs
`reminder-delivery.md` (recurrence + cleanup category) and `data-model.md` (slot sharing) updated in-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)