### PR TITLE
Fix Google Calendar connect: cid requires a webcal:// URL

### DIFF
--- a/global/docs/request-flows.md
+++ b/global/docs/request-flows.md
@@ -162,7 +162,9 @@ fetching:
 
 1. An authenticated Mini App request creates or reuses a random private feed
    token and stable UID namespace.
-2. The Mini App opens Google Calendar with the HTTPS feed URL. A copy-link
+2. The Mini App opens Google Calendar's add-by-URL flow with the feed URL in
+   the **`webcal://` scheme** — Google's `cid` parameter requires it; an
+   `https://` URL is accepted but its events are never fetched. A copy-link
    button supports Google's desktop **Other calendars → From URL** flow.
 3. Google fetches the `.ics` URL without Telegram authentication.
 4. The server validates the random token, loads the current profile, and

--- a/global/internal/adapter/in/miniapp/handler_test.go
+++ b/global/internal/adapter/in/miniapp/handler_test.go
@@ -54,6 +54,12 @@ func TestStaticMiniAppIsEmbeddedWithSecurityHeaders(t *testing.T) {
 		!strings.Contains(string(script), "/api/miniapp/calendar-subscription") {
 		t.Fatal("Mini App is missing Qibla compass or rolling calendar subscription support")
 	}
+	// Google's render?cid= flow requires the webcal:// scheme: an https:// URL
+	// inside cid adds a calendar whose events are never fetched.
+	if !strings.Contains(string(script), `"webcal://"`) ||
+		!strings.Contains(string(script), "encodeURIComponent(webcalURL)") {
+		t.Fatal("Google Calendar connect link must embed the feed as a webcal:// URL")
+	}
 	if !strings.Contains(html, "add-home-screen") || !strings.Contains(html, "share-prayer-card") ||
 		!strings.Contains(string(script), "DeviceStorage") ||
 		!strings.Contains(string(script), "addToHomeScreen") ||

--- a/global/internal/adapter/in/miniapp/static/app.js
+++ b/global/internal/adapter/in/miniapp/static/app.js
@@ -782,7 +782,10 @@
     byId("calendar-status").classList.remove("hidden");
     try {
       const feedURL = await ensureCalendarSubscription();
-      const googleURL = `https://calendar.google.com/calendar/render?cid=${encodeURIComponent(feedURL)}`;
+      // Google's add-by-URL flow requires a webcal:// URL inside cid. With an
+      // https:// URL the calendar is added but its events are never fetched.
+      const webcalURL = feedURL.replace(/^https:\/\//, "webcal://");
+      const googleURL = `https://calendar.google.com/calendar/render?cid=${encodeURIComponent(webcalURL)}`;
       if (telegram && telegram.openLink) {
         telegram.openLink(googleURL);
       } else {

--- a/global/internal/adapter/in/miniapp/static/sw.js
+++ b/global/internal/adapter/in/miniapp/static/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const cacheName = "global-prayer-miniapp-shell-v10";
+const cacheName = "global-prayer-miniapp-shell-v11";
 const shellAssets = [
   "./",
   "./app.css",


### PR DESCRIPTION
## The bug (user report: calendar adds fine, but prayer times never appear)

The **Connect Google Calendar** button built `calendar.google.com/calendar/render?cid=<https://…feed>`. Google's `cid` parameter **requires a `webcal://` URL** — with `https://` it happily adds the calendar but treats the value as an opaque calendar ID and **never fetches the feed**. Result: subscription "succeeds", zero events. ([Documented behavior](https://til.simonwillison.net/ics/google-calendar-ics-subscribe-link); confirmed in multiple community reports.)

## Proof the rest of the pipeline is healthy

I self-tested end-to-end against the **live testing deployment** (signed real Mini App init-data → created a subscription → fetched the feed exactly as Google does, unauthenticated):

| Check | Result |
| --- | --- |
| Create subscription | HTTP 200 |
| Feed fetch | HTTP 200, `text/calendar; charset=utf-8`, ETag |
| ICS validity | `BEGIN:VCALENDAR`…`END:VCALENDAR`, strict CRLF, **181 events** (30 days × 6 prayers + occasions) |
| Conditional refresh | `If-None-Match` → **304** |

So the generator and the serving endpoint are correct — the failure is isolated to the add-flow URL scheme.

## Fix
- `app.js`: convert the feed URL to **`webcal://`** inside `cid` (the **copy-link** button keeps `https://`, which is correct for Google's manual *Other calendars → From URL* flow).
- Regression test: the connect link must embed a `webcal://` URL.
- `sw.js` → v11; `request-flows.md` documents the scheme requirement.

## Note for affected users (including the reporter)
The previously added broken calendar won't heal itself: **remove it in Google Calendar, then press Connect again** after this deploys. Also remember Google refreshes subscribed calendars on its own schedule (commonly 12–24 h) — but the *initial* fetch after a webcal add happens promptly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)