### PR TITLE
Fix deploy-time profile sync: Telegram rejects empty multipart requests

### DIFF
--- a/global/cmd/botprofile/main.go
+++ b/global/cmd/botprofile/main.go
@@ -22,7 +22,10 @@ func main() {
 	if webhookURL == "" {
 		fatal(fmt.Errorf("WEBHOOK_URL is required"))
 	}
-	client, err := botapi.New(cfg.TelegramToken, botapi.WithSkipGetMe())
+	// profile.HTTPClient works around Telegram rejecting the empty multipart
+	// bodies the library produces for parameterless methods like getMyName.
+	client, err := botapi.New(cfg.TelegramToken, botapi.WithSkipGetMe(),
+		botapi.WithHTTPClient(0, profile.HTTPClient()))
 	if err != nil {
 		fatal(err)
 	}

--- a/global/docs/operations.md
+++ b/global/docs/operations.md
@@ -35,7 +35,7 @@ payload.
 | Old notification remains | Immediate Telegram deletion failed and its durable deletion task is retrying or expired past Telegram's limit | [Reminder delivery](reminder-delivery.md#cleanup-categories) |
 | Existing schedules work but location update fails | Google Time Zone or Geocoding failure | [Maps failure mode](#maps-failure-mode) |
 | Mini App says to open it in Telegram | Missing, expired, or invalid signed Telegram init data | [Request flows](request-flows.md#mini-app-session-and-api) |
-| Profile sync reports an empty or malformed Telegram response | The deploy command retries the idempotent sync three times, then skips only the cosmetic profile step | [Runtime and deployment](runtime-and-deployment.md#deployment-workflow) |
+| Profile sync reports an empty or malformed Telegram response | The deploy command retries the idempotent sync three times, then skips only the cosmetic profile step. A deterministic cause was fixed once already: Telegram answers a bodyless HTTP 400 to the empty multipart requests the bot library emits for parameterless methods, which `cmd/botprofile`'s HTTP client now rewrites to JSON | [Runtime and deployment](runtime-and-deployment.md#deployment-workflow) |
 
 For a duplicate reminder, reconstruct the sequence in this order:
 

--- a/global/internal/adapter/out/botprofile/transport.go
+++ b/global/internal/adapter/out/botprofile/transport.go
@@ -1,0 +1,55 @@
+package botprofile
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Telegram rejects multipart/form-data requests that carry no fields with a
+// bodyless HTTP 400. The bot library encodes every call as multipart and
+// sends parameterless methods (getMyName, getMe, getChatMenuButton, ...) with
+// a multipart Content-Type but a completely empty body, so those calls always
+// fail. Rewriting the empty envelope into an empty JSON object keeps them
+// valid; requests that carry any field pass through untouched.
+type emptyMultipartFix struct {
+	base http.RoundTripper
+}
+
+// An empty multipart body is either no bytes at all or just the closing
+// boundary delimiter.
+var closingBoundaryOnly = regexp.MustCompile(`\A\s*--[^\r\n]+--\s*\z`)
+
+func (t emptyMultipartFix) RoundTrip(request *http.Request) (*http.Response, error) {
+	if request.ContentLength >= 0 && request.ContentLength <= 128 &&
+		strings.HasPrefix(request.Header.Get("Content-Type"), "multipart/form-data") {
+		var body []byte
+		if request.Body != nil {
+			read, err := io.ReadAll(request.Body)
+			_ = request.Body.Close()
+			if err != nil {
+				return nil, err
+			}
+			body = read
+		}
+		if len(body) == 0 || closingBoundaryOnly.Match(body) {
+			request.Header.Set("Content-Type", "application/json")
+			body = []byte("{}")
+		}
+		request.Body = io.NopCloser(bytes.NewReader(body))
+		request.ContentLength = int64(len(body))
+	}
+	return t.base.RoundTrip(request)
+}
+
+// HTTPClient returns the HTTP client every profile-sync Telegram call must go
+// through. See emptyMultipartFix for why a plain client is not enough.
+func HTTPClient() *http.Client {
+	return &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: emptyMultipartFix{base: http.DefaultTransport},
+	}
+}

--- a/global/internal/adapter/out/botprofile/transport_test.go
+++ b/global/internal/adapter/out/botprofile/transport_test.go
@@ -1,0 +1,76 @@
+package botprofile
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestEmptyMultipartIsRewrittenToJSON(t *testing.T) {
+	var gotContentType, gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotContentType, gotBody = r.Header.Get("Content-Type"), string(body)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	empty := &bytes.Buffer{}
+	writer := multipart.NewWriter(empty)
+	_ = writer.Close()
+	request, _ := http.NewRequest(http.MethodPost, server.URL, bytes.NewReader(empty.Bytes()))
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	if _, err := HTTPClient().Do(request); err != nil {
+		t.Fatal(err)
+	}
+	if gotContentType != "application/json" || gotBody != "{}" {
+		t.Fatalf("empty multipart was not rewritten: content-type=%q body=%q", gotContentType, gotBody)
+	}
+}
+
+func TestBodylessMultipartIsRewrittenToJSON(t *testing.T) {
+	var gotContentType, gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotContentType, gotBody = r.Header.Get("Content-Type"), string(body)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	// The bot library sends parameterless methods as a multipart Content-Type
+	// with a completely empty body.
+	request, _ := http.NewRequest(http.MethodPost, server.URL, bytes.NewReader(nil))
+	request.Header.Set("Content-Type", "multipart/form-data; boundary=deadbeef")
+	if _, err := HTTPClient().Do(request); err != nil {
+		t.Fatal(err)
+	}
+	if gotContentType != "application/json" || gotBody != "{}" {
+		t.Fatalf("bodyless multipart was not rewritten: content-type=%q body=%q", gotContentType, gotBody)
+	}
+}
+
+func TestNonEmptyMultipartPassesThrough(t *testing.T) {
+	var gotContentType, gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotContentType, gotBody = r.Header.Get("Content-Type"), string(body)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	filled := &bytes.Buffer{}
+	writer := multipart.NewWriter(filled)
+	_ = writer.WriteField("language_code", "en")
+	_ = writer.Close()
+	request, _ := http.NewRequest(http.MethodPost, server.URL, bytes.NewReader(filled.Bytes()))
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	if _, err := HTTPClient().Do(request); err != nil {
+		t.Fatal(err)
+	}
+	if gotContentType == "application/json" || gotBody != filled.String() {
+		t.Fatalf("multipart with fields must pass through unchanged: content-type=%q", gotContentType)
+	}
+}


### PR DESCRIPTION
## Symptom

The last three testing deploys ended with the warning *"Telegram profile synchronization remained temporarily unavailable after retries"*. It looked transient; it wasn't.

## Root cause (verified with a raw-transport probe)

- The go-telegram/bot library encodes **every** API call as `multipart/form-data` — including parameterless methods (`getMyName`, `getMe`, `getChatMenuButton`), which it sends with a multipart Content-Type and a **zero-byte body**.
- Telegram now answers those with a bodyless HTTP 400, which the library surfaces as "unexpected end of JSON input" — classified as transient, retried 3×, always failing.
- The same requests succeed as `application/json` `{}` (verified with curl); the latest library (v1.23.0) still has the bug.

## Fix

A `RoundTripper` in the botprofile adapter rewrites a multipart request whose body is empty (or only a closing boundary) into an `application/json` `{}` body. Requests carrying any field — including the avatar upload — pass through untouched (≤128-byte guard). Wired only into `cmd/botprofile`; the runtime services never call parameterless methods (all use `WithSkipGetMe`, every call has fields).

## Verified live

Ran `cmd/botprofile` against the testing bot with this fix:
- `PROFILE_SYNC_STATUS=synchronized` (first success in 3 deploys)
- `getMyCommands` now lists all 12 commands **including `/city`**
- webhook unchanged, `pending: 0`, `last_error: none`

So the testing bot is already fully synced; merging this makes future deploys stop tripping over it.

## Tests

Transport unit tests: bodyless multipart → JSON, closing-boundary-only multipart → JSON, multipart with fields → untouched. `make check` green. Triage row in `operations.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)